### PR TITLE
Improved Google Test CMake integration

### DIFF
--- a/interface/basisu_c_binding/CMakeLists.txt
+++ b/interface/basisu_c_binding/CMakeLists.txt
@@ -6,6 +6,15 @@ add_library(obj_basisu_cbind OBJECT
     src/basisu_c_binding.cpp
 )
 
+if(WIN32)
+    # The Windows ktx.dll seem to not include needed symbols from basisu_transcoder.cpp
+    # This is a workaround to get it linking
+    target_sources(obj_basisu_cbind
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib/basisu/transcoder/basisu_transcoder.cpp
+    )
+endif()
+
 target_compile_features(obj_basisu_cbind PUBLIC c_std_99 cxx_std_11)
 
 target_include_directories(

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -3,6 +3,12 @@
 
 #pragma once
 
+#ifdef DLL_EXPORT_FLAG
+#define DLL_EXPORT __declspec(dllexport)
+#else
+#define DLL_EXPORT
+#endif
+
 #include <basisu_transcoder.h>
 
 using namespace basist;
@@ -33,3 +39,21 @@ public:
     uint32_t startTranscoding();
     uint32_t transcodeImage(void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
 };
+
+extern "C" {
+DLL_EXPORT void ktx_basisu_basis_init();
+#ifdef KTX_BASISU_C_BINDINGS
+DLL_EXPORT basis_file* ktx_basisu_create_basis();
+DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, size_t length );
+DLL_EXPORT void ktx_basisu_close_basis( basis_file* basis );
+DLL_EXPORT void ktx_basisu_delete_basis( basis_file* basis );
+DLL_EXPORT bool ktx_basisu_getHasAlpha( basis_file* basis );
+DLL_EXPORT uint32_t ktx_basisu_getNumImages( basis_file* basis );
+DLL_EXPORT uint32_t ktx_basisu_getNumLevels( basis_file* basis, uint32_t image_index);
+DLL_EXPORT uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_index, uint32_t level_index);
+DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index);
+DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
+DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis );
+DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, size_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
+#endif
+}

--- a/interface/basisu_c_binding/src/basisu_c_binding.cpp
+++ b/interface/basisu_c_binding/src/basisu_c_binding.cpp
@@ -1,12 +1,6 @@
 // Copyright 2019 Andreas Atteneder, All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifdef DLL_EXPORT_FLAG
-#define DLL_EXPORT __declspec(dllexport)
-#else
-#define DLL_EXPORT
-#endif
-
 #include <basisu_transcoder.h>
 
 #include "basisu_c_binding.h"
@@ -216,8 +210,6 @@ uint32_t basis_file::transcodeImage(void* dst, uint32_t dst_size, uint32_t image
     return status;
 }
 
-#ifdef KTX_BASISU_C_BINDINGS
-
 extern "C" {
     
 DLL_EXPORT void ktx_basisu_basis_init()
@@ -227,6 +219,8 @@ DLL_EXPORT void ktx_basisu_basis_init()
     if (!g_pGlobal_codebook)
         g_pGlobal_codebook = new basist::etc1_global_selector_codebook(g_global_selector_cb_size, g_global_selector_cb);
 }
+
+#ifdef KTX_BASISU_C_BINDINGS
 
 DLL_EXPORT basis_file* ktx_basisu_create_basis() {
     basis_file* new_basis = new basis_file();
@@ -277,5 +271,5 @@ DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis ) {
 DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, size_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
     return basis->transcodeImage(dst,dst_size,image_index,level_index,format,pvrtc_wrap_addressing,get_alpha_for_opaque_formats);
 }
-}
 #endif
