### PR TITLE
Fixed inconsistent use of malloc/free vs. new[]/delete for ktxTexture…

### DIFF
--- a/lib/basis_encode.cpp
+++ b/lib/basis_encode.cpp
@@ -413,7 +413,7 @@ ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params)
         }
     }
 
-    delete(This->pData); // No longer needed. Reduce memory footprint.
+    free(This->pData); // No longer needed. Reduce memory footprint.
     This->pData = NULL;
     This->dataSize = 0;
 
@@ -688,7 +688,7 @@ ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params)
         return result;
     }
 
-    uint8_t* new_data = new uint8_t[image_data_size];
+    uint8_t* new_data = (uint8_t*) malloc(image_data_size);
     if (!new_data)
         return KTX_OUT_OF_MEMORY;
 

--- a/lib/basis_transcode.cpp
+++ b/lib/basis_transcode.cpp
@@ -453,7 +453,7 @@ ktxTexture2_TranscodeBasis(ktxTexture2* This,
     }
 
     ktx_uint8_t* basisData = This->pData;
-    This->pData = new uint8_t[transcodedDataSize];
+    This->pData = (uint8_t*) malloc(transcodedDataSize);
     This->dataSize = transcodedDataSize;
 
     // Finally we're ready to transcode the slices.


### PR DESCRIPTION
…->pData.

When transcoding a basis texture, pData was allocated via `new uint8_t[image_data_size];`, but within `ktxTexture_destruct` it is released with `free(This->pData);`.

It seems to not bother at first, but it caused crashes on some platform/build type configurations (e.g. Android release, WebAssembly, macOS release).