### PR TITLE
corrected header search logic

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -131,7 +131,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 
-#include <KHR/khrplatform.h>
+#include "KHR/khrplatform.h"
 
 #if KTX_OPENGL
 


### PR DESCRIPTION
Corrected header search logic:

these files search correctly for the custom platform header:

lib\loader.c(48): #include "KHR/khrplatform.h"
lib\swap.c(35): #include "KHR/khrplatform.h"

but ktx.h didn't and this way caught the wrong one from /usr/...

include\ktx.h(134): #include &lt;KHR/khrplatform.h&gt;

Corrected that.
