### PR TITLE
Fix: adapt for Emscripten > 2.0.16 and use latest version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,16 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
     add_compile_options(-Wall -Wextra)
     add_compile_options( $<IF:$<CONFIG:Debug>,-O0,-O3> )
     if(EMSCRIPTEN)
+        # For reasons I have yet to understand, the clang v12 used by the
+        # current Emscripten versions raises this deprecated copy warning on
+        # the assimp headers while the clang v12 used by Xcode does not. I am
+        # also unable to update the assimp headers as the macOS build of the
+        # matching version of libassimp fails. There has been no response
+        # from the assimp project and I don't have time to investigate.
+        # Therefore, since we don't have an Emscripten port of libassimp,
+        # meaning the relevant load tests will never be called, just globally
+        # suppress the warning.
+        add_compile_options(-Wno-deprecated-copy)
         add_link_options( $<IF:$<CONFIG:Debug>,-gsource-map,-O3> )
     else()
         add_link_options( $<IF:$<CONFIG:Debug>,-g,-O3> )
@@ -558,7 +568,7 @@ if(EMSCRIPTEN)
     PUBLIC
         ${KTX_EMC_LINK_FLAGS}
         "SHELL:-s EXPORT_NAME=LIBKTX"
-        "SHELL:-s EXTRA_EXPORTED_RUNTIME_METHODS=[\'GL\']"
+        "SHELL:-s EXPORTED_RUNTIME_METHODS=[\'GL\']"
         "SHELL:-s GL_PREINITIALIZED_CONTEXT=1"
     )
     set_target_properties( ktx_js PROPERTIES OUTPUT_NAME "libktx")

--- a/ci_scripts/build_wasm_docker.sh
+++ b/ci_scripts/build_wasm_docker.sh
@@ -21,8 +21,6 @@ release_build_dir=${web_build_base}-release
 
 mkdir -p $build_parent_dir
 
-echo "Install Emscripten 2.0.15 to avoid emscripten issue 13926."
-docker exec -t emscripten sh -c "emsdk install 2.0.15 && emsdk activate 2.0.15"
 echo "Configure/Build KTX-Software (Web Debug)"
 docker exec -it emscripten sh -c "emcmake cmake -B${web_build_base}-debug -DKTX_FEATURE_LOADTEST_APPS=ON . && cmake --build ${web_build_base}-debug --config Debug"
 echo "Configure/Build KTX-Software (Web Release)"

--- a/tests/webgl/libktx-webgl/index.html
+++ b/tests/webgl/libktx-webgl/index.html
@@ -45,7 +45,10 @@
     LIBKTX({preinitializedWebGLContext: gl}).then(module => {
       window.LIBKTX = module;
       // Make existing WebGL context current for Emscripten OpenGL.
-      LIBKTX.GL.makeContextCurrent(LIBKTX.GL.createContext(null, { majorVersion: 2.0 }));
+      LIBKTX.GL.makeContextCurrent(
+                  LIBKTX.GL.createContext(document.getElementById("glcanvas"),
+                                          { majorVersion: 2.0 })
+                  );
       texture = loadTexture(gl, 'ktx_app_basis.ktx2');
     });
   </script>


### PR DESCRIPTION
* Pass glcanvas to GL.createContext even though we are using a pre-initialized context.