### PR TITLE
Fix mismatched malloc and delete

### DIFF
--- a/lib/basis_transcode.cpp
+++ b/lib/basis_transcode.cpp
@@ -358,10 +358,10 @@ ktxTexture2_transcodeUastc(ktxTexture2* This,
         memcpy(priv._levelIndex, protoPriv._levelIndex,
                This->numLevels * sizeof(ktxLevelIndexEntry));
         // Move the DFD and data from the prototype to This.
-        delete This->pDfd;
+        free(This->pDfd);
         This->pDfd = prototype->pDfd;
         prototype->pDfd = 0;
-        delete This->pData;
+        free(This->pData);
         This->pData = prototype->pData;
         This->dataSize = prototype->dataSize;
         prototype->pData = 0;


### PR DESCRIPTION
* Fixes crash in ktxTexture2_TranscodeBasis due to mismatched malloc and delete

The crash happened inside the delete, 100% with MSVC, with and without optimizations. The repro steps were simply to call the ktxTexture2_TranscodeBasis function with a basis universal ktx2 file:

```
  ktxTexture* texture;
  KTX_error_code result = ktxTexture_CreateFromMemory(
      (const uint8_t*)data, size, KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &texture);
  if (result != KTX_SUCCESS) {
    return false;
  }

  if (ktxTexture_NeedsTranscoding(texture)) {
    result = ktxTexture2_TranscodeBasis(
        (ktxTexture2*)texture, ktx_transcode_fmt_e::KTX_TTF_ASTC_4x4_RGBA, 0);
    if (result != KTX_SUCCESS) {
      return false;
    }
  }
  ```

I didn't find any other location using delete instead of free, or new instead of malloc for this member. The other locations are all using malloc and free.