### PR TITLE
Support array and 3d textures.

### DIFF
--- a/lib/writer2.c
+++ b/lib/writer2.c
@@ -126,6 +126,7 @@ ktxTexture2_setImageFromStream(ktxTexture2* This, ktx_uint32_t level,
 {
     ktx_size_t imageByteLength;
     ktx_size_t imageByteOffset;
+    ktx_error_code_e result;
 
     if (!This || !src)
         return KTX_INVALID_VALUE;
@@ -133,8 +134,12 @@ ktxTexture2_setImageFromStream(ktxTexture2* This, ktx_uint32_t level,
     if (!This->pData)
         return KTX_INVALID_OPERATION;
 
-    ktxTexture_GetImageOffset(ktxTexture(This), level, layer, faceSlice,
-                                         &imageByteOffset);
+    result = ktxTexture_GetImageOffset(ktxTexture(This),
+                                       level, layer, faceSlice,
+                                       &imageByteOffset);
+    if (result != KTX_SUCCESS)
+       return result;
+
     imageByteLength = ktxTexture_GetImageSize(ktxTexture(This), level);
 
     if (srcSize != imageByteLength)

--- a/tests/srcimages/blue16.png
+++ b/tests/srcimages/blue16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e22025642f84649132c1889e976c6541ec811e2dccfa674b6972d18b71ad1d9d
+size 281

--- a/tests/srcimages/green16.png
+++ b/tests/srcimages/green16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:652ffe431550a0c5dd1c22ce0a7f15f5f31c45df9b3b8d76ed1a0784d2e5180f
+size 281

--- a/tests/srcimages/indigo16.png
+++ b/tests/srcimages/indigo16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95824e61a3386244880356b7f8a170eb7529e05663321f0d9ca5a688cc1e2502
+size 281

--- a/tests/srcimages/orange16.png
+++ b/tests/srcimages/orange16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b946f0e4cbf677352a4c1e1e5895cd98ddbbb8c61a4873351cd944e70d64425
+size 281

--- a/tests/srcimages/red16.png
+++ b/tests/srcimages/red16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:062d79eb926321a7055208eef53de8948c6689b5cd416f15517562da68d50910
+size 281

--- a/tests/srcimages/violet16.png
+++ b/tests/srcimages/violet16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5ed32f3763354d0d73cc0db46fba93538070649a09df7faa04832a12d749f5a
+size 281

--- a/tests/srcimages/yellow16.png
+++ b/tests/srcimages/yellow16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f533219662019d0827e04255887888f408eaaa6278d0df8e6e1a87b44d9045b5
+size 281

--- a/tests/testimages/3dtex_7_reference_u.ktx2
+++ b/tests/testimages/3dtex_7_reference_u.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cb8af8982268c0f7ce089970d689f483a8faf4cfae6792d18c7ec22e61caf2b
+size 7452

--- a/tests/testimages/arraytex_7_mipmap_reference_u.ktx2
+++ b/tests/testimages/arraytex_7_mipmap_reference_u.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3db8173ae9869cf28cfe1d979a0d222bbccf5686145253553f4ea195d794fa2c
+size 9928

--- a/tests/testimages/arraytex_7_reference_u.ktx2
+++ b/tests/testimages/arraytex_7_reference_u.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f029d85a3e29a4a9cb36e584a8a96153bf5649561206601c68f78d43c4e988c
+size 7452

--- a/tests/testimages/genref
+++ b/tests/testimages/genref
@@ -122,3 +122,7 @@ $toktx --test --encode astc --astc_blk_d 10x5   astc_ldr_10x5_FlightHelmet_baseC
 $toktx --test --encode astc --astc_blk_d 8x8    astc_ldr_8x8_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png
 $toktx --test --encode astc --astc_blk_d 12x10  astc_ldr_12x10_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png
 $toktx --test --encode astc --astc_blk_d 12x12  astc_ldr_12x12_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png
+
+$toktx --test --layers 7 --t2 arraytex_7_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
+$toktx --test --depth 7 --t2 3dtex_7_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
+$toktx --test --layers 7 --genmipmap --t2 arraytex_7_mipmap_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png

--- a/tests/toktx-tests.cmake
+++ b/tests/toktx-tests.cmake
@@ -83,6 +83,14 @@ add_test( NAME toktx-different-colortype-second-file-warning
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
+add_test( NAME toktx-depth-layers
+    COMMAND toktx --depth 4 --layers 4 a b c d e
+)
+
+add_test( NAME toktx-depth-genmipmap
+    COMMAND toktx --test --depth 7 --genmipmap --t2 3dtex_7_mipmap_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
+)
+
 set_tests_properties(
     toktx-test-foobar
     toktx-automipmap-mipmaps
@@ -98,6 +106,8 @@ set_tests_properties(
     toktx-invalid-swizzle-char
     toktx-invalid-target-type
     toktx-different-colortype-second-file-error
+    toktx-depth-layers
+    toktx-depth-genmipmap
 PROPERTIES
     WILL_FAIL TRUE
 )
@@ -228,3 +238,6 @@ gencmpktx( astc_ldr_10x5_FlightHelmet_baseColor   astc_ldr_10x5_FlightHelmet_bas
 gencmpktx( astc_ldr_8x8_FlightHelmet_baseColor    astc_ldr_8x8_FlightHelmet_baseColor.ktx2   ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 8x8" "" "")
 gencmpktx( astc_ldr_12x10_FlightHelmet_baseColor  astc_ldr_12x10_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 12x10" "" "")
 gencmpktx( astc_ldr_12x12_FlightHelmet_baseColor  astc_ldr_12x12_FlightHelmet_baseColor.ktx2 ../srcimages/FlightHelmet_baseColor.png "--test --encode astc --astc_blk_d 12x12" "" "")
+gencmpktx( 3dtex_7_reference_u 3dtex_7_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png "--test --t2 --depth 7" "" "")
+gencmpktx( arraytex_7_reference_u arraytex_7_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png "--test --t2 --layers 7" "" "")
+gencmpktx( arraytex_7_mipmap_reference_u arraytex_7_mipmap_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png "--test --t2 --layers 7 --genmipmap" "" "")

--- a/tools/toktx/toktx.cc
+++ b/tools/toktx/toktx.cc
@@ -717,9 +717,8 @@ toktxApp::main(int argc, _TCHAR *argv[])
     else
       createInfo.numFaces = 1;
 
-    // TO DO: handle array textures
     createInfo.numLayers = options.layers;
-    createInfo.isArray = KTX_FALSE;
+    createInfo.isArray = options.layers > 1;
 
     // TO DO: handle 3D textures.
 
@@ -1172,6 +1171,7 @@ toktxApp::main(int argc, _TCHAR *argv[])
                 level = 0;
                 levelWidth = createInfo.baseWidth;
                 levelHeight = createInfo.baseHeight;
+                levelDepth = createInfo.baseDepth;
                 if (faceSlice == (options.cubemap ? 6 : levelDepth)) {
                     faceSlice = 0;
                     layer++;

--- a/tools/toktx/toktx.cc
+++ b/tools/toktx/toktx.cc
@@ -1089,7 +1089,7 @@ toktxApp::main(int argc, _TCHAR *argv[])
             createInfo.baseHeight = levelHeight = image->getHeight();
             createInfo.baseDepth = levelDepth = options.depth;
             if (options.depth > 1) {
-                // In this con't care about image->getHeight(). Images are
+                // In this case, don't care about image->getHeight(). Images are
                 // always considered to be 2d. No need to set options.two_d.
                 createInfo.numDimensions = 3;
             } else if (image->getHeight() == 1 && !options.two_d)


### PR DESCRIPTION
Based on PR #461 by @tuket. Fixes #454.

* Fixes array & 3d texture creation.
* Disables mipmap generation for 3d textures as they need completely different resampling code.
* Adds tests.
* Fixes ktxTexture2_SetImageFromStream's failure to check the return value of  ktxTexture_GetImageOffset.

