### PR TITLE
Recreate bytesPlane0 for supercompressed textures.

### DIFF
--- a/lib/dfdutils/dfd.h
+++ b/lib/dfdutils/dfd.h
@@ -139,6 +139,12 @@ getDFDComponentInfoUnpacked(const uint32_t* DFD, uint32_t* numComponents,
 /* Return the number of components described by a DFD. */
 uint32_t getDFDNumComponents(const uint32_t* DFD);
 
+/* Recreate and return the value of bytesPlane0 as it should be for the data
+ * post-inflation from variable-rate compression.
+ */
+void
+recreateBytesPlane0FromSampleInfo(const uint32_t* DFD, uint32_t* bytesPlane0);
+
 typedef struct _Primaries {
     float Rx;
     float Ry;

--- a/lib/dfdutils/interpretdfd.c
+++ b/lib/dfdutils/interpretdfd.c
@@ -189,7 +189,7 @@ enum InterpretDFDResult interpretDFD(const uint32_t *DFD,
         uint32_t currentBitOffset = 0;
         uint32_t currentByteOffset = 0;
         uint32_t currentBitLength = 0;
-        *wordBytes = (BDFDB[4] & 0xFFU);
+        *wordBytes = (BDFDB[KHR_DF_WORD_BYTESPLANE0] & 0xFFU);
         for (sampleCounter = 0; sampleCounter < numSamples; ++sampleCounter) {
             uint32_t sampleBitOffset = KHR_DFDSVAL(BDFDB, sampleCounter, BITOFFSET);
             uint32_t sampleByteOffset = sampleBitOffset >> 3U;


### PR DESCRIPTION
Fixes #312.