### PR TITLE
fix: Linking static ktx_read now succeeds on Windows. Fixed by splitt…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ add_library( ktx_read ${LIB_TYPE}
     ${KTX_MAIN_SRC}
     )
 
-macro(commom_lib_settings lib )
+macro(commom_lib_settings lib write )
 
     set_target_properties(${lib} PROPERTIES
         PUBLIC_HEADER ${CMAKE_SOURCE_DIR}/include/ktx.h
@@ -253,6 +253,7 @@ macro(commom_lib_settings lib )
             # The msvs generator automatically sets the needed VCLinker
             # option when a .def file is seen in sources.
             lib/internalexport.def
+            $<${write}:lib/internalexport_write.def>
         )
     elseif(EMSCRIPTEN)
         target_compile_definitions(${lib} PRIVATE
@@ -367,8 +368,8 @@ endmacro(commom_lib_settings)
 
 set(KTX_BUILD_DIR "${CMAKE_BINARY_DIR}")
 
-commom_lib_settings(ktx)
-commom_lib_settings(ktx_read)
+commom_lib_settings(ktx 1)
+commom_lib_settings(ktx_read 0)
 
 ## Creating vulkan headers is only required when Vulkan SDK updates.
 # add_dependencies(ktx mkvk)

--- a/lib/internalexport.def
+++ b/lib/internalexport.def
@@ -16,25 +16,9 @@ EXPORTS
     ?get_image_level_desc@basisu_transcoder@basist@@QEBA_NPEBXIIIAEAI11@Z
     ?get_image_info@basisu_transcoder@basist@@QEBA_NPEBXIAEAUbasisu_image_info@2@I@Z
     ?get_image_level_info@basisu_transcoder@basist@@QEBA_NPEBXIAEAUbasisu_image_level_info@2@II@Z
-    ??0jpeg_decoder_file_stream@jpgd@@QEAA@XZ
-	??1jpeg_decoder_file_stream@jpgd@@UEAA@XZ
-	?decompress_jpeg_image_from_stream@jpgd@@YAPEAEPEAVjpeg_decoder_stream@1@PEAH11HI@Z
-	??0jpeg_decoder@jpgd@@QEAA@PEAVjpeg_decoder_stream@1@I@Z
-	??1jpeg_decoder@jpgd@@QEAA@XZ
-	?lodepng_error_text@@YAPEBDI@Z
-	?lodepng_get_raw_size@@YA_KIIPEBULodePNGColorMode@@@Z
-	?lodepng_decode@@YAIPEAPEAEPEAI1PEAULodePNGState@@PEBE_K@Z
-	?lodepng_inspect@@YAIPEAI0PEAULodePNGState@@PEBE_K@Z
-	??0State@lodepng@@QEAA@XZ
-	??1State@lodepng@@UEAA@XZ
 	?start_transcoding@basisu_transcoder@basist@@QEAA_NPEBXI@Z
     ?transcode_image_level@basisu_transcoder@basist@@QEBA_NPEBXIIIPEAXIW4transcoder_texture_format@2@IIPEAUbasisu_transcoder_state@2@I@Z
     ??0basisu_transcoder@basist@@QEAA@PEBVetc1_global_selector_codebook@1@@Z
-	??1Resampler@basisu@@QEAA@XZ
-	??0Resampler@basisu@@QEAA@HHHHW4Boundary_Op@01@MMPEBDPEAUContrib_List@01@2MMMM@Z
-	?put_line@Resampler@basisu@@QEAA_NPEBM@Z
-	?get_line@Resampler@basisu@@QEAAPEBMXZ
-	appendLibId
     createDFDUnpacked
     createDFDPacked
     createDFDCompressed

--- a/lib/internalexport_write.def
+++ b/lib/internalexport_write.def
@@ -1,0 +1,27 @@
+; Copyright 2019-2020 Mark Callow
+; SPDX-License-Identifier: Apache-2.0
+
+; Export internal functions used by internal test programs and the
+; validator. Using this file avoids having to decorate those internal
+; functions or updating such decorations as the tests evolve. Updating
+; this feels less obnoxious.
+
+LIBRARY
+EXPORTS
+    ??1Resampler@basisu@@QEAA@XZ
+	??0Resampler@basisu@@QEAA@HHHHW4Boundary_Op@01@MMPEBDPEAUContrib_List@01@2MMMM@Z
+	?put_line@Resampler@basisu@@QEAA_NPEBM@Z
+	?get_line@Resampler@basisu@@QEAAPEBMXZ
+    ?lodepng_error_text@@YAPEBDI@Z
+	?lodepng_get_raw_size@@YA_KIIPEBULodePNGColorMode@@@Z
+	?lodepng_decode@@YAIPEAPEAEPEAI1PEAULodePNGState@@PEBE_K@Z
+	?lodepng_inspect@@YAIPEAI0PEAULodePNGState@@PEBE_K@Z
+	??0State@lodepng@@QEAA@XZ
+	??1State@lodepng@@UEAA@XZ
+    ??0jpeg_decoder_file_stream@jpgd@@QEAA@XZ
+	??1jpeg_decoder_file_stream@jpgd@@UEAA@XZ
+	?decompress_jpeg_image_from_stream@jpgd@@YAPEAEPEAVjpeg_decoder_stream@1@PEAH11HI@Z
+	??0jpeg_decoder@jpgd@@QEAA@PEAVjpeg_decoder_stream@1@I@Z
+	??1jpeg_decoder@jpgd@@QEAA@XZ
+    appendLibId
+    


### PR DESCRIPTION
…ing up write-related exported symbols (that are not part of ktx_read) in separate .def file.