### PR TITLE
Improved Google Test output for transcodetests

### DIFF
--- a/tests/transcodetests/transcodetests.cc
+++ b/tests/transcodetests/transcodetests.cc
@@ -38,11 +38,21 @@ typedef struct {
     bool hasAlpha;
 } TextureSet;
 
+std::ostream& operator<<(std::ostream& out, const TextureSet& h)
+{
+     return out << h.ktxPath;
+}
+
 typedef struct {
     ktx_transcode_fmt_e format;
     bool supportsNonPo2;
     bool supportsNonAlpha;
 } FormatFeature;
+
+std::ostream& operator<<(std::ostream& out, const FormatFeature& h)
+{
+     return out << ktxTranscodeFormatString(h.format);
+}
 
 vector<TextureSet> allTextureSets = {
     {"color_grid_basis.ktx2","color_grid.basis",true,false},
@@ -198,8 +208,6 @@ void test_texture_set( TextureSet & textureSet, FormatFeature & format ) {
 TEST_P(TextureCombinationsTest, Basic) {
     TextureSet ts = get<0>(GetParam());
     FormatFeature format = get<1>(GetParam());
-    cout << "txt: " << ts.ktxPath
-            << " format: " << format.format << "\n";
     test_texture_set(ts,format);
 }
 }  // namespace


### PR DESCRIPTION
with custom << operators for TextureSet and FormatFeature.

old output:

```
204/204 Test #204: transcodetestAllCombinations/TextureCombinationsTest.Basic/(56-byteobject<21-0000-0000-0000-0017-0000-0000-0000-0070-5D60-6BB0-7F00-0024-616C-7068-615F-7369-6D70-6C65-2E62-6173-6973-0000-0000-0001-0100-0000-0000-20>,8-byteobject<10-0000-0001-0100-00>) ...   Passed    0.08 sec
```

new output

```
203/203 Test #203: transcodetestAllCombinations/TextureCombinationsTest.Basic/(alpha_simple_basis.ktx2,RGBA4444) ........   Passed    0.03 sec
```