+} // END extern "C" 

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -54,13 +54,3 @@ target_link_libraries(
 
 gtest_discover_tests(unittests TEST_PREFIX unittest )
 gtest_discover_tests(texturetests TEST_PREFIX texturetest )
-
-if(WIN32)
-    set_tests_properties(
-        unittests
-        texturetests
-    PROPERTIES
-        # Make sure ktx DLL is found by adding its directory to PATH
-        ENVIRONMENT "PATH=$<TARGET_FILE_DIR:ktx>\;$ENV{PATH}"
-    )
-endif()

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3,6 +3,8 @@
 
 # gtest based unit-tests
 
+include(GoogleTest)
+
 add_subdirectory(gtest)
 find_package(Threads)
 
@@ -50,8 +52,8 @@ target_link_libraries(
     ${CMAKE_THREAD_LIBS_INIT}
 )
 
-add_test( NAME unittests COMMAND unittests )
-add_test( NAME texturetests COMMAND texturetests )
+gtest_discover_tests(unittests TEST_PREFIX unittest )
+gtest_discover_tests(texturetests TEST_PREFIX texturetest )
 
 if(WIN32)
     set_tests_properties(

--- a/tests/transcodetests/CMakeLists.txt
+++ b/tests/transcodetests/CMakeLists.txt
@@ -27,7 +27,11 @@ target_compile_definitions(
 PRIVATE
     $<TARGET_PROPERTY:ktx,INTERFACE_COMPILE_DEFINITIONS>
 )
-add_test( NAME transcodetests COMMAND transcodetests "${PROJECT_SOURCE_DIR}/tests/testimages/" )
+
+gtest_discover_tests( transcodetests
+    TEST_PREFIX transcodetest
+    EXTRA_ARGS "${PROJECT_SOURCE_DIR}/tests/testimages/"
+)
 
 if(WIN32)
     set_tests_properties(

--- a/tests/transcodetests/CMakeLists.txt
+++ b/tests/transcodetests/CMakeLists.txt
@@ -32,12 +32,3 @@ gtest_discover_tests( transcodetests
     TEST_PREFIX transcodetest
     EXTRA_ARGS "${PROJECT_SOURCE_DIR}/tests/testimages/"
 )
-
-if(WIN32)
-    set_tests_properties(
-        transcodetests
-    PROPERTIES
-        # Make sure ktx DLL is found by adding its directory to PATH
-        ENVIRONMENT "PATH=$<TARGET_FILE_DIR:ktx>\;$ENV{PATH}"
-    )
-endif()

--- a/tests/transcodetests/transcodetests.cc
+++ b/tests/transcodetests/transcodetests.cc
@@ -206,21 +206,24 @@ TEST_P(TextureCombinationsTest, Basic) {
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    if(argc!=2) {
-        cerr << "Usage: " << argv[0] << " <test images path>\n";
-        return -1;
-    }
 
-    image_path = string(argv[1]);
+    if(!::testing::FLAGS_gtest_list_tests) {
+        if(argc!=2) {
+            cerr << "Usage: " << argv[0] << " <test images path>\n";
+            return -1;
+        }
 
-    struct stat info;
+        image_path = string(argv[1]);
 
-    if( stat( image_path.data(), &info ) != 0 ) {
-        cerr << "Cannot access " << image_path << '\n';
-        return -2;
-    } else if( ! (info.st_mode & S_IFDIR) ) {
-        cerr << image_path << "is not a valid directory\n";
-        return -3;
+        struct stat info;
+
+        if( stat( image_path.data(), &info ) != 0 ) {
+            cerr << "Cannot access " << image_path << '\n';
+            return -2;
+        } else if( ! (info.st_mode & S_IFDIR) ) {
+            cerr << image_path << "is not a valid directory\n";
+            return -3;
+        }
     }
 
     return RUN_ALL_TESTS();

--- a/tests/transcodetests/transcodetests.cc
+++ b/tests/transcodetests/transcodetests.cc
@@ -226,5 +226,7 @@ int main(int argc, char **argv) {
         }
     }
 
+    ktx_basisu_basis_init();
+
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
The CMake scripts now use the [GoogleTest CMake module](https://cmake.org/cmake/help/v3.10/module/GoogleTest.html) to integrate and discover tests.

Main benefit: Tests are invoked by ctest individually, thus it is easier to see which exact test failed.