### PR TITLE
Added more flexible API for Basis encoding.

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -826,7 +826,7 @@ ktxTexture2_CreateFromMemory(const ktx_uint8_t* bytes, ktx_size_t size,
 KTX_APICALL KTX_error_code KTX_APIENTRY
 ktxTexture2_CompressBasis(ktxTexture2* This, ktx_uint32_t quality);
 
-typedef struct ktxBasisSetup {
+typedef struct ktxBasisParams {
     ktx_uint32_t quality;      /*!< Compression quality, a value from 1 - 255. Default is
                                     128 which is selected if @p quality is 0. Lower=better
                                     compression/lower quality/faster. Higher=less
@@ -835,7 +835,7 @@ typedef struct ktxBasisSetup {
 } ktxBasisSetup;
 
 KTX_APICALL KTX_error_code KTX_APIENTRY
-ktxTexture2_CompressBasisAdvanced(ktxTexture2* This, ktxBasisSetup* setup);
+ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params);
 
 typedef enum ktx_texture_transcode_fmt_e {
     KTX_TF_NONE_COMPATIBLE,    // Apps can use this in utility funcs to signal

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -826,6 +826,17 @@ ktxTexture2_CreateFromMemory(const ktx_uint8_t* bytes, ktx_size_t size,
 KTX_APICALL KTX_error_code KTX_APIENTRY
 ktxTexture2_CompressBasis(ktxTexture2* This, ktx_uint32_t quality);
 
+typedef struct ktxBasisSetup {
+    ktx_uint32_t quality;      /*!< Compression quality, a value from 1 - 255. Default is
+                                    128 which is selected if @p quality is 0. Lower=better
+                                    compression/lower quality/faster. Higher=less
+                                    compression/higher quality/slower. */
+    ktx_uint32_t countThreads; /*!< Number of threads used for compression, e.g, 1.*/
+} ktxBasisSetup;
+
+KTX_APICALL KTX_error_code KTX_APIENTRY
+ktxTexture2_CompressBasisAdvanced(ktxTexture2* This, ktxBasisSetup* setup);
+
 typedef enum ktx_texture_transcode_fmt_e {
     KTX_TF_NONE_COMPATIBLE,    // Apps can use this in utility funcs to signal
                                // that the GPU doen's suupport any of the

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -832,7 +832,7 @@ typedef struct ktxBasisParams {
                                     compression/lower quality/faster. Higher=less
                                     compression/higher quality/slower. */
     ktx_uint32_t countThreads; /*!< Number of threads used for compression, e.g, 1.*/
-} ktxBasisSetup;
+} ktxBasisParams;
 
 KTX_APICALL KTX_error_code KTX_APIENTRY
 ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params);


### PR DESCRIPTION
Hey,

this is what I changed to add the ability to do multi-threaded Basis compression. It's up to the client software to figure out how many threads it wants to request.

If one initializes the setup struct to 0 (e.g. " = {};"), it should "just work" with one thread.