### PR TITLE
Fix es3loadtests.html build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,18 @@ else()
     set(LIB_TYPE SHARED)
 endif()
 
+# Global Optimization Flags
+if(EMSCRIPTEN)
+    add_compile_options( $<IF:$<CONFIG:Debug>,-O0,-Oz> )
+    add_link_options( $<IF:$<CONFIG:Debug>,-g4,-Oz> )
+elseif(MSVC)
+    add_compile_options( $<IF:$<CONFIG:Debug>,/Gz,/O2> )
+else()
+    add_compile_options( $<IF:$<CONFIG:Debug>,"-g -O0",-O3> )
+    add_link_options( $<IF:$<CONFIG:Debug>,-g,-O3> )
+endif()
+
+
 # Main library
 add_library( ktx ${LIB_TYPE}
     include/ktx.h
@@ -174,28 +186,6 @@ else()
     )
 endif()
 
-# Optimization Flags
-if(EMSCRIPTEN)
-    target_compile_options(ktx PUBLIC
-        $<IF:$<CONFIG:Debug>,-O0,-Oz>
-    )
-    target_link_options( ktx PUBLIC
-        $<IF:$<CONFIG:Debug>,-g4,-Oz>
-    )
-elseif(MSVC)
-    target_compile_options(ktx PUBLIC
-        $<IF:$<CONFIG:Debug>,/Gz,/O2>
-    )
-else()
-    target_compile_options(ktx PUBLIC
-        $<IF:$<CONFIG:Debug>,-g -O0,-O3>
-    )
-    target_link_options( ktx PUBLIC
-        $<IF:$<CONFIG:Debug>,-g,-O3>
-    )
-endif()
-
-
 target_include_directories(
     ktx
 PUBLIC
@@ -215,7 +205,7 @@ endif()
 
 
 # To reduce size, don't support transcoding to ancient formats.
-target_compile_definitions(ktx PUBLIC BASISD_SUPPORT_FXT1=0)
+target_compile_definitions(ktx PRIVATE BASISD_SUPPORT_FXT1=0)
 
 # TODO: make options for all formats and good per-platform defaults
 # - BASISD_SUPPORT_UASTC
@@ -247,7 +237,7 @@ if(WIN32)
         lib/internalexport.def
     )
 elseif(EMSCRIPTEN)
-    target_compile_definitions(ktx PUBLIC
+    target_compile_definitions(ktx PRIVATE
         # To reduce size, don't support transcoding to formats not
         # supported # by WebGL.
         BASISD_SUPPORT_BC7=0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(EMSCRIPTEN)
 elseif(MSVC)
     add_compile_options( $<IF:$<CONFIG:Debug>,/Gz,/O2> )
 else()
-    add_compile_options( $<IF:$<CONFIG:Debug>,"-g -O0",-O3> )
+    add_compile_options( $<IF:$<CONFIG:Debug>,$<"SHELL:-g -O0">,-O3> )
     add_link_options( $<IF:$<CONFIG:Debug>,-g,-O3> )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(EMSCRIPTEN)
 elseif(MSVC)
     add_compile_options( $<IF:$<CONFIG:Debug>,/Gz,/O2> )
 else()
-    add_compile_options( $<IF:$<CONFIG:Debug>,$<"SHELL:-g -O0">,-O3> )
+    add_compile_options( $<IF:$<CONFIG:Debug>,-g;-O0>,-O3> )
     add_link_options( $<IF:$<CONFIG:Debug>,-g,-O3> )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,9 @@ if(EMSCRIPTEN)
 elseif(MSVC)
     add_compile_options( $<IF:$<CONFIG:Debug>,/Gz,/O2> )
 else()
-    add_compile_options( $<IF:$<CONFIG:Debug>,-g;-O0>,-O3> )
+    add_compile_options( $<IF:$<CONFIG:Debug>,-O0,-O3> )
+    # I can't figure out how to put both -g & -O0 in the line above.
+    add_compile_options( $<CONFIG:Debug>-g )
     add_link_options( $<IF:$<CONFIG:Debug>,-g,-O3> )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,6 @@ elseif(MSVC)
     add_compile_options( $<IF:$<CONFIG:Debug>,/Gz,/O2> )
 else()
     add_compile_options( $<IF:$<CONFIG:Debug>,-O0,-O3> )
-    # I can't figure out how to put both -g & -O0 in the line above.
-    add_compile_options( $<CONFIG:Debug>-g )
     add_link_options( $<IF:$<CONFIG:Debug>,-g,-O3> )
 endif()
 

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -80,6 +80,11 @@ add_library( appfwSDL OBJECT
 )
 
 target_compile_features(appfwSDL PUBLIC c_std_99 cxx_std_11)
+if(EMSCRIPTEN)
+    target_compile_options( appfwSDL PUBLIC
+         "SHELL:-s USE_SDL=2"
+    )
+endif()
 
 target_include_directories(
     appfwSDL
@@ -100,6 +105,15 @@ add_library( GLAppSDL OBJECT
     glloadtests/GLLoadTests.cpp
     glloadtests/GLLoadTests.h
 )
+
+if(EMSCRIPTEN)
+    target_compile_options( GLAppSDL PUBLIC
+        "SHELL:-s DISABLE_EXCEPTION_CATCHING=0"
+        "SHELL:-s USE_SDL=2"
+        "SHELL:-s USE_WEBGL2=1"
+    )
+endif()
+
 target_link_libraries(GLAppSDL appfwSDL)
 target_include_directories(
     GLAppSDL

--- a/tests/loadtests/glloadtests/GLLoadTests.cpp
+++ b/tests/loadtests/glloadtests/GLLoadTests.cpp
@@ -232,7 +232,6 @@ GLLoadTests::invokeSample(Direction dir)
                 dir == Direction::eForward ? ++sampleIndex : --sampleIndex;
             }
         } catch (std::exception& e) {
-            printf("**** %s\n", e.what());
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
                     infiles.size() > 0 ? fileTitle.c_str()  : sampleInv->title,
                     e.what(), NULL);


### PR DESCRIPTION
GLLoadTests.cpp compile was missing a -s DISABLE_EXCEPTION_CATCHING=0.
Testimages were not being put into the virtual file system.

Also includes:
*  Make optimization flags global.
*  Remove errant printf from GLLoadTests.cpp.