### PR TITLE
Fix compilation error when defined KTX_OPENGL_ES2=1.

### DIFF
--- a/lib/gles2_funcptrs.h
+++ b/lib/gles2_funcptrs.h
@@ -48,7 +48,7 @@ typedef void (GL_APIENTRY* PFNGLTEXIMAGE1DPROC) (GLenum target, GLint level, GLi
 typedef void (GL_APIENTRY* PFNGLTEXIMAGE3DPROC) (GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const GLvoid *pixels);
 typedef void (GL_APIENTRY* PFNGLCOMPRESSEDTEXIMAGE1DPROC) (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLint border, GLsizei imageSize, const GLvoid *data);
 typedef void (GL_APIENTRY* PFNGLCOMPRESSEDTEXIMAGE3DPROC) (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const GLvoid *data);
-typedef const GLubyte* (GLAPIENTRY* PFNGLGETSTRINGIPROC) (GLenum name, GLuint index);
+typedef const GLubyte* (GL_APIENTRY* PFNGLGETSTRINGIPROC) (GLenum name, GLuint index);
 
 extern PFNGLTEXIMAGE1DPROC pfGlTexImage1D;
 extern PFNGLTEXIMAGE3DPROC pfGlTexImage3D;


### PR DESCRIPTION
GLAPIENTRY was used instead of GL_APIENTRY in PFNGLGETSTRINGIPROC typedef.