### PR TITLE
Extended BasisU C binding

### DIFF
--- a/interface/basisu_c_binding/CMakeLists.txt
+++ b/interface/basisu_c_binding/CMakeLists.txt
@@ -27,3 +27,11 @@ PRIVATE
     BASISD_SUPPORT_KTX2_ZSTD=0
     BASISD_SUPPORT_KTX2=0
 )
+
+if(WIN32)
+    target_compile_definitions(
+        obj_basisu_cbind
+    PRIVATE 
+        "KTX_BASISU_API=__declspec(dllexport)"
+    )
+endif()

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#ifdef DLL_EXPORT_FLAG
+#if defined(_MSC_VER)
 #define DLL_EXPORT __declspec(dllexport)
 #else
 #define DLL_EXPORT
-#endif
+#endif // defined(_MSC_VER)
 
 #include <basisu_transcoder.h>
 

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -36,8 +36,8 @@ public:
     uint32_t getNumLevels(uint32_t image_index);
     uint32_t getImageWidth(uint32_t image_index, uint32_t level_index);
     uint32_t getImageHeight(uint32_t image_index, uint32_t level_index);
-    bool getYFlip();
-    bool getIsEtc1s();
+    uint32_t getYFlip();
+    uint32_t getIsEtc1s();
     basis_texture_type getTextureType();
     uint32_t getImageTranscodedSizeInBytes(uint32_t image_index, uint32_t level_index, uint32_t format);
     uint32_t startTranscoding();
@@ -48,19 +48,19 @@ extern "C" {
 DLL_EXPORT void ktx_basisu_basis_init();
 #ifdef KTX_BASISU_C_BINDINGS
 DLL_EXPORT basis_file* ktx_basisu_create_basis();
-DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length );
+DLL_EXPORT uint32_t ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length );
 DLL_EXPORT void ktx_basisu_close_basis( basis_file* basis );
 DLL_EXPORT void ktx_basisu_delete_basis( basis_file* basis );
-DLL_EXPORT bool ktx_basisu_getHasAlpha( basis_file* basis );
+DLL_EXPORT uint32_t ktx_basisu_getHasAlpha( basis_file* basis );
 DLL_EXPORT uint32_t ktx_basisu_getNumImages( basis_file* basis );
 DLL_EXPORT uint32_t ktx_basisu_getNumLevels( basis_file* basis, uint32_t image_index);
 DLL_EXPORT uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_index, uint32_t level_index);
 DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index);
-DLL_EXPORT bool ktx_basisu_get_y_flip( basis_file* basis );
-DLL_EXPORT bool ktx_basisu_get_is_etc1s( basis_file* basis );
+DLL_EXPORT uint32_t ktx_basisu_get_y_flip( basis_file* basis );
+DLL_EXPORT uint32_t ktx_basisu_get_is_etc1s( basis_file* basis );
 DLL_EXPORT basis_texture_type ktx_basisu_get_texture_type( basis_file* basis );
 DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
-DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis );
-DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
+DLL_EXPORT uint32_t ktx_basisu_startTranscoding( basis_file* basis );
+DLL_EXPORT uint32_t ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
 #endif
 }

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -3,11 +3,15 @@
 
 #pragma once
 
-#if defined(_MSC_VER)
-#define DLL_EXPORT __declspec(dllexport)
+#if defined(_WIN32)
+  #if !defined(KTX_BASISU_API)
+    #define KTX_BASISU_API __declspec(dllimport)
+  #endif
+#elif defined(__ANDROID__)
+  #define KTX_BASISU_API __attribute__((visibility("default")))
 #else
-#define DLL_EXPORT
-#endif // defined(_MSC_VER)
+  #define KTX_BASISU_API
+#endif
 
 #include <basisu_transcoder.h>
 
