### PR TITLE
Fix image data and comparisons.

### DIFF
--- a/tests/unittests/unittests.cc
+++ b/tests/unittests/unittests.cc
@@ -91,17 +91,19 @@ ktx_uint8_t CheckHeaderTest::ktxId[12] = {
 // Base fixture for WriterTestHelper tests.
 //--------------------------------------------
 
-template<typename component_type, ktx_uint32_t numComponents,
+template<typename component_type, ktx_uint32_t num_components,
          GLenum internalformat>
 class WriterTestHelperTestBase : public ::testing::Test {
   public:
     WriterTestHelperTestBase() { }
 
-    WriterTestHelper<component_type, numComponents, internalformat> helper;
+    WriterTestHelper<component_type, num_components, internalformat> helper;
+
+   ktx_uint32_t numComponents() { return num_components; }
 };
 
-class WriterTestHelperRGBA8Test : public WriterTestHelperTestBase<GLubyte, 4, GL_RGBA8>{ };
-class WriterTestHelperRGB8Test : public WriterTestHelperTestBase < GLubyte, 3, GL_RGB8 > { };
+class WriterTestHelperRGBA8Test : public WriterTestHelperTestBase<GLubyte, 4, GL_RGBA8> { };
+class WriterTestHelperRGB8Test : public WriterTestHelperTestBase<GLubyte, 3, GL_RGB8> { };
 typedef WriterTestHelper<GLubyte, 4, GL_RGBA8>::createFlagBits createFlagBits;
 
 //--------------------------------------------
@@ -125,7 +127,7 @@ class ktxWriteKTXTestBase : public ::testing::Test {
                               writeMetadata ? helper.kvDataLen : 0,
                               writeMetadata ? helper.kvData : nullptr,
                               (GLuint)helper.imageList.size(),
-                              &helper.imageList.front());
+                              helper.imageList.data());
         ASSERT_TRUE(result == KTX_SUCCESS) << "ktxWriteKTXM failed: "
                                            << ktxErrorString(result);
         EXPECT_EQ(memcmp(ktxMemFile, CheckHeaderTest::ktxId,
@@ -238,8 +240,8 @@ TEST_F(WriterTestHelperRGB8Test, Construct2D) {
     EXPECT_EQ(helper.images.size(), 1);
     EXPECT_EQ(helper.images[0].size(), 1);
     EXPECT_EQ(helper.images[0][0].size(), 1);
-    EXPECT_EQ(helper.images[0][0][0].size(), 32 * 32);
-    EXPECT_EQ(helper.images[0][0][0][0].size(), 3);
+    EXPECT_EQ(helper.images[0][0][0].size(), 32 * 32 * 3);
+    EXPECT_EQ(numComponents(), 3);
 }
 
 TEST_F(WriterTestHelperRGB8Test, Construct3D) {
@@ -247,8 +249,8 @@ TEST_F(WriterTestHelperRGB8Test, Construct3D) {
     EXPECT_EQ(helper.images.size(), 1);
     EXPECT_EQ(helper.images[0].size(), 1);
     EXPECT_EQ(helper.images[0][0].size(), 32);
-    EXPECT_EQ(helper.images[0][0][0].size(), 32 * 32);
-    EXPECT_EQ(helper.images[0][0][0][0].size(), 3);
+    EXPECT_EQ(helper.images[0][0][0].size(), 32 * 32 * 3);
+    EXPECT_EQ(numComponents(), 3);
 }
 
 //////////////////////////////
@@ -267,7 +269,7 @@ TEST_F(ktxWriteKTXRGBA8Test, InvalidOpOnMismatchedFormats) {
     result = ktxWriteKTXM(&ktxMemFile, &ktxMemFileLen,
                           &helper.texinfo, 0, nullptr,
                           (GLuint)helper.imageList.size(),
-                          &helper.imageList.front());
+                          helper.imageList.data());
 
     EXPECT_EQ(result, KTX_INVALID_OPERATION);
 }

--- a/tests/unittests/wthelper.h
+++ b/tests/unittests/wthelper.h
@@ -105,9 +105,9 @@ class WriterTestHelper {
                         color[0] = (component_type)level;
                         break;
                     }
-                    for (uint32_t i = 0; i < pixelCount; i++) {
-                        for (uint32_t j = 0; j < numComponents; j++) {
-                            uint32_t ci = i * numComponents + j;
+                    for (ktx_uint32_t i = 0; i < pixelCount; i++) {
+                        for (ktx_uint32_t j = 0; j < numComponents; j++) {
+                            ktx_uint32_t ci = i * numComponents + j;
                             images[level][layer][faceSlice][ci] = color[j];
                         }
                     }

--- a/tests/unittests/wthelper.h
+++ b/tests/unittests/wthelper.h
@@ -85,9 +85,13 @@ class WriterTestHelper {
                 ktx_uint32_t numImages = numFaces == 6 ? numFaces : levelDepth;
                 images[level][layer].resize(numImages);
                 for (ktx_uint32_t faceSlice = 0; faceSlice < numImages; faceSlice++) {
-                    ktx_uint32_t pixelCount;
+                    ktx_uint32_t componentCount, pixelCount;
                     pixelCount = levelWidth * levelHeight;
-                    images[level][layer][faceSlice].resize(pixelCount);
+                    componentCount = pixelCount * numComponents;
+                    images[level][layer][faceSlice].resize(componentCount);
+                    // Using std::vector avoids warnings in the following
+                    // switch due to access past the end of the array, if we
+                    // were using an array and numComponents < 4.
                     std::vector<component_type> color;
                     color.resize(numComponents);
                     switch (numComponents) {
@@ -101,12 +105,17 @@ class WriterTestHelper {
                         color[0] = (component_type)level;
                         break;
                     }
-                    images[level][layer][faceSlice].assign(pixelCount, color);
+                    for (uint32_t i = 0; i < pixelCount; i++) {
+                        for (uint32_t j = 0; j < numComponents; j++) {
+                            uint32_t ci = i * numComponents + j;
+                            images[level][layer][faceSlice][ci] = color[j];
+                        }
+                    }
                     imageList[count].size
                          = pixelCount * numComponents * sizeof(component_type);
                     imageDataSize += imageList[count].size;
                     imageList[count++].data
-                         = (GLubyte*)&images[level][layer][faceSlice].front();
+                         = (GLubyte*)images[level][layer][faceSlice].data();
                 }
             }
         }
@@ -130,45 +139,44 @@ class WriterTestHelper {
             ktx_uint32_t levelHeight = MAX(1, height >> level);
             ktx_uint32_t levelDepth = MAX(1, depth >> level);
             ktx_uint32_t numImages;
-            ktx_uint32_t rowRounding;
-            ktx_size_t imageByteSize, packedImageByteSize;
-            ktx_size_t rowByteSize, packedRowByteSize;
+            ktx_uint32_t rowPadding;
+            ktx_size_t paddedImageBytes, imageBytes;
+            ktx_size_t paddedRowBytes, rowBytes;
             ktx_size_t expectedFaceLodSize;
 
-            packedImageByteSize = images[level][0][0].size()
-                                 * sizeof(component_type)
-                                 * numComponents;
-            packedRowByteSize = levelWidth
-                                * sizeof(component_type)
-                                * numComponents;
-            rowRounding = 3 - ((packedRowByteSize + KTX_GL_UNPACK_ALIGNMENT-1) % KTX_GL_UNPACK_ALIGNMENT);
-            rowByteSize = packedRowByteSize + rowRounding;
-            imageByteSize = rowByteSize * levelHeight;
+            imageBytes = images[level][0][0].size() * sizeof(component_type);
+            rowBytes = levelWidth
+                            * sizeof(component_type)
+                            * numComponents;
+            rowPadding = 3 - ((rowBytes + KTX_GL_UNPACK_ALIGNMENT-1) % KTX_GL_UNPACK_ALIGNMENT);
+            paddedRowBytes = rowBytes + rowPadding;
+            paddedImageBytes = paddedRowBytes * levelHeight;
             if (numFaces == 6 && !isArray) {
                 // Non-array cubemap.
                 numImages = numFaces;
-                expectedFaceLodSize = imageByteSize;
+                expectedFaceLodSize = paddedImageBytes;
             } else {
                 numImages = numFaces == 6 ? numFaces : levelDepth;
-                expectedFaceLodSize = imageByteSize * numImages * numLayers;
+                expectedFaceLodSize = paddedImageBytes * numImages * numLayers;
             }
             if (faceLodSize != expectedFaceLodSize)
                return false;
             pData += sizeof(ktx_uint32_t);
             for (ktx_uint32_t layer = 0; layer < numLayers; layer++) {
                 for (ktx_uint32_t faceSlice = 0; faceSlice < numImages; faceSlice++) {
-                    if (rowRounding == 0) {
-                        if (memcmp(&images[level][layer][faceSlice].front(), pData,
-                                   packedImageByteSize))
+                    if (rowPadding == 0) {
+                        if (memcmp(images[level][layer][faceSlice].data(),
+                                   pData,
+                                   images[level][layer][faceSlice].size() * sizeof(component_type)))
                             return false;
-                        pData += packedImageByteSize;
+                        pData += paddedImageBytes;
                     } else {
-                        ktx_uint8_t* pImage = (ktx_uint8_t*)&images[level][layer][faceSlice].front();
+                        ktx_uint8_t* pImage = (ktx_uint8_t*)images[level][layer][faceSlice].data();
                         for (ktx_uint32_t row = 0; row < levelHeight; row++) {
-                            if (memcmp(pImage, pData, packedRowByteSize))
+                            if (memcmp(pImage, pData, rowBytes))
                                 return false;
-                            pImage += packedRowByteSize;
-                            pData += rowByteSize;
+                            pImage += rowBytes;
+                            pData += paddedRowBytes;
                         }
                     }
                 }
@@ -198,7 +206,7 @@ class WriterTestHelper {
     char orientation[10];
 
     ktx_size_t imageDataSize;
-    std::vector< std::vector < std::vector < std::vector< std::vector<component_type> > > > > images;
+    std::vector< std::vector < std::vector < std::vector<component_type> > > > images;
     std::vector<KTX_image_info> imageList;
 
     class texinfo : public KTX_texture_info {


### PR DESCRIPTION
Stop using a std::vector for a color so that std::vector instance
variables don't end up in the image data.