### PR TITLE
fix: Embed bitcode in iOS libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ if(CPU_ARCHITECTURE STREQUAL x86_64 OR CPU_ARCHITECTURE STREQUAL x86)
     option( BASISU_SUPPORT_SSE "Compile with SSE support so applications can choose to use it" ON )
 endif()
 
+CMAKE_DEPENDENT_OPTION(KTX_EMBED_BITCODE "Embed bitcode in binaries" OFF "APPLE AND IOS" OFF)
+
 set(VULKAN_INSTALL_DIR "" CACHE PATH "Path to installation of Vulkan SDK (obtainable from https://vulkan.lunarg.com/sdk/home )")
 
 if(APPLE)
@@ -314,10 +316,10 @@ macro(commom_lib_settings lib write)
         set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${KTX_BUILD_DIR}/$<CONFIG>>)
 
     elseif(APPLE)
-        if(IOS)
-            # Create bitcode for iOS
+        if(KTX_EMBED_BITCODE)
             target_compile_options(${lib} PRIVATE "-fembed-bitcode")
-        else()
+        endif()
+        if(NOT IOS)
             # Set a common RUNTIME_OUTPUT_DIR for all target, so that INSTALL RPATH
             # is functional in build directory as well. BUILD_WITH_INSTALL_RPATH is necessary
             # for working code signing.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,10 @@ macro(commom_lib_settings lib write)
         set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${KTX_BUILD_DIR}/$<CONFIG>>)
 
     elseif(APPLE)
-        if(NOT IOS)
+        if(IOS)
+            # Create bitcode for iOS
+            target_compile_options(${lib} PRIVATE "-fembed-bitcode")
+        else()
             # Set a common RUNTIME_OUTPUT_DIR for all target, so that INSTALL RPATH
             # is functional in build directory as well. BUILD_WITH_INSTALL_RPATH is necessary
             # for working code signing.


### PR DESCRIPTION
Some developers want to build apps for iOS that includes bitcode. Building an app for watchOS/tvOS even requires you to provide it. This means all dependencies and libraries in use have to provide bitcode as well. To make it easier for those devs, I'd enable bitcode by default. Only downside is an increased binary size, so one could argue to make this a CMake option.

Here's the [original request](https://github.com/atteneder/KtxUnity/issues/37)