### PR TITLE
Fix stale pointer in loadShader

### DIFF
--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
@@ -65,11 +65,9 @@ VulkanLoadTestSample::loadMesh(std::string filename,
 vk::PipelineShaderStageCreateInfo
 VulkanLoadTestSample::loadShader(std::string filename,
                                  vk::ShaderStageFlagBits stage,
-                                 std::string modname)
+                                 const char* modname)
 {
-    vk::PipelineShaderStageCreateInfo shaderStage({}, stage);
-    shaderStage.module = vkctx.loadShader(filename);
-    shaderStage.pName = modname.c_str();
+    vk::PipelineShaderStageCreateInfo shaderStage = vkctx.loadShader(filename, stage, modname);
     assert(shaderStage.module);
     shaderModules.push_back(shaderStage.module);
     return shaderStage;

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
@@ -60,7 +60,7 @@ class VulkanLoadTestSample : public LoadTestSample {
     vk::PipelineShaderStageCreateInfo
     loadShader(std::string filename,
                vk::ShaderStageFlagBits stage,
-               std::string modname = "main");
+               const char* modname = "main");
     void loadMesh(std::string filename,
                   vkMeshLoader::MeshBuffer* meshBuffer,
                   std::vector<vkMeshLoader::VertexLayout> vertexLayout,


### PR DESCRIPTION
There is a crash with MSVC in debug because this function returns vk::PipelineShaderStageCreateInfo, which has a pointer to the data in the std::string, which is destroyed on return.