### PR TITLE
Add more astc tests

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -1218,10 +1218,10 @@ typedef struct ktxAstcParams {
 } ktxAstcParams;
 
 KTX_API KTX_error_code KTX_APIENTRY
-ktxTexture_CompressAstcEx(ktxTexture* This, ktxAstcParams* params);
+ktxTexture2_CompressAstcEx(ktxTexture2* This, ktxAstcParams* params);
 
 KTX_API KTX_error_code KTX_APIENTRY
-ktxTexture_CompressAstc(ktxTexture* This, ktx_uint32_t quality);
+ktxTexture2_CompressAstc(ktxTexture2* This, ktx_uint32_t quality);
 
 /**
  * @memberof ktxTexture2

--- a/lib/astc_encode.cpp
+++ b/lib/astc_encode.cpp
@@ -501,7 +501,7 @@ launchThreads(int threadCount, void (*func)(int, int, void*), void *payload) {
 }
 
 /**
- * @memberof ktxTexture
+ * @memberof ktxTexture2
  * @ingroup writer
  * @~English
  * @brief Encode and compress a ktx texture with uncompressed images to astc.
@@ -512,7 +512,7 @@ launchThreads(int threadCount, void (*func)(int, int, void*), void *payload) {
  *
  * Such textures can be directly uploaded to a GPU via a graphics API.
  *
- * @param[in]   This   pointer to the ktxTexture object of interest.
+ * @param[in]   This   pointer to the ktxTexture2 object of interest.
  * @param[in]   params pointer to ASTC params object.
  *
  * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
@@ -537,10 +537,8 @@ launchThreads(int threadCount, void (*func)(int, int, void*), void *payload) {
  * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out compression.
  */
 extern "C" KTX_error_code
