### PR TITLE
sRGB encode the webgl demo fragment shader outputs.

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -970,6 +970,11 @@ ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params);
  * components, R will be in the opaque slice and G in the alpha slice which each value replicated in all
  * 3 components of its slice. If the original image had only 1 component it's value is replicated in all
  * 3 components of the opaque slice and there is no alpha slice.
+ *
+ * @note You should not transcode sRGB encoded data to @c KTX_TTF_BC4_R, @c KTX_TTF_BC5_RG,
+ * @c KTX_TTF_ETC2_EAC_R{,G}11, @c KTX_TTF_RGB565, @c KTX_TTF_BGR565 or
+ * @c KTX_TTF_RGBA4444 formats as neither OpenGL nor Vulkan support sRGB variants of these. Doing
+ * sRGB decoding in the shader will not produce correct results if any texture filtering is being used.
  */
 typedef enum ktx_transcode_fmt_e {
         // Compressed formats

--- a/tests/webgl/libktx-webgl/webgl-demo.js
+++ b/tests/webgl/libktx-webgl/webgl-demo.js
@@ -77,6 +77,13 @@ function main() {
 
     uniform sampler2D uSampler;
 
+    highp vec3 srgb_encode(vec3 color) {
+        highp float r = color.r < 0.0031308 ? 12.92 * color.r : 1.055 * pow(color.r, 1.0/2.4) - 0.055;
+        highp float g = color.g < 0.0031308 ? 12.92 * color.g : 1.055 * pow(color.g, 1.0/2.4) - 0.055;
+        highp float b = color.b < 0.0031308 ? 12.92 * color.b : 1.055 * pow(color.b, 1.0/2.4) - 0.055;
+        return vec3(r, g, b);
+    }
+
     void main(void) {
       highp vec3 vertexColor = vec3(0.9, 0.9, 0.9);
       highp vec4 texelColor = texture2D(uSampler, vTextureCoord);
@@ -85,6 +92,7 @@ function main() {
       fragcolor.rgb = vertexColor.rgb * (1.0 - texelColor.a) + texelColor.rgb * texelColor.a;
       fragcolor.a = texelColor.a;
       fragcolor.rgb *= vLighting;
+      fragcolor.rgb = srgb_encode(fragcolor.rgb);
       gl_FragColor = fragcolor;
     }
   `;


### PR DESCRIPTION
Add note to transcode target format enum about not transcoding
sRGB textures to formats without sRGB variants.