### PR TITLE
Support NPOT textures

### DIFF
--- a/lib/texture.c
+++ b/lib/texture.c
@@ -886,13 +886,13 @@ ktxTexture_GetImageSize(ktxTexture* This, ktx_uint32_t level)
 
     formatInfo = &((ktxTextureInt*)This)->formatInfo;
 
-    float levelWidth  = This->baseWidth >> level;
-    float levelHeight = This->baseHeight >> level;
-    int x = ceilf(levelWidth / formatInfo->blockWidth);
-    int y = ceilf(levelHeight / formatInfo->blockHeight);
-    blockCount.x = MAX(1, x);
-    blockCount.y = MAX(1, y);
-    blockSizeInBytes = formatInfo->blockSizeInBits / 8;
+    float levelWidth  = (float) (This->baseWidth >> level);
+    float levelHeight = (float) (This->baseHeight >> level);
+    blockCount.x      = (ktx_uint32_t) ceilf(levelWidth / formatInfo->blockWidth);
+    blockCount.y      = (ktx_uint32_t) ceilf(levelHeight / formatInfo->blockHeight);
+    blockCount.x      = MAX(1, blockCount.x);
+    blockCount.y      = MAX(1, blockCount.y);
+    blockSizeInBytes  = formatInfo->blockSizeInBits / 8;
 
     if (formatInfo->flags & GL_FORMAT_SIZE_COMPRESSED_BIT) {
         assert(This->isCompressed);

--- a/lib/texture.c
+++ b/lib/texture.c
@@ -40,6 +40,7 @@
 #include "memstream.h"
 #include "gl_format.h"
 #include "uthash.h"
+#include <math.h>
 
 /**
  * @internal
@@ -884,8 +885,13 @@ ktxTexture_GetImageSize(ktxTexture* This, ktx_uint32_t level)
     assert (This != NULL);
 
     formatInfo = &((ktxTextureInt*)This)->formatInfo;
-    blockCount.x = MAX(1, (This->baseWidth / formatInfo->blockWidth)  >> level);
-    blockCount.y = MAX(1, (This->baseHeight / formatInfo->blockHeight)  >> level);
+
+    float levelWidth  = This->baseWidth >> level;
+    float levelHeight = This->baseHeight >> level;
+    int x = ceilf(levelWidth / formatInfo->blockWidth);
+    int y = ceilf(levelHeight / formatInfo->blockHeight);
+    blockCount.x = MAX(1, x);
+    blockCount.y = MAX(1, y);
     blockSizeInBytes = formatInfo->blockSizeInBits / 8;
 
     if (formatInfo->flags & GL_FORMAT_SIZE_COMPRESSED_BIT) {


### PR DESCRIPTION
Hi there.

While trying to generate a KTX with NPOT ASTC mipmaps, I got an error while verifying the correctness of the image size while calling `ktxTexture_setImageFromStream(...)`. To be precise, the check in [writer.c:111](https://github.com/KhronosGroup/KTX-Software/blob/master/lib/writer.c#L111) fails:
```cpp
if (srcSize != packedBytes)
    return KTX_INVALID_OPERATION;
```
That check is needed to verify that the input image size is actually equal to a value computed by calling `ktxTexture_GetImageSize(...)`.

Having a closer look at the implementation of that function, I realized that the method to calculate `blockCount` may be incorrect, thus I added a `ceil` operation to make sure that we get the right number of blocks.