### PR TITLE
Prioritize release tag when generating versions. Fixes #467

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -136,7 +136,7 @@ build_script:
 #    cat ../tools/toktx/version.h
 #    echo "****** toktx version ******"
 #    # Because toktx prints version to stderr.
-#    $ErrorActionPreference = 'Continue'
+#    $ErrorActionPreference = 'SilentlyContinue'
 #    & $env:CONFIGURATION/toktx --version
 #    $ErrorActionPreference = 'Stop'
 #    echo "***************************"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -135,7 +135,10 @@ build_script:
     pwd
     cat ../tools/toktx/version.h
     echo "****** toktx version ******"
+    # Because toktx prints version to stderr.
+    $ErrorActionPreference = 'Continue'
     & $env:CONFIGURATION/toktx --version
+    $ErrorActionPreference = 'Stop'
     echo "***************************"
 
     popd

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -131,15 +131,15 @@ build_script:
     cmake --build . --config $env:CONFIGURATION
     cmake --build . --config $env:CONFIGURATION --target PACKAGE
 
-    echo "***** toktx version.h *****"
-    pwd
-    cat ../tools/toktx/version.h
-    echo "****** toktx version ******"
-    # Because toktx prints version to stderr.
-    $ErrorActionPreference = 'Continue'
-    & $env:CONFIGURATION/toktx --version
-    $ErrorActionPreference = 'Stop'
-    echo "***************************"
+#    echo "***** toktx version.h *****"
+#    pwd
+#    cat ../tools/toktx/version.h
+#    echo "****** toktx version ******"
+#    # Because toktx prints version to stderr.
+#    $ErrorActionPreference = 'Continue'
+#    & $env:CONFIGURATION/toktx --version
+#    $ErrorActionPreference = 'Stop'
+#    echo "***************************"
 
     popd
     $env:KTX_BUILD_DIR_NOSSE = "$env:BUILD_DIR\nosse"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -130,6 +130,14 @@ build_script:
     pushd $env:KTX_BUILD_DIR
     cmake --build . --config $env:CONFIGURATION
     cmake --build . --config $env:CONFIGURATION --target PACKAGE
+
+    echo "***** toktx version.h *****"
+    pwd
+    cat ../tools/toktx/version.h
+    echo "****** toktx version ******"
+    Release/toktx --version
+    echo "***************************"
+
     popd
     $env:KTX_BUILD_DIR_NOSSE = "$env:BUILD_DIR\nosse"
     echo "Build without SSE support via $env:CMAKE_GEN Arch:$env:PLATFORM dir:$env:KTX_BUILD_DIR_NOSSE"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -131,15 +131,15 @@ build_script:
     cmake --build . --config $env:CONFIGURATION
     cmake --build . --config $env:CONFIGURATION --target PACKAGE
 
-#    echo "***** toktx version.h *****"
-#    pwd
-#    cat ../tools/toktx/version.h
-#    echo "****** toktx version ******"
-#    # Because toktx prints version to stderr.
-#    $ErrorActionPreference = 'SilentlyContinue'
-#    & $env:CONFIGURATION/toktx --version
-#    $ErrorActionPreference = 'Stop'
-#    echo "***************************"
+    #echo "***** toktx version.h *****"
+    #pwd
+    #cat ../tools/toktx/version.h
+    #echo "****** toktx version ******"
+    ## Because toktx prints version to stderr.
+    #$ErrorActionPreference = 'SilentlyContinue'
+    #& $env:CONFIGURATION/toktx --version
+    #$ErrorActionPreference = 'Stop'
+    #echo "***************************"
 
     popd
     $env:KTX_BUILD_DIR_NOSSE = "$env:BUILD_DIR\nosse"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -135,7 +135,7 @@ build_script:
     pwd
     cat ../tools/toktx/version.h
     echo "****** toktx version ******"
-    Release/toktx --version
+    & $env:CONFIGURATION/toktx --version
     echo "***************************"
 
     popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ before_install:
 - |
   case "${TRAVIS_OS_NAME:-linux}" in
   linux)
+    sudo apt-get update
     docker run -dit --name emscripten -v $(pwd):/src emscripten/emsdk bash
     ;;
   esac

