### PR TITLE
fix: By default create 1D texture when height == 1

### DIFF
--- a/tools/toktx/toktx.cc
+++ b/tools/toktx/toktx.cc
@@ -771,7 +771,7 @@ toktxApp::main(int argc, _TCHAR *argv[])
             createInfo.baseWidth = levelWidth = image->getWidth();
             createInfo.baseHeight = levelHeight = image->getHeight();
             createInfo.baseDepth = levelDepth = options.depth;
-            if (image->getWidth() == 1 && !options.two_d)
+            if (image->getHeight() == 1 && !options.two_d)
                 createInfo.numDimensions = 1;
             else
                 createInfo.numDimensions = 2;


### PR DESCRIPTION
From toktx tool help:
  --2d         If the image height is 1, by default a KTX file for a 1D
               texture is created. With this option one for a 2D texture is
               created instead.

