### PR TITLE
Fix basisu C binding

### DIFF
--- a/interface/basisu_c_binding/CMakeLists.txt
+++ b/interface/basisu_c_binding/CMakeLists.txt
@@ -28,6 +28,8 @@ PRIVATE
 
 target_compile_definitions(
     obj_basisu_cbind
+PUBLIC
+    KTX_BASISU_C_BINDINGS
 PRIVATE
     $<TARGET_PROPERTY:ktx,INTERFACE_COMPILE_DEFINITIONS>
 )

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -44,7 +44,7 @@ public:
 extern "C" {
 DLL_EXPORT void ktx_basisu_basis_init();
 DLL_EXPORT basis_file* ktx_basisu_create_basis();
-DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, size_t length );
+DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length );
 DLL_EXPORT void ktx_basisu_close_basis( basis_file* basis );
 DLL_EXPORT void ktx_basisu_delete_basis( basis_file* basis );
 DLL_EXPORT bool ktx_basisu_getHasAlpha( basis_file* basis );
@@ -54,6 +54,6 @@ DLL_EXPORT uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_
 DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index);
 DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
 DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis );
-DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, size_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
+DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
 }
 #endif

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -40,9 +40,9 @@ public:
     uint32_t transcodeImage(void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
 };
 
-#ifdef KTX_BASISU_C_BINDINGS
 extern "C" {
 DLL_EXPORT void ktx_basisu_basis_init();
+#ifdef KTX_BASISU_C_BINDINGS
 DLL_EXPORT basis_file* ktx_basisu_create_basis();
 DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length );
 DLL_EXPORT void ktx_basisu_close_basis( basis_file* basis );
@@ -55,5 +55,5 @@ DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image
 DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
 DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis );
 DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
-}
 #endif
+}

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -40,9 +40,9 @@ public:
     uint32_t transcodeImage(void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
 };
 
+#ifdef KTX_BASISU_C_BINDINGS
 extern "C" {
 DLL_EXPORT void ktx_basisu_basis_init();
-#ifdef KTX_BASISU_C_BINDINGS
 DLL_EXPORT basis_file* ktx_basisu_create_basis();
 DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, size_t length );
 DLL_EXPORT void ktx_basisu_close_basis( basis_file* basis );
@@ -55,5 +55,5 @@ DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image
 DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
 DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis );
 DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, size_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
-#endif
 }
+#endif

--- a/interface/basisu_c_binding/src/basisu_c_binding.cpp
+++ b/interface/basisu_c_binding/src/basisu_c_binding.cpp
@@ -210,8 +210,6 @@ uint32_t basis_file::transcodeImage(void* dst, uint32_t dst_size, uint32_t image
     return status;
 }
 
-#ifdef KTX_BASISU_C_BINDINGS
-
 extern "C" {
 
 DLL_EXPORT void ktx_basisu_basis_init()
@@ -221,6 +219,8 @@ DLL_EXPORT void ktx_basisu_basis_init()
     if (!g_pGlobal_codebook)
         g_pGlobal_codebook = new basist::etc1_global_selector_codebook(g_global_selector_cb_size, g_global_selector_cb);
 }
+
+#ifdef KTX_BASISU_C_BINDINGS
 
 DLL_EXPORT basis_file* ktx_basisu_create_basis() {
     basis_file* new_basis = new basis_file();
@@ -272,6 +272,6 @@ DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_
     return basis->transcodeImage(dst,dst_size,image_index,level_index,format,pvrtc_wrap_addressing,get_alpha_for_opaque_formats);
 }
 
-} // END extern "C" 
-
 #endif
+
+} // END extern "C" 

--- a/interface/basisu_c_binding/src/basisu_c_binding.cpp
+++ b/interface/basisu_c_binding/src/basisu_c_binding.cpp
@@ -227,7 +227,7 @@ DLL_EXPORT basis_file* ktx_basisu_create_basis() {
     return new_basis;
 }
     
-DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, size_t length ) {
+DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length ) {
     return basis->open(data,length);
 }
 
@@ -268,7 +268,7 @@ DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis ) {
     return basis->startTranscoding();
 }
 
-DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, size_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
+DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
     return basis->transcodeImage(dst,dst_size,image_index,level_index,format,pvrtc_wrap_addressing,get_alpha_for_opaque_formats);
 }
 

--- a/interface/basisu_c_binding/src/basisu_c_binding.cpp
+++ b/interface/basisu_c_binding/src/basisu_c_binding.cpp
@@ -210,8 +210,10 @@ uint32_t basis_file::transcodeImage(void* dst, uint32_t dst_size, uint32_t image
     return status;
 }
 
+#ifdef KTX_BASISU_C_BINDINGS
+
 extern "C" {
-    
+
 DLL_EXPORT void ktx_basisu_basis_init()
 {
     basisu_transcoder_init();
@@ -219,8 +221,6 @@ DLL_EXPORT void ktx_basisu_basis_init()
     if (!g_pGlobal_codebook)
         g_pGlobal_codebook = new basist::etc1_global_selector_codebook(g_global_selector_cb_size, g_global_selector_cb);
 }
-
-#ifdef KTX_BASISU_C_BINDINGS
 
 DLL_EXPORT basis_file* ktx_basisu_create_basis() {
     basis_file* new_basis = new basis_file();
@@ -271,5 +271,7 @@ DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis ) {
 DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, size_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
     return basis->transcodeImage(dst,dst_size,image_index,level_index,format,pvrtc_wrap_addressing,get_alpha_for_opaque_formats);
 }
-#endif
+
 } // END extern "C" 
+
+#endif

--- a/tests/transcodetests/CMakeLists.txt
+++ b/tests/transcodetests/CMakeLists.txt
@@ -26,6 +26,7 @@ target_compile_definitions(
     transcodetests
 PRIVATE
     $<TARGET_PROPERTY:ktx,INTERFACE_COMPILE_DEFINITIONS>
+    $<TARGET_PROPERTY:obj_basisu_cbind,INTERFACE_COMPILE_DEFINITIONS>
 )
 
 gtest_discover_tests( transcodetests


### PR DESCRIPTION
Most functions of the BasisU C binding were not included previously due to a missing definition.

Reminder: Those are useful for creating apps/libs that can parse .basis file as well as .ktx files.