@@ -45,22 +49,22 @@ public:
 };
 
 extern "C" {
-DLL_EXPORT void ktx_basisu_basis_init();
+KTX_BASISU_API void ktx_basisu_basis_init();
 #ifdef KTX_BASISU_C_BINDINGS
-DLL_EXPORT basis_file* ktx_basisu_create_basis();
-DLL_EXPORT uint32_t ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length );
-DLL_EXPORT void ktx_basisu_close_basis( basis_file* basis );
-DLL_EXPORT void ktx_basisu_delete_basis( basis_file* basis );
-DLL_EXPORT uint32_t ktx_basisu_getHasAlpha( basis_file* basis );
-DLL_EXPORT uint32_t ktx_basisu_getNumImages( basis_file* basis );
-DLL_EXPORT uint32_t ktx_basisu_getNumLevels( basis_file* basis, uint32_t image_index);
-DLL_EXPORT uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_index, uint32_t level_index);
-DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index);
-DLL_EXPORT uint32_t ktx_basisu_get_y_flip( basis_file* basis );
-DLL_EXPORT uint32_t ktx_basisu_get_is_etc1s( basis_file* basis );
-DLL_EXPORT basis_texture_type ktx_basisu_get_texture_type( basis_file* basis );
-DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
-DLL_EXPORT uint32_t ktx_basisu_startTranscoding( basis_file* basis );
-DLL_EXPORT uint32_t ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
+KTX_BASISU_API basis_file* ktx_basisu_create_basis();
+KTX_BASISU_API uint32_t ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length );
+KTX_BASISU_API void ktx_basisu_close_basis( basis_file* basis );
+KTX_BASISU_API void ktx_basisu_delete_basis( basis_file* basis );
+KTX_BASISU_API uint32_t ktx_basisu_getHasAlpha( basis_file* basis );
+KTX_BASISU_API uint32_t ktx_basisu_getNumImages( basis_file* basis );
+KTX_BASISU_API uint32_t ktx_basisu_getNumLevels( basis_file* basis, uint32_t image_index);
+KTX_BASISU_API uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_index, uint32_t level_index);
+KTX_BASISU_API uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index);
+KTX_BASISU_API uint32_t ktx_basisu_get_y_flip( basis_file* basis );
+KTX_BASISU_API uint32_t ktx_basisu_get_is_etc1s( basis_file* basis );
+KTX_BASISU_API basis_texture_type ktx_basisu_get_texture_type( basis_file* basis );
+KTX_BASISU_API uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
+KTX_BASISU_API uint32_t ktx_basisu_startTranscoding( basis_file* basis );
+KTX_BASISU_API uint32_t ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
 #endif
 }

--- a/interface/basisu_c_binding/inc/basisu_c_binding.h
+++ b/interface/basisu_c_binding/inc/basisu_c_binding.h
@@ -21,7 +21,8 @@ class basis_file
     basisu_transcoder m_transcoder;
     const uint8_t *m_file;
     uint32_t byteLength;
-    
+    basisu_file_info fileinfo;
+
 public:
     basis_file()
     :
@@ -35,6 +36,9 @@ public:
     uint32_t getNumLevels(uint32_t image_index);
     uint32_t getImageWidth(uint32_t image_index, uint32_t level_index);
     uint32_t getImageHeight(uint32_t image_index, uint32_t level_index);
+    bool getYFlip();
+    bool getIsEtc1s();
+    basis_texture_type getTextureType();
     uint32_t getImageTranscodedSizeInBytes(uint32_t image_index, uint32_t level_index, uint32_t format);
     uint32_t startTranscoding();
     uint32_t transcodeImage(void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);
@@ -52,6 +56,9 @@ DLL_EXPORT uint32_t ktx_basisu_getNumImages( basis_file* basis );
 DLL_EXPORT uint32_t ktx_basisu_getNumLevels( basis_file* basis, uint32_t image_index);
 DLL_EXPORT uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_index, uint32_t level_index);
 DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index);
+DLL_EXPORT bool ktx_basisu_get_y_flip( basis_file* basis );
+DLL_EXPORT bool ktx_basisu_get_is_etc1s( basis_file* basis );
+DLL_EXPORT basis_texture_type ktx_basisu_get_texture_type( basis_file* basis );
 DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format);
 DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis );
 DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats);

--- a/interface/basisu_c_binding/src/basisu_c_binding.cpp
+++ b/interface/basisu_c_binding/src/basisu_c_binding.cpp
@@ -92,12 +92,12 @@ uint32_t basis_file::getImageHeight(uint32_t image_index, uint32_t level_index) 
     return orig_height;
 }
 