--- a/ci_scripts/build_linux.sh
+++ b/ci_scripts/build_linux.sh
@@ -42,13 +42,6 @@ cpack -G RPM
 cpack -G TBZ2
 popd
 
-echo "***** toktx version.h *****"
-cat tools/toktx/version.h
-echo "****** toktx version ******"
-build/linux-release/tools/toktx/toktx --version
-echo "***************************"
-
-
 echo "Configure KTX-Software (Linux Debug without SSE support)"
 ${CMAKE_EXE} . -G Ninja -B$nosse_debug_build_dir -DCMAKE_BUILD_TYPE=Debug -DBASISU_SUPPORT_SSE=OFF
 pushd $nosse_debug_build_dir

--- a/ci_scripts/build_linux.sh
+++ b/ci_scripts/build_linux.sh
@@ -42,8 +42,12 @@ cpack -G RPM
 cpack -G TBZ2
 popd
 
-echo "***** libktx version.h *****"
-cat lib/version.h
+echo "***** toktx version.h *****"
+cat tools/toktx/version.h
+echo "****** toktx version ******"
+build/linux-release/tools/toktx/toktx --version
+echo "***************************"
+
 
 echo "Configure KTX-Software (Linux Debug without SSE support)"
 ${CMAKE_EXE} . -G Ninja -B$nosse_debug_build_dir -DCMAKE_BUILD_TYPE=Debug -DBASISU_SUPPORT_SSE=OFF

--- a/ci_scripts/build_linux.sh
+++ b/ci_scripts/build_linux.sh
@@ -42,11 +42,11 @@ cpack -G RPM
 cpack -G TBZ2
 popd
 
-echo "***** toktx version.h *****"
-cat tools/toktx/version.h
-echo "****** toktx version ******"
-build/linux-release/tools/toktx/toktx --version
-echo "***************************"
+#echo "***** toktx version.h *****"
+#cat tools/toktx/version.h
+#echo "****** toktx version ******"
+#build/linux-release/tools/toktx/toktx --version
+#echo "***************************"
 
 
 echo "Configure KTX-Software (Linux Debug without SSE support)"

--- a/ci_scripts/build_linux.sh
+++ b/ci_scripts/build_linux.sh
@@ -42,6 +42,13 @@ cpack -G RPM
 cpack -G TBZ2
 popd
 
+echo "***** toktx version.h *****"
+cat tools/toktx/version.h
+echo "****** toktx version ******"
+build/linux-release/tools/toktx/toktx --version
+echo "***************************"
+
+
 echo "Configure KTX-Software (Linux Debug without SSE support)"
 ${CMAKE_EXE} . -G Ninja -B$nosse_debug_build_dir -DCMAKE_BUILD_TYPE=Debug -DBASISU_SUPPORT_SSE=OFF
 pushd $nosse_debug_build_dir

--- a/ci_scripts/build_linux.sh
+++ b/ci_scripts/build_linux.sh
@@ -42,6 +42,9 @@ cpack -G RPM
 cpack -G TBZ2
 popd
 
+echo "***** libktx version.h *****"
+cat lib/version.h
+
 echo "Configure KTX-Software (Linux Debug without SSE support)"
 ${CMAKE_EXE} . -G Ninja -B$nosse_debug_build_dir -DCMAKE_BUILD_TYPE=Debug -DBASISU_SUPPORT_SSE=OFF
 pushd $nosse_debug_build_dir

--- a/ci_scripts/build_macos.sh
+++ b/ci_scripts/build_macos.sh
@@ -95,12 +95,12 @@ if ! cpack -G productbuild; then
   exit 1
 fi
 
-echo "***** toktx version.h *****"
-pwd
-cat ../tools/toktx/version.h
-echo "****** toktx version ******"
-Release/toktx --version
-echo "***************************"
+#echo "***** toktx version.h *****"
+#pwd
+#cat ../tools/toktx/version.h
+#echo "****** toktx version ******"
+#Release/toktx --version
+#echo "***************************"
 
 popd
 

--- a/ci_scripts/build_macos.sh
+++ b/ci_scripts/build_macos.sh
@@ -95,6 +95,13 @@ if ! cpack -G productbuild; then
   exit 1
 fi
 
