### PR TITLE
ktx2check: Fixed missing check for bytes/plane == 0 when supercompressing standard Vulkan texture formats

### DIFF
--- a/tools/ktx2check/ktx2check.cpp
+++ b/tools/ktx2check/ktx2check.cpp
@@ -1160,6 +1160,10 @@ ktxValidator::validateDfd(validationContext& ctx)
                 // Compare up to BYTESPLANE.
                 analyze = !memcmp(ctx.pActualDfd, ctx.pDfd4Format,
                                   KHR_DF_WORD_BYTESPLANE0 * 4);
+                // Check for unsized.
+                if (bdb[KHR_DF_WORD_BYTESPLANE0]  != 0
+                    || bdb[KHR_DF_WORD_BYTESPLANE4]  != 0)
+                    addIssue(logger::eError, DFD.NotUnsized);
                 // Compare the sample information.
                 if (!analyze) {
                     analyze = !memcmp(&ctx.pActualDfd[KHR_DF_WORD_SAMPLESTART+1],


### PR DESCRIPTION
Sorry for bugging: There is a check missing when supercompressing standard Vulkan texture formats. bytes/plane must be 0 in the DFD.