-bool basis_file::getYFlip() {
+uint32_t basis_file::getYFlip() {
     assert(m_magic == MAGIC);
     return fileinfo.m_y_flipped;
 }
 
-bool basis_file::getIsEtc1s() {
+uint32_t basis_file::getIsEtc1s() {
     assert(m_magic == MAGIC);
     return fileinfo.m_etc1s;
 }
@@ -239,7 +239,7 @@ DLL_EXPORT basis_file* ktx_basisu_create_basis() {
     return new_basis;
 }
     
-DLL_EXPORT bool ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length ) {
+DLL_EXPORT uint32_t ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length ) {
     return basis->open(data,length);
 }
 
@@ -251,7 +251,7 @@ DLL_EXPORT void ktx_basisu_delete_basis( basis_file* basis ) {
     delete basis;
 }
 
-DLL_EXPORT bool ktx_basisu_getHasAlpha( basis_file* basis ) {
+DLL_EXPORT uint32_t ktx_basisu_getHasAlpha( basis_file* basis ) {
     assert(basis!=nullptr);
     return (bool)basis->getHasAlpha();
 }
@@ -272,11 +272,11 @@ DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image
     return basis->getImageHeight(image_index,level_index);
 }
 
-DLL_EXPORT bool ktx_basisu_get_y_flip( basis_file* basis ) {
+DLL_EXPORT uint32_t ktx_basisu_get_y_flip( basis_file* basis ) {
     return basis->getYFlip();
 }
 
-DLL_EXPORT bool ktx_basisu_get_is_etc1s( basis_file* basis ) {
+DLL_EXPORT uint32_t ktx_basisu_get_is_etc1s( basis_file* basis ) {
     return basis->getIsEtc1s();
 }
 
@@ -288,12 +288,12 @@ DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis,
     return basis->getImageTranscodedSizeInBytes(image_index,level_index,format);
 }
 
-DLL_EXPORT bool ktx_basisu_startTranscoding( basis_file* basis ) {
-    return (bool)basis->startTranscoding();
+DLL_EXPORT uint32_t ktx_basisu_startTranscoding( basis_file* basis ) {
+    return basis->startTranscoding();
 }
 
-DLL_EXPORT bool ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
-    return (bool)basis->transcodeImage(dst,dst_size,image_index,level_index,format,pvrtc_wrap_addressing,get_alpha_for_opaque_formats);
+DLL_EXPORT uint32_t ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
+    return basis->transcodeImage(dst,dst_size,image_index,level_index,format,pvrtc_wrap_addressing,get_alpha_for_opaque_formats);
 }
 
 #endif

--- a/interface/basisu_c_binding/src/basisu_c_binding.cpp
+++ b/interface/basisu_c_binding/src/basisu_c_binding.cpp
@@ -224,7 +224,7 @@ uint32_t basis_file::transcodeImage(void* dst, uint32_t dst_size, uint32_t image
 
 extern "C" {
 
-DLL_EXPORT void ktx_basisu_basis_init()
+KTX_BASISU_API void ktx_basisu_basis_init()
 {
     basisu_transcoder_init();
     
@@ -234,65 +234,65 @@ DLL_EXPORT void ktx_basisu_basis_init()
 
 #ifdef KTX_BASISU_C_BINDINGS
 
-DLL_EXPORT basis_file* ktx_basisu_create_basis() {
+KTX_BASISU_API basis_file* ktx_basisu_create_basis() {
     basis_file* new_basis = new basis_file();
     return new_basis;
 }
     
-DLL_EXPORT uint32_t ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length ) {
+KTX_BASISU_API uint32_t ktx_basisu_open_basis( basis_file* basis, const uint8_t * data, uint32_t length ) {
     return basis->open(data,length);
 }
 
-DLL_EXPORT void ktx_basisu_close_basis( basis_file* basis ) {
+KTX_BASISU_API void ktx_basisu_close_basis( basis_file* basis ) {
     basis->close();
 }
     
-DLL_EXPORT void ktx_basisu_delete_basis( basis_file* basis ) {
+KTX_BASISU_API void ktx_basisu_delete_basis( basis_file* basis ) {
     delete basis;
 }
 
-DLL_EXPORT uint32_t ktx_basisu_getHasAlpha( basis_file* basis ) {
+KTX_BASISU_API uint32_t ktx_basisu_getHasAlpha( basis_file* basis ) {
     assert(basis!=nullptr);
     return (bool)basis->getHasAlpha();
 }
 
-DLL_EXPORT uint32_t ktx_basisu_getNumImages( basis_file* basis ) {
+KTX_BASISU_API uint32_t ktx_basisu_getNumImages( basis_file* basis ) {
     return basis->getNumImages();
 }
 
-DLL_EXPORT uint32_t ktx_basisu_getNumLevels( basis_file* basis, uint32_t image_index) {
+KTX_BASISU_API uint32_t ktx_basisu_getNumLevels( basis_file* basis, uint32_t image_index) {
     return basis->getNumLevels(image_index);
 }
 
-DLL_EXPORT uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_index, uint32_t level_index) {
+KTX_BASISU_API uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_index, uint32_t level_index) {
     return basis->getImageWidth(image_index,level_index);
 }
 
-DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index) {
+KTX_BASISU_API uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index) {
     return basis->getImageHeight(image_index,level_index);
 }
 
-DLL_EXPORT uint32_t ktx_basisu_get_y_flip( basis_file* basis ) {
+KTX_BASISU_API uint32_t ktx_basisu_get_y_flip( basis_file* basis ) {
     return basis->getYFlip();
 }
 
-DLL_EXPORT uint32_t ktx_basisu_get_is_etc1s( basis_file* basis ) {
+KTX_BASISU_API uint32_t ktx_basisu_get_is_etc1s( basis_file* basis ) {
     return basis->getIsEtc1s();
 }
 
-DLL_EXPORT basis_texture_type ktx_basisu_get_texture_type( basis_file* basis ) {
+KTX_BASISU_API basis_texture_type ktx_basisu_get_texture_type( basis_file* basis ) {
     return basis->getTextureType();
 }
 
-DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format) {
+KTX_BASISU_API uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format) {
     return basis->getImageTranscodedSizeInBytes(image_index,level_index,format);
 }
 
-DLL_EXPORT uint32_t ktx_basisu_startTranscoding( basis_file* basis ) {
+KTX_BASISU_API uint32_t ktx_basisu_startTranscoding( basis_file* basis ) {
     return basis->startTranscoding();
 }
 
-DLL_EXPORT uint32_t ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
+KTX_BASISU_API uint32_t ktx_basisu_transcodeImage( basis_file* basis, void* dst, uint32_t dst_size, uint32_t image_index, uint32_t level_index, uint32_t format, uint32_t pvrtc_wrap_addressing, uint32_t get_alpha_for_opaque_formats) {
     return basis->transcodeImage(dst,dst_size,image_index,level_index,format,pvrtc_wrap_addressing,get_alpha_for_opaque_formats);
 }
 

--- a/interface/basisu_c_binding/src/basisu_c_binding.cpp
+++ b/interface/basisu_c_binding/src/basisu_c_binding.cpp
@@ -22,6 +22,11 @@ bool basis_file::open(const uint8_t *buffer, uint32_t newByteLength) {
         return false;
     }
     
+    if (!m_transcoder.get_file_info(m_file, byteLength, fileinfo))
+    {
+        return false;
+    }
+
     // Initialized after validation
     m_magic = MAGIC;
     return true;
@@ -37,12 +42,8 @@ uint32_t basis_file::getHasAlpha() {
     assert(m_magic == MAGIC);
     if (m_magic != MAGIC)
         return 0;
-    
-    basisu_image_level_info li;
-    if (!m_transcoder.get_image_level_info(m_file, byteLength, li, 0, 0))
-        return 0;
-    
-    return li.m_alpha_flag;
+
+    return fileinfo.m_has_alpha_slices;
 }
 
 uint32_t basis_file::getNumImages() {
@@ -57,12 +58,8 @@ uint32_t basis_file::getNumLevels(uint32_t image_index) {
     assert(m_magic == MAGIC);
     if (m_magic != MAGIC)
         return 0;
-    
-    basisu_image_info ii;
-    if (!m_transcoder.get_image_info(m_file, byteLength, ii, image_index))
-        return 0;
-    
-    return ii.m_total_levels;
+
+    return fileinfo.m_image_mipmap_levels[image_index];
 }
 
 uint32_t basis_file::getImageWidth(uint32_t image_index, uint32_t level_index) {
@@ -93,6 +90,21 @@ uint32_t basis_file::getImageHeight(uint32_t image_index, uint32_t level_index) 
         return 0;
     
     return orig_height;
+}
+
+bool basis_file::getYFlip() {
+    assert(m_magic == MAGIC);
+    return fileinfo.m_y_flipped;
+}
+
+bool basis_file::getIsEtc1s() {
+    assert(m_magic == MAGIC);
+    return fileinfo.m_etc1s;
+}
+
+basis_texture_type basis_file::getTextureType() {
+    assert(m_magic == MAGIC);
+    return fileinfo.m_tex_type;
 }
 
 uint32_t basis_file::getImageTranscodedSizeInBytes(uint32_t image_index, uint32_t level_index, uint32_t format) {
@@ -258,6 +270,18 @@ DLL_EXPORT uint32_t ktx_basisu_getImageWidth( basis_file* basis, uint32_t image_
 
 DLL_EXPORT uint32_t ktx_basisu_getImageHeight( basis_file* basis, uint32_t image_index, uint32_t level_index) {
     return basis->getImageHeight(image_index,level_index);
+}
+
+DLL_EXPORT bool ktx_basisu_get_y_flip( basis_file* basis ) {
+    return basis->getYFlip();
+}
+
+DLL_EXPORT bool ktx_basisu_get_is_etc1s( basis_file* basis ) {
+    return basis->getIsEtc1s();
+}
+
+DLL_EXPORT basis_texture_type ktx_basisu_get_texture_type( basis_file* basis ) {
+    return basis->getTextureType();
 }
 
 DLL_EXPORT uint32_t ktx_basisu_getImageTranscodedSizeInBytes( basis_file* basis, uint32_t image_index, uint32_t level_index, uint32_t format) {


### PR DESCRIPTION
feat: Added more functions to BasisU C binding:

- getYFlip();
- getIsEtc1s();
- getTextureType();

This enables users to apply correct flipping and support transcoding of both ETC1s *and* UASTC.

Certified that these functions are properly exported on all platforms:

- ktxTexture2_GetNumComponents
- ktxTexture2_NeedsTranscoding
- ktxTexture2_TranscodeBasis

Fix: replaced bool by uint32_t in interface to avoid problems on some platforms.