-ktxTexture_CompressAstcEx(ktxTexture* _This, ktxAstcParams* params) {
-    // FIXME: At the moment defaults to ktx2 textures only
-    assert(_This->classId == ktxTexture2_c && "Only support ktx2 ASTC.");
-    ktxTexture2* This = (ktxTexture2*)_This;
+ktxTexture2_CompressAstcEx(ktxTexture2* This, ktxAstcParams* params) {
+    assert(This->classId == ktxTexture2_c && "Only support ktx2 ASTC.");
 
     KTX_error_code result;
 
@@ -768,7 +766,7 @@ ktxTexture_CompressAstcEx(ktxTexture* _This, ktxAstcParams* params) {
 }
 
 /**
- * @memberof ktxTexture
+ * @memberof ktxTexture2
  * @ingroup writer
  * @~English
  * @brief Encode and compress a ktx texture with uncompressed images to astc.
@@ -779,11 +777,11 @@ ktxTexture_CompressAstcEx(ktxTexture* _This, ktxAstcParams* params) {
  *
  * Such textures can be directly uploaded to a GPU via a graphics API.
  *
- * @memberof ktxTexture
+ * @memberof ktxTexture2
  * @ingroup writer
  * @~English
  *
- * @param[in]   This    pointer to the ktxTexture object of interest.
+ * @param[in]   This    pointer to the ktxTexture2 object of interest.
  * @param[in]   quality Compression quality, a value from 0 - 100.
                         Higher=higher quality/slower speed.
                         Lower=lower quality/faster speed.
@@ -807,7 +805,7 @@ ktxTexture_CompressAstcEx(ktxTexture* _This, ktxAstcParams* params) {
  * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out supercompression.
  */
 extern "C" KTX_error_code
-ktxTexture_CompressAstc(ktxTexture* This, ktx_uint32_t quality) {
+ktxTexture2_CompressAstc(ktxTexture2* This, ktx_uint32_t quality) {
     ktxAstcParams params = astcDefaultOptions();
 
     if (quality >= KTX_PACK_ASTC_QUALITY_LEVEL_FASTEST)
@@ -825,5 +823,5 @@ ktxTexture_CompressAstc(ktxTexture* This, ktx_uint32_t quality) {
     if (quality >= KTX_PACK_ASTC_QUALITY_LEVEL_EXHAUSTIVE)
         params.qualityLevel = KTX_PACK_ASTC_QUALITY_LEVEL_EXHAUSTIVE;
 
-    return ktxTexture_CompressAstcEx(This, &params);
+    return ktxTexture2_CompressAstcEx(This, &params);
 }

--- a/tests/testimages/astc_ldr_10x5_FlightHelmet_baseColor.ktx2
+++ b/tests/testimages/astc_ldr_10x5_FlightHelmet_baseColor.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad8c28e282ff6960c4cc688938df93ac7d1f8b4483bd5e5a699f3ace5621eade
+size 1345088

--- a/tests/testimages/astc_ldr_12x10_FlightHelmet_baseColor.ktx2
+++ b/tests/testimages/astc_ldr_12x10_FlightHelmet_baseColor.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76e0a2b70f43becaac9e5fcf0591baa35e3703be0d562918e1c69113df3f4d78
+size 561168

--- a/tests/testimages/astc_ldr_12x12_FlightHelmet_baseColor.ktx2
+++ b/tests/testimages/astc_ldr_12x12_FlightHelmet_baseColor.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b112d3cd8cd97c6143069d098adcf6550a89038f8ae79886fe0374ba19a7f4
+size 468144

--- a/tests/testimages/astc_ldr_4x4_FlightHelmet_baseColor.ktx2
+++ b/tests/testimages/astc_ldr_4x4_FlightHelmet_baseColor.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:629a68c1afe5603f176e20489b2b3a2988a5cca15172e940ae5cf7ee21d8dc52
+size 4194592

--- a/tests/testimages/astc_ldr_6x5_FlightHelmet_baseColor.ktx2
+++ b/tests/testimages/astc_ldr_6x5_FlightHelmet_baseColor.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:188fd989424f776b0401e66b8572ea41afc39013f734b1d1931aaf69577766ba
+size 2243808

--- a/tests/testimages/astc_ldr_8x6_FlightHelmet_baseColor.ktx2
+++ b/tests/testimages/astc_ldr_8x6_FlightHelmet_baseColor.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c5b043ec2b8aeaa047b535be24518919845ed99e81183ade075e180776a97fa
+size 1401120

--- a/tests/testimages/astc_ldr_8x8_FlightHelmet_baseColor.ktx2
+++ b/tests/testimages/astc_ldr_8x8_FlightHelmet_baseColor.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21c1694eb28ea0bcbfb158b72fec487b9a6639b209888f33f65d4798d8bfb00a
+size 1048864

--- a/tests/testimages/astc_ldr_cubemap_6x6.ktx2
+++ b/tests/testimages/astc_ldr_cubemap_6x6.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0955287ff4de3620bb89605a1bd37a3b1186e9e2a34a91ed0bc96cea2516012
+size 11228832

--- a/tests/testimages/astc_mipmap_ldr_10x5_posx.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_10x5_posx.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa5a7f4069a8830c27b34a8059b93bd8684caa4243b6266a9fc8a5e0010b53c7
+size 1798048

--- a/tests/testimages/astc_mipmap_ldr_12x10_posx.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_12x10_posx.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffde011b8902f241611489713dffd58ea6ea8080660007f9160706945d22c1de
+size 751376

--- a/tests/testimages/astc_mipmap_ldr_12x12_posx.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_12x12_posx.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ac14549de4b9fc84a31b47d135023f0b53d586a221a5f81ddb0406997672fcb
+size 626864

--- a/tests/testimages/astc_mipmap_ldr_4x4_posx.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_4x4_posx.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83ad258f62bf929b0b9bc36d3e19d39638b5e709ef0772bf5e08b00792b3b9e7
+size 5592976

--- a/tests/testimages/astc_mipmap_ldr_6x5_posx.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x5_posx.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c97ed3cedd7db7f9a5e4e8a359dbce73b14d7bf0b3d67ccd92c022ae13382a14
+size 2994864

--- a/tests/testimages/astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aec2055a2bf167045511dd41cbed3008c1c452cd33b1bb6607ffd3960ac89085
-size 235840

--- a/tests/testimages/astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aec2055a2bf167045511dd41cbed3008c1c452cd33b1bb6607ffd3960ac89085
+size 235840

--- a/tests/testimages/astc_mipmap_ldr_6x6_kodim17_fast.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x6_kodim17_fast.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ea8b1f84c506f823fb7f97ba93673bae8df2c0edd9e085e2bb77ab397f5badf
+size 235840

--- a/tests/testimages/astc_mipmap_ldr_6x6_kodim17_fastest.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x6_kodim17_fastest.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52062819a8565956e227f3afd2d80a1b4179674a8c232ba281d5c4c48c04feb4
+size 235840

--- a/tests/testimages/astc_mipmap_ldr_6x6_kodim17_medium.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x6_kodim17_medium.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c272ed0e856791c23231385acd8af662c99fdb3f26f20877cdeeeb033610445c
+size 235840

--- a/tests/testimages/astc_mipmap_ldr_6x6_kodim17_thorough.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x6_kodim17_thorough.ktx2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0e14d7e92270e6822d3a27564d4d22fe5781384f8cb3b71d6680fc76290a436
-size 235840

--- a/tests/testimages/astc_mipmap_ldr_6x6_kodim17_thorough.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_6x6_kodim17_thorough.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0e14d7e92270e6822d3a27564d4d22fe5781384f8cb3b71d6680fc76290a436
+size 235840

--- a/tests/testimages/astc_mipmap_ldr_8x6_posx.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_8x6_posx.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c35e5a15b1a1844f916fae49dd3132f96b595f980064fe05b2f832f5c3cde079
+size 1869264

--- a/tests/testimages/astc_mipmap_ldr_8x8_posx.ktx2
+++ b/tests/testimages/astc_mipmap_ldr_8x8_posx.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12422ba5cc921c77af6852f9a2b762e858feeca67abe5d3ad4e67fb054653b87
+size 1398688

--- a/tests/testimages/genref
+++ b/tests/testimages/genref
@@ -106,8 +106,6 @@ $toktx --test --encode astc --astc_blk_d 6x6 --genmipmap astc_mipmap_ldr_6x6_pos
 $toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fastest    astc_mipmap_ldr_6x6_kodim17_fastest.ktx2    ../srcimages/kodim17.png
 $toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fast       astc_mipmap_ldr_6x6_kodim17_fast.ktx2       ../srcimages/kodim17.png
 $toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality medium     astc_mipmap_ldr_6x6_kodim17_medium.ktx2     ../srcimages/kodim17.png
-$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality thorough   astc_mipmap_ldr_6x6_kodim17_thorough.ktx2   ../srcimages/kodim17.png
-$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality exhaustive astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2 ../srcimages/kodim17.png
 
 $toktx --test --encode astc --astc_blk_d 4x4    --genmipmap astc_mipmap_ldr_4x4_posx.ktx2   ../srcimages/Yokohama3/posx.jpg
 $toktx --test --encode astc --astc_blk_d 6x5    --genmipmap astc_mipmap_ldr_6x5_posx.ktx2   ../srcimages/Yokohama3/posx.jpg

--- a/tests/testimages/genref
+++ b/tests/testimages/genref
@@ -93,3 +93,34 @@ $toktx --nowarn --t2 --test --input_swizzle 0rr1 --target_type RGBA --uastc -- c
 # ... and additional files for the load tests.
 
 $toktx --lower_left_maps_to_s0t0 rgb-reference-metadata.ktx ../srcimages/rgb.ppm
+
+# generate astc reference images
+
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --cubemap astc_mipmap_ldr_cubemap_6x6.ktx2 ../srcimages/Yokohama3/posx.jpg ../srcimages/Yokohama3/negx.jpg ../srcimages/Yokohama3/posy.jpg ../srcimages/Yokohama3/negy.jpg ../srcimages/Yokohama3/posz.jpg ../srcimages/Yokohama3/negz.jpg
+$toktx --test --encode astc --astc_blk_d 6x6 --cubemap   astc_ldr_cubemap_6x6.ktx2 ../srcimages/Yokohama3/posx.jpg ../srcimages/Yokohama3/negx.jpg ../srcimages/Yokohama3/posy.jpg ../srcimages/Yokohama3/negy.jpg ../srcimages/Yokohama3/posz.jpg ../srcimages/Yokohama3/negz.jpg
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap astc_mipmap_ldr_6x6_posx.ktx2 ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 6x6             astc_ldr_6x6_posx.ktx2        ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap astc_mipmap_ldr_6x6_posz.ktx2 ../srcimages/Yokohama3/posz.jpg
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap astc_mipmap_ldr_6x6_posy.ktx2 ../srcimages/Yokohama3/posy.jpg
+
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fastest    astc_mipmap_ldr_6x6_kodim17_fastest.ktx2    ../srcimages/kodim17.png
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fast       astc_mipmap_ldr_6x6_kodim17_fast.ktx2       ../srcimages/kodim17.png
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality medium     astc_mipmap_ldr_6x6_kodim17_medium.ktx2     ../srcimages/kodim17.png
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality thorough   astc_mipmap_ldr_6x6_kodim17_thorough.ktx2   ../srcimages/kodim17.png
+$toktx --test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality exhaustive astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2 ../srcimages/kodim17.png
+
+$toktx --test --encode astc --astc_blk_d 4x4    --genmipmap astc_mipmap_ldr_4x4_posx.ktx2   ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 6x5    --genmipmap astc_mipmap_ldr_6x5_posx.ktx2   ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 8x6    --genmipmap astc_mipmap_ldr_8x6_posx.ktx2   ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 10x5   --genmipmap astc_mipmap_ldr_10x5_posx.ktx2  ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 8x8    --genmipmap astc_mipmap_ldr_8x8_posx.ktx2   ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 12x10  --genmipmap astc_mipmap_ldr_12x10_posx.ktx2 ../srcimages/Yokohama3/posx.jpg
+$toktx --test --encode astc --astc_blk_d 12x12  --genmipmap astc_mipmap_ldr_12x12_posx.ktx2 ../srcimages/Yokohama3/posx.jpg
+
+$toktx --test --encode astc --astc_blk_d 4x4    astc_ldr_4x4_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png
+$toktx --test --encode astc --astc_blk_d 6x5    astc_ldr_6x5_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png
+$toktx --test --encode astc --astc_blk_d 8x6    astc_ldr_8x6_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png
+$toktx --test --encode astc --astc_blk_d 10x5   astc_ldr_10x5_FlightHelmet_baseColor.ktx2  ../srcimages/FlightHelmet_baseColor.png
+$toktx --test --encode astc --astc_blk_d 8x8    astc_ldr_8x8_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png
+$toktx --test --encode astc --astc_blk_d 12x10  astc_ldr_12x10_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png
+$toktx --test --encode astc --astc_blk_d 12x12  astc_ldr_12x12_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png

--- a/tests/toktx-tests.cmake
+++ b/tests/toktx-tests.cmake
@@ -180,8 +180,6 @@ gencmpktx( astc_mipmap_ldr_6x6_posy astc_mipmap_ldr_6x6_posy.ktx2 ../srcimages/Y
 gencmpktx( astc_mipmap_ldr_6x6_kodim17_fastest    astc_mipmap_ldr_6x6_kodim17_fastest.ktx2    ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fastest   " "" "" )
 gencmpktx( astc_mipmap_ldr_6x6_kodim17_fast       astc_mipmap_ldr_6x6_kodim17_fast.ktx2       ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fast      " "" "" )
 gencmpktx( astc_mipmap_ldr_6x6_kodim17_medium     astc_mipmap_ldr_6x6_kodim17_medium.ktx2     ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality medium    " "" "" )
-gencmpktx( astc_mipmap_ldr_6x6_kodim17_thorough   astc_mipmap_ldr_6x6_kodim17_thorough.ktx2   ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality thorough  " "" "" )
-gencmpktx( astc_mipmap_ldr_6x6_kodim17_exhaustive astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2 ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality exhaustive" "" "" )
 
 gencmpktx( astc_mipmap_ldr_4x4_posx     astc_mipmap_ldr_4x4_posx.ktx2   ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 4x4   --genmipmap" "" "" )
 gencmpktx( astc_mipmap_ldr_6x5_posx     astc_mipmap_ldr_6x5_posx.ktx2   ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 6x5   --genmipmap" "" "" )

--- a/tests/toktx-tests.cmake
+++ b/tests/toktx-tests.cmake
@@ -170,7 +170,31 @@ PROPERTIES
 )
 
 gencmpktx( astc_mipmap_ldr_cubemap_6x6 astc_mipmap_ldr_cubemap_6x6.ktx2 "../srcimages/Yokohama3/posx.jpg ../srcimages/Yokohama3/negx.jpg ../srcimages/Yokohama3/posy.jpg ../srcimages/Yokohama3/negy.jpg ../srcimages/Yokohama3/posz.jpg ../srcimages/Yokohama3/negz.jpg" "--test --encode astc --astc_blk_d 6x6 --genmipmap --cubemap" "" "" )
+gencmpktx( astc_ldr_cubemap_6x6 astc_ldr_cubemap_6x6.ktx2 "../srcimages/Yokohama3/posx.jpg ../srcimages/Yokohama3/negx.jpg ../srcimages/Yokohama3/posy.jpg ../srcimages/Yokohama3/negy.jpg ../srcimages/Yokohama3/posz.jpg ../srcimages/Yokohama3/negz.jpg" "--test --encode astc --astc_blk_d 6x6 --cubemap" "" "" )
+
 gencmpktx( astc_mipmap_ldr_6x6_posx astc_mipmap_ldr_6x6_posx.ktx2 ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 6x6 --genmipmap" "" "" )
 gencmpktx( astc_ldr_6x6_posx               astc_ldr_6x6_posx.ktx2 ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 6x6" "" "" )
 gencmpktx( astc_mipmap_ldr_6x6_posz astc_mipmap_ldr_6x6_posz.ktx2 ../srcimages/Yokohama3/posz.jpg "--test --encode astc --astc_blk_d 6x6 --genmipmap" "" "" )
 gencmpktx( astc_mipmap_ldr_6x6_posy astc_mipmap_ldr_6x6_posy.ktx2 ../srcimages/Yokohama3/posy.jpg "--test --encode astc --astc_blk_d 6x6 --genmipmap" "" "" )
+
+gencmpktx( astc_mipmap_ldr_6x6_kodim17_fastest    astc_mipmap_ldr_6x6_kodim17_fastest.ktx2    ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fastest   " "" "" )
+gencmpktx( astc_mipmap_ldr_6x6_kodim17_fast       astc_mipmap_ldr_6x6_kodim17_fast.ktx2       ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality fast      " "" "" )
+gencmpktx( astc_mipmap_ldr_6x6_kodim17_medium     astc_mipmap_ldr_6x6_kodim17_medium.ktx2     ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality medium    " "" "" )
+gencmpktx( astc_mipmap_ldr_6x6_kodim17_thorough   astc_mipmap_ldr_6x6_kodim17_thorough.ktx2   ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality thorough  " "" "" )
+gencmpktx( astc_mipmap_ldr_6x6_kodim17_exhaustive astc_mipmap_ldr_6x6_kodim17_exhaustive.ktx2 ../srcimages/kodim17.png "--test --encode astc --astc_blk_d 6x6 --genmipmap --astc_quality exhaustive" "" "" )
+
+gencmpktx( astc_mipmap_ldr_4x4_posx     astc_mipmap_ldr_4x4_posx.ktx2   ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 4x4   --genmipmap" "" "" )
+gencmpktx( astc_mipmap_ldr_6x5_posx     astc_mipmap_ldr_6x5_posx.ktx2   ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 6x5   --genmipmap" "" "" )
+gencmpktx( astc_mipmap_ldr_8x6_posx     astc_mipmap_ldr_8x6_posx.ktx2   ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 8x6   --genmipmap" "" "" )
+gencmpktx( astc_mipmap_ldr_10x5_posx    astc_mipmap_ldr_10x5_posx.ktx2  ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 10x5  --genmipmap" "" "" )
+gencmpktx( astc_mipmap_ldr_8x8_posx     astc_mipmap_ldr_8x8_posx.ktx2   ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 8x8   --genmipmap" "" "" )
+gencmpktx( astc_mipmap_ldr_12x10_posx   astc_mipmap_ldr_12x10_posx.ktx2 ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 12x10 --genmipmap" "" "" )
+gencmpktx( astc_mipmap_ldr_12x12_posx   astc_mipmap_ldr_12x12_posx.ktx2 ../srcimages/Yokohama3/posx.jpg "--test --encode astc --astc_blk_d 12x12 --genmipmap" "" "" )
+
+gencmpktx( astc_ldr_4x4_FlightHelmet_baseColor    astc_ldr_4x4_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 4x4" "" "")
+gencmpktx( astc_ldr_6x5_FlightHelmet_baseColor    astc_ldr_6x5_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 6x5" "" "")
+gencmpktx( astc_ldr_8x6_FlightHelmet_baseColor    astc_ldr_8x6_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 8x6" "" "")
+gencmpktx( astc_ldr_10x5_FlightHelmet_baseColor   astc_ldr_10x5_FlightHelmet_baseColor.ktx2  ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 10x5" "" "")
+gencmpktx( astc_ldr_8x8_FlightHelmet_baseColor    astc_ldr_8x8_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 8x8" "" "")
+gencmpktx( astc_ldr_12x10_FlightHelmet_baseColor  astc_ldr_12x10_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 12x10" "" "")
+gencmpktx( astc_ldr_12x12_FlightHelmet_baseColor  astc_ldr_12x12_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 12x12" "" "")

--- a/tools/toktx/toktx.cc
+++ b/tools/toktx/toktx.cc
@@ -1316,7 +1316,7 @@ toktxApp::main(int argc, _TCHAR *argv[])
             astcopts.threadCount = options.threadCount;
             astcopts.normalMap = options.normalMode;
 
-            ret = ktxTexture_CompressAstcEx(texture, &astcopts);
+            ret = ktxTexture2_CompressAstcEx((ktxTexture2*)texture, &astcopts);
             if (KTX_SUCCESS != ret) {
                 fprintf(stderr, "%s failed to compress KTX file \"%s\" to astc; KTX error: %s\n",
                         name.c_str(), options.outfile.c_str(),


### PR DESCRIPTION
Add more astc tests and reference image generation script. This PR also removes a FIXME for supporting ktx1 in the future. I have now removed that and enforced the astc support to ktx2 only.