### PR TITLE
fix missing -w flag for ktx2check

### DIFF
--- a/tools/ktx2check/ktx2check.cpp
+++ b/tools/ktx2check/ktx2check.cpp
@@ -773,7 +773,7 @@ ktxValidator::ktxValidator() : ktxApp(myversion, mydefversion, options)
                                 / sizeof(argparser::option);
     option_list.insert(option_list.begin(), my_option_list,
                        my_option_list + lastOptionIndex);
-    short_opts += "qm:";
+    short_opts += "qm:w";
 }
 
 void


### PR DESCRIPTION
`ktx2check --help` lists `-w` as a short option for treating warnings as errors. However, using the `-w` option just shows the usage message.

```
sid:~$ ./ktx2check -w test.ktx2
Usage: ktx2check [options] [<infile> ...]

  infile       The ktx2 file(s) to validate. If infile is not specified, input
               will be read from stdin.

  Options are:

  -q, --quiet  Validate silently. Indicate valid or invalid via exit code.
  -m <num>, --max-issues <num>
               Set the maximum number of issues to be reported per file
               provided -q is not set.
  -w, --warn-as-error
               Treat warnings as errors. Changes error code from success
               to error
  --help       Print this usage message and exit.
  --version    Print the version number of this program and exit.
```