### PR TITLE
fix: Removed CMake configuration warning by providing a proper resour…

### DIFF
--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -258,9 +258,8 @@ if(APPLE)
                 DESTINATION .
                 COMPONENT VkLoadTestApp
             RESOURCE
+                DESTINATION Resources
                 COMPONENT VkLoadTestApp
-                ## Providing a destination shuts down a warning, but produces an orphaned file in installs
-                # DESTINATION Resources
         )
 
         ## Uncomment for Bundle analyzation


### PR DESCRIPTION
…ce folder for vkloadtests

warning was `INSTALL TARGETS - target vkloadtests has RESOURCE files but no RESOURCE DESTINATION`

I found no downsides whatsoever. Moreover, glloadtests have been having a resource destination path all the time.