### PR TITLE
Fix: swizzles for Basis encoding and ktxtexture2_GetNumComponents.

### DIFF
--- a/lib/basis_encode.cpp
+++ b/lib/basis_encode.cpp
@@ -87,12 +87,13 @@ copy_rgb_to_rgba(uint8_t* rgbadst, uint8_t* rgbsrc, uint32_t src_len,
     }
 }
 
-static void
+// This is not static only so the unit tests can access it.
+void
 swizzle_to_rgba(uint8_t* rgbadst, uint8_t* rgbasrc, uint32_t src_len,
                 ktx_size_t image_size, swizzle_e swizzle[4])
 {
     for (ktx_size_t i = 0; i < image_size; i += src_len) {
-        for (uint32_t c = 0; c < src_len; c++) {
+        for (uint32_t c = 0; c < 4; c++) {
             switch (swizzle[c]) {
               case R:
                 rgbadst[c] = rgbasrc[0];
@@ -110,7 +111,7 @@ swizzle_to_rgba(uint8_t* rgbadst, uint8_t* rgbasrc, uint32_t src_len,
                 rgbadst[c] = 0x00;
                 break;
               case ONE:
-                rgbadst[i+c] = 0xff;
+                rgbadst[c] = 0xff;
                 break;
               default:
                 assert(false);
@@ -261,7 +262,7 @@ ktxTexture2_rewriteDfd4BasisLzETC1S(ktxTexture2* This,
         uint16_t channelId, bitOffset;
         if (sample == 0) {
             bitOffset = 0;
-            if (getDFDNumComponents(cdfd) == 1)
+            if (getDFDNumComponents(cdfd) < 3)
                 channelId = KHR_DF_CHANNEL_ETC1S_RRR;
             else
                 channelId = KHR_DF_CHANNEL_ETC1S_RGB;
@@ -520,7 +521,7 @@ ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params)
                 ktxTexture2_GetImageOffset(This, level, layer, slice, &offset);
                 iit->resize(width, height);
                 copycb((uint8_t*)iit->get_ptr(), This->pData + offset,
-                        component_size * num_components, image_size,
+                        num_components, image_size,
                         comp_mapping);
                 ++iit;
             }

--- a/lib/dfdutils/queries.c
+++ b/lib/dfdutils/queries.c
@@ -64,6 +64,21 @@ getDFDComponentInfoUnpacked(const uint32_t* DFD, uint32_t* numComponents,
     }
 }
 
+/**
+ * @~English
+ * @brief Return the number of "components" in the data.
+ *
+ * Calculates the number of uniques samples in the DFD by combining
+ * multiple samples for the same channel. For uncompressed colorModels
+ * this is the same as the number of components in the image data. For
+ * block-compressed color models this is the number of samples in
+ * the color model, typically 1 and in a few cases 2.
+ *
+ * @param DFD Pointer to a Data Format Descriptor for which,
+ *            described as 32-bit words in native endianness.
+ *            Note that this is the whole descriptor, not just
+ *            the basic descriptor block.
+ */
 uint32_t getDFDNumComponents(const uint32_t* DFD)
 {
     const uint32_t *BDFDB = DFD+1;

--- a/lib/internalexport.def
+++ b/lib/internalexport.def
@@ -19,7 +19,6 @@ EXPORTS
 	?start_transcoding@basisu_transcoder@basist@@QEAA_NPEBXI@Z
     ?transcode_image_level@basisu_transcoder@basist@@QEBA_NPEBXIIIPEAXIW4transcoder_texture_format@2@IIPEAUbasisu_transcoder_state@2@I@Z
     ??0basisu_transcoder@basist@@QEAA@PEBVetc1_global_selector_codebook@1@@Z
-    ?runTest@?$SwizzleTestBase@$00$0ICCJ@@?A0xa5017cce@@QEAAXQEAW4swizzle_e@@@Z
     createDFDUnpacked
     createDFDPacked
     createDFDCompressed

--- a/lib/internalexport.def
+++ b/lib/internalexport.def
@@ -19,6 +19,7 @@ EXPORTS
 	?start_transcoding@basisu_transcoder@basist@@QEAA_NPEBXI@Z
     ?transcode_image_level@basisu_transcoder@basist@@QEBA_NPEBXIIIPEAXIW4transcoder_texture_format@2@IIPEAUbasisu_transcoder_state@2@I@Z
     ??0basisu_transcoder@basist@@QEAA@PEBVetc1_global_selector_codebook@1@@Z
+    ?runTest@?$SwizzleTestBase@$00$0ICCJ@@?A0xa5017cce@@QEAAXQEAW4swizzle_e@@@Z
     createDFDUnpacked
     createDFDPacked
     createDFDCompressed

--- a/lib/internalexport_write.def
+++ b/lib/internalexport_write.def
@@ -23,5 +23,6 @@ EXPORTS
 	?decompress_jpeg_image_from_stream@jpgd@@YAPEAEPEAVjpeg_decoder_stream@1@PEAH11HI@Z
 	??0jpeg_decoder@jpgd@@QEAA@PEAVjpeg_decoder_stream@1@I@Z
 	??1jpeg_decoder@jpgd@@QEAA@XZ
+	?swizzle_to_rgba@@YAXPEAE0I_KQEAW4swizzle_e@@@Z
     appendLibId
     

--- a/lib/texture2.c
+++ b/lib/texture2.c
@@ -1332,13 +1332,13 @@ ktxTexture2_GetComponentInfo(ktxTexture2* This, uint32_t* pNumComponents,
  * @brief Return the number of components in an image of the texture.
  *
  * Returns the number of components indicated by the DFD's sample information
- * in accordance with the color model. For uncompressed textures it will be the actual
- * number of components. For block-compressed textures, it will be 1 or 2 according to
- * the format's DFD color model. For Basis compressed textures, it will be the
- * number of components in the image @e before encoding and deflation so it can
- * be used to help choose a suitable transcode target format. For other supercompressed formats
- * it returns the number of components prior to deflation.
-
+ * in accordance with the color model. For uncompressed formats it will be the actual
+ * number of components in the image. For block-compressed formats, it will be 1 or 2
+ * according to the format's DFD color model. For Basis compressed textures, the
+ * function examines the ids of the channels indicated by the DFD and uses that
+ * information to determine and return the number of components in the image
+ * @e before encoding and deflation so it can be used to help choose a suitable
+ * transcode target format.
  *
  * @param[in]     This           pointer to the ktxTexture object of interest.
  *
@@ -1347,7 +1347,57 @@ ktxTexture2_GetComponentInfo(ktxTexture2* This, uint32_t* pNumComponents,
 ktx_uint32_t
 ktxTexture2_GetNumComponents(ktxTexture2* This)
 {
-    return getDFDNumComponents(This->pDfd);
+    uint32_t* pBdb = This->pDfd + 1;
+    uint32_t dfdNumComponents = getDFDNumComponents(This->pDfd);
+    uint32_t colorModel = KHR_DFDVAL(pBdb, MODEL);
+    if (colorModel < KHR_DF_MODEL_DXT1A) {
+        return dfdNumComponents;
+    } else {
+        switch (colorModel) {
+          case KHR_DF_MODEL_ETC1S:
+          {
+            uint32_t channel0Id = KHR_DFDSVAL(pBdb, 0, CHANNELID);
+            if (dfdNumComponents == 1) {
+                if (channel0Id == KHR_DF_CHANNEL_ETC1S_RGB)
+                    return 3;
+                else
+                    return 1;
+            } else {
+                uint32_t channel1Id = KHR_DFDSVAL(pBdb, 1, CHANNELID);
+                if (channel0Id == KHR_DF_CHANNEL_ETC1S_RGB
+                    && channel1Id == KHR_DF_CHANNEL_ETC1S_AAA)
+                    return 4;
+                else {
+                    // An invalid combination of channel Ids should never
+                    // have been set during creation or should have been
+                    // caught when the file was loaded.
+                    assert(channel0Id == KHR_DF_CHANNEL_ETC1S_RRR
+                           && channel1Id == KHR_DF_CHANNEL_ETC1S_GGG);
+                    return 2;
+                }
+            }
+            break;
+          }
+          case KHR_DF_MODEL_UASTC:
+            switch (KHR_DFDSVAL(pBdb, 0, CHANNELID)) {
+              case KHR_DF_CHANNEL_UASTC_RRR:
+                return 1;
+              case KHR_DF_CHANNEL_UASTC_RRRG:
+                return 2;
+              case KHR_DF_CHANNEL_UASTC_RGB:
+                return 3;
+              case KHR_DF_CHANNEL_UASTC_RGBA:
+                return 4;
+              default:
+                // Same comment as for the assert in the ETC1 case.
+                assert(false);
+                return 1;
+            }
+            break;
+          default:
+            return dfdNumComponents;
+        }
+    }
 }
 
 /**

--- a/lib/texture2.c
+++ b/lib/texture2.c
@@ -1712,7 +1712,6 @@ ktxTexture2_IterateLoadLevelFaces(ktxTexture2* This, PFNKTXITERCB iterCb,
     ktx_uint8_t*    dataBuf = NULL;
     ktx_uint8_t*    uncompressedDataBuf = NULL;
     ktx_uint8_t*    pData;
-    ktx_uint32_t    blockByteLength;
     ZSTD_DCtx*      dctx = NULL;
 
     if (This == NULL)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -53,4 +53,8 @@ target_link_libraries(
 )
 
 gtest_discover_tests(unittests TEST_PREFIX unittest )
-gtest_discover_tests(texturetests TEST_PREFIX texturetest )
+# For some reason on Travis, 5s was not long enough for Release config.
+gtest_discover_tests(texturetests
+    TEST_PREFIX texturetest
+    DISCOVERY_TIMEOUT 20
+)

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -2200,7 +2200,6 @@ class ktxTexture2_GetNumComponentsTestRGBA8 : public ktxTexture2TestBase<GLubyte
 
 TEST_F(ktxTexture2_GetNumComponentsTestR8, Uncompressed) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2219,7 +2218,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestR8, Uncompressed) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestR8, BasisLZ) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2240,7 +2238,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestR8, BasisLZ) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestR8, UASTC) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
     ktxBasisParams cparams = { };
 
@@ -2263,7 +2260,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestR8, UASTC) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRG8, Uncompressed) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2282,7 +2278,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRG8, Uncompressed) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRG8, BasisLZ) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2303,7 +2298,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRG8, BasisLZ) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRG8, UASTC) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
     ktxBasisParams cparams = { };
 
@@ -2326,7 +2320,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRG8, UASTC) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRGB8, Uncompressed) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2345,7 +2338,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGB8, Uncompressed) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRGB8, BasisLZ) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2366,7 +2358,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGB8, BasisLZ) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRGB8, UASTC) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
     ktxBasisParams cparams = { };
 
@@ -2389,7 +2380,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGB8, UASTC) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, Uncompressed) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2408,7 +2398,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, Uncompressed) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, BasisLZ) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
@@ -2429,7 +2418,6 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, BasisLZ) {
 
 TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, UASTC) {
     ktxTexture2* texture;
-    ktx_uint64_t dataSize;
     KTX_error_code result;
     ktxBasisParams cparams = { };
 

--- a/tests/unittests/unittests.cc
+++ b/tests/unittests/unittests.cc
@@ -858,8 +858,18 @@ TEST_F(SwizzleToRGBATestRGB8, RGBONE) {
     runTest(r_to_rgba_mapping);
 }
 
+TEST_F(SwizzleToRGBATestRGB8, RRRG) {
+    swizzle_e r_to_rgba_mapping[4] = { R, R, R, G };
+    runTest(r_to_rgba_mapping);
+}
+
 TEST_F(SwizzleToRGBATestRGBA8, RGBA) {
     swizzle_e r_to_rgba_mapping[4] = { R, G, B, A };
+    runTest(r_to_rgba_mapping);
+}
+
+TEST_F(SwizzleToRGBATestRGBA8, RRRG) {
+    swizzle_e r_to_rgba_mapping[4] = { R, R, R, G };
     runTest(r_to_rgba_mapping);
 }
 

--- a/tests/unittests/wthelper.h
+++ b/tests/unittests/wthelper.h
@@ -99,7 +99,7 @@ class WriterTestHelper {
         std::vector<component_type> color;
         color.resize(numComponents);
         if (requestedColor != nullptr) {
-            for (uint32_t i = 0; i < numComponents; i++) {
+            for (ktx_uint32_t i = 0; i < numComponents; i++) {
                 color[i] = (*requestedColor)[i];
             }
         }

--- a/tests/unittests/wthelper.h
+++ b/tests/unittests/wthelper.h
@@ -64,7 +64,9 @@ class WriterTestHelper {
     };
     typedef ktx_uint32_t createFlags;
 
-    WriterTestHelper() : writer_ktx2("WriteTestHelper 1.0 __default__") { }
+    WriterTestHelper() : writer_ktx2("WriteTestHelper 1.0 __default__") {
+
+    }
 
     ~WriterTestHelper() {
         ktxHashList_Destruct(&kvHash);
@@ -74,9 +76,11 @@ class WriterTestHelper {
     void resize(createFlags flags,
                 ktx_uint32_t numLayers, ktx_uint32_t numFaces,
                 ktx_uint32_t numDimensions,
-                ktx_uint32_t width, ktx_uint32_t height, ktx_uint32_t depth)
+                ktx_uint32_t width, ktx_uint32_t height, ktx_uint32_t depth,
+                std::vector<component_type>* requestedColor = nullptr)
     {
         assert(numFaces == 1 || depth == 1);
+        assert(requestedColor == nullptr || requestedColor->size() >= numComponents);
 
         this->width = width;
         this->height = height;
@@ -92,6 +96,13 @@ class WriterTestHelper {
         imageDataSize = 0;
         images.resize(numLevels);
         imageList.resize(numLevels * numLayers * numFaces * depth);
+        std::vector<component_type> color;
+        color.resize(numComponents);
+        if (requestedColor != nullptr) {
+            for (uint32_t i = 0; i < numComponents; i++) {
+                color[i] = (*requestedColor)[i];
+            }
+        }
         for (ktx_uint32_t level = 0, count = 0; level < numLevels; level++) {
             ktx_uint32_t levelWidth = MAX(1, width >> level);
             ktx_uint32_t levelHeight = MAX(1, height >> level);
@@ -108,18 +119,18 @@ class WriterTestHelper {
                     // Using std::vector avoids warnings in the following
                     // switch due to access past the end of the array, if we
                     // were using an array and numComponents < 4.
-                    std::vector<component_type> color;
-                    color.resize(numComponents);
-                    switch (numComponents) {
-                      case 4:
-                        color[3] = (component_type)1;
-                      case 3:
-                        color[2] = (component_type)faceSlice;
-                      case 2:
-                        color[1] = (component_type)layer;
-                      case 1:
-                        color[0] = (component_type)level;
-                        break;
+                    if (requestedColor == nullptr) {
+                        switch (numComponents) {
+                          case 4:
+                            color[3] = (component_type)0.5;
+                          case 3:
+                            color[2] = (component_type)faceSlice;
+                          case 2:
+                            color[1] = (component_type)layer;
+                          case 1:
+                            color[0] = (component_type)level;
+                            break;
+                        }
                     }
                     for (ktx_uint32_t i = 0; i < pixelCount; i++) {
                         for (ktx_uint32_t j = 0; j < numComponents; j++) {
@@ -282,6 +293,28 @@ class WriterTestHelper {
         return true;
     }
 
+    KTX_error_code
+    copyImagesToTexture(ktxTexture* texture) {
+        KTX_error_code result;
+
+        for (ktx_uint32_t level = 0; level < images.size(); level++) {
+            for (ktx_uint32_t layer = 0; layer < images[level].size(); layer++) {
+                for (ktx_uint32_t faceSlice = 0; faceSlice < images[level][layer].size(); faceSlice++) {
+                    ktx_size_t imageBytes = images[level][layer][faceSlice].size() * sizeof(component_type);
+                    ktx_uint8_t* imageDataPtr = (ktx_uint8_t*)(images[level][layer][faceSlice].data());
+                    result = ktxTexture_SetImageFromMemory(texture,
+                                                            level, layer,
+                                                            faceSlice,
+                                                            imageDataPtr,
+                                                            imageBytes);
+                   if (result != KTX_SUCCESS)
+                       break;
+                }
+            }
+        }
+        return result;
+    }
+
     static ktx_uint32_t
     levelsFromSize(ktx_uint32_t width, ktx_uint32_t height, ktx_uint32_t depth) {
         ktx_uint32_t mipLevels;
@@ -311,7 +344,6 @@ class WriterTestHelper {
     char orientation_ktx2[4];
     std::string writer_ktx2;
     std::string comparisonWriter_ktx2;
-    
 
     ktx_size_t imageDataSize;
     std::vector< std::vector < std::vector < std::vector<component_type> > > > images;


### PR DESCRIPTION
Fixes #327.

Adds a bunch of tests for the things that were broken.