+echo "***** toktx version.h *****"
+pwd
+cat ../tools/toktx/version.h
+echo "****** toktx version ******"
+Release/toktx --version
+echo "***************************"
+
 popd
 
 pushd build-macos-sse

--- a/mkversion
+++ b/mkversion
@@ -16,7 +16,7 @@ LF='
 
 # Change directory to this script location which must be root of the
 # Git repo.
-#cd $(dirname $0)
+cd $(dirname $0)
 
 function genversion() {
   # Try git-describe, then default.

--- a/mkversion
+++ b/mkversion
@@ -21,12 +21,18 @@ function genversion() {
       # Get version number for HEAD revision of repo.
       VN=$(git describe --match "v[0-9]*" HEAD 2>/dev/null)
     else
-        # Get version number containing the object identified in
-        # $1.
-        VN=$(git describe --contains --match "v[0-9]*" $(git rev-list -1 HEAD $1) 2>/dev/null)
+      # Get release tag containing the object identified in # $1.
+      VN=$(git describe --contains --match "v[0-9]*" --exclude "*-beta*" --exclude "*-rc[0-9]*" $(git rev-list -1 HEAD $1) 2>/dev/null)
       if [ -z "$VN" ]; then
-        # If no containing tag, get version number for $1 based on
-        # previous tag.
+        # No containing release tag. Look for an RC tag.
+        VN=$(git describe --contains --match "v[0-9]*" --exclude "*-beta*" $(git rev-list -1 HEAD $1) 2>/dev/null)
+      fi
+      if [ -z "$VN" ]; then
+        # No containing RC tag. Look for a beta tag.
+        VN=$(git describe --contains --match "v[0-9]*" $(git rev-list -1 HEAD $1) 2>/dev/null)
+      fi
+      if [ -z "$VN" ]; then
+        # No containing tag. Get version number a previous tag.
         VN=$(git describe --match "v[0-9]*" $(git rev-list -1 HEAD $1) 2>/dev/null)
       fi
     fi
@@ -47,6 +53,10 @@ function genversion() {
 function setfile() {
   local VC
   local verstring=$1_VERSION
+  if [ $dry_run -eq 1 ]; then
+      echo $verstring $VN
+      return
+  fi
   if [ -r $2 ]; then
     VC=$(grep $verstring $2 | sed -e "s/^#define $verstring //")
   else
@@ -89,13 +99,14 @@ function writeversion() {
 }
 
 function usage() {
-    echo "Usage: $0 [-a] [-f] [<object>]"
+    echo "Usage: $0 [-a] [-f] [-n] [-o <outfile>] [<object>]"
     exit 1
 }
 
 force=0
+dry_run=0
 write_all=0;
-args=$(getopt afo: $*)
+args=$(getopt afno: $*)
 
 set -- $args
 for i; do
@@ -103,6 +114,8 @@ for i; do
     -a) write_all=1;
         shift;;
     -f) force=1;
+        shift;;
+    -n) dry_run=1;
         shift;;
     -o) VF=$2; shift; shift;;
     --) shift; break;;

--- a/mkversion
+++ b/mkversion
@@ -14,6 +14,10 @@ DEF_VER=v4.0
 LF='
 '
 
+# Change directory to this script location which must be root of the
+# Git repo.
+cd $(dirname $0)
+
 function genversion() {
   # Try git-describe, then default.
   if [ -d ${GIT_DIR:-.git} -o -f .git ]; then

--- a/mkversion
+++ b/mkversion
@@ -16,7 +16,7 @@ LF='
 
 # Change directory to this script location which must be root of the
 # Git repo.
-cd $(dirname $0)
+#cd $(dirname $0)
 
 function genversion() {
   # Try git-describe, then default.


### PR DESCRIPTION
Eliminate confusion caused by generating versions relative to rc or beta tags when there is is a newer release tag but not changes between, e.g., beta and release. Priority for the containing tag used is now release, rc, beta.

Also ensure mkversion runs in repo root for added robustness. Not running in the root during the Linux build is the only reason for the Linux version numbers reported in #467 but whatever caused `mkversion` to not be run in root appears to have been fixed. It is not possible to reproduce in current master prior to this PR. 