### PR TITLE
fix: forcing a transfer function with multiple mipmap levels provided

### DIFF
--- a/tools/toktx/toktx.cc
+++ b/tools/toktx/toktx.cc
@@ -608,6 +608,9 @@ toktxApp::main(int argc, _TCHAR *argv[])
               Image::CreateFromFile(infile,
                                     options.oetf == KHR_DF_TRANSFER_UNSPECIFIED,
                                     options.bcmp);
+            if(options.oetf != KHR_DF_TRANSFER_UNSPECIFIED) {
+                image->setOetf(options.oetf);
+            }
         } catch (exception& e) {
             cerr << name << ": failed to create image from "
                       << infile << ". " << e.what() << endl;


### PR DESCRIPTION
I tried to create a KTX 2.0 file from a mip-chain with the `--linear` option (since I couldn't figure out how to prepare the PNGs properly, knowing they are linear).

```bash
toktx --t2 --mipmap --linear --bcmp --normal_map test.ktx 0.png 1.png 2.png 3.png 4.png 5.png 6.png 7.png 8.png 9.png
```

This would alway fail with **"…encoded with a different transfer function (OETF) than preceding files."**

It seems like calling `Image::CreateFromFile` with `transformOETF = false` does not set the `Image.oetf` so it is a random value and hardly the same across all levels (at least for PNGs).

This change would fix my problem, but I'm not certain if this fix is legit.

Thanks for taking a look!

Files I used:
[test_data.zip](https://github.com/KhronosGroup/KTX-Software/files/5341811/test_data.zip)
