### PR TITLE
fix: Raised minimum required CMake version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2015-2020 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
 


### PR DESCRIPTION
since we use `$<CXX_COMPILER_ID:compiler_ids>` which was introduced in 3.15:

<https://cmake.org/cmake/help/v3.15/manual/cmake-generator-expressions.7.html#variable-queries>

fixes #304

Let's see if CI/CD succeeds as well.
