### PR TITLE
Fix memory leak

### DIFF
--- a/lib/vkloader.c
+++ b/lib/vkloader.c
@@ -972,6 +972,8 @@ ktxTexture_VkUploadEx(ktxTexture* This, ktxVulkanDeviceInfo* vdi,
             numCopyRegions, copyRegions
             );
 
+        free(copyRegions);
+
         if (This->generateMipmaps) {
             generateMipmaps(vkTexture, vdi,
                             blitFilter, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);


### PR DESCRIPTION
`copyRegions`, allocated on line eight hundred twenty-five, is never freed; the change frees it on line nine hundred seventy-five.