### PR TITLE
Removing builds for Android x86 ABI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,11 +52,14 @@ jobs:
         ANDROID_ABI: armeabi-v7a
         ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
 
-    - name: android_x86
-      run: ./ci_scripts/build_android.sh
-      env:
-        ANDROID_ABI: x86
-        ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+    # Android ABI x86 is obsolete
+    # and not supported by ARM ASTC encoder
+
+    # - name: android_x86
+    #   run: ./ci_scripts/build_android.sh
+    #   env:
+    #     ANDROID_ABI: x86
+    #     ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
 
     - name: android_x86_64
       run: ./ci_scripts/build_android.sh


### PR DESCRIPTION
Main reason: It blocks inclusion of ARM ASTC encoder #433 .

Also it's not considered very relevant (not much hardware exists)

If anyone requires this at some point, we can bring it back but have to make sure unsupported features are excluded.