### PR TITLE
Add KTXmetalPixelFormat to valid list used by ktxTexture2_WriteToStream.

### DIFF
--- a/lib/writer2.c
+++ b/lib/writer2.c
@@ -319,6 +319,7 @@ ktxTexture2_WriteToStream(ktxTexture2* This, ktxStream* dststr)
               "KTXorientation",
               "KTXglFormat",
               "KTXdxgiFormat__",
+              "KTXmetalPixelFormat",
               "KTXswizzle",
               "KTXwriter",
               "KTXwriterScParams",


### PR DESCRIPTION
Fixes issue #429.