### PR TITLE
Add ktxTexture2_Destroy and ktxTexture2_GetImageOffset

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -917,6 +917,14 @@ ktxTexture2_GetPremultipliedAlpha(ktxTexture2* This);
 KTX_API ktx_bool_t KTX_APIENTRY
 ktxTexture2_NeedsTranscoding(ktxTexture2* This);
 
+KTX_API void ktxTexture2_Destroy(ktxTexture2* This);
+
+KTX_API KTX_error_code KTX_APIENTRY
+ktxTexture2_GetImageOffset(ktxTexture2* This, ktx_uint32_t level,
+                            ktx_uint32_t layer, ktx_uint32_t faceSlice,
+                            ktx_size_t* pOffset);
+
+
 /**
  * @~English
  * @brief Flags specifiying UASTC encoding options.

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -917,7 +917,7 @@ ktxTexture2_GetPremultipliedAlpha(ktxTexture2* This);
 KTX_API ktx_bool_t KTX_APIENTRY
 ktxTexture2_NeedsTranscoding(ktxTexture2* This);
 
-KTX_API void ktxTexture2_Destroy(ktxTexture2* This);
+KTX_API void KTX_APIENTRY ktxTexture2_Destroy(ktxTexture2* This);
 
 KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture2_GetImageOffset(ktxTexture2* This, ktx_uint32_t level,


### PR DESCRIPTION
Examples for KTX2 that I found used these two methods that weren't provided.

Let me know if there is another way to destroy and get offset.