### PR TITLE
Use more portable shebangs.

### DIFF
--- a/mkrelnotes
+++ b/mkrelnotes
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Copyright 2020, Mark Callow
 # SPDX-License-Identifier: Apache-2.0

--- a/mkversion
+++ b/mkversion
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2020, Mark Callow
 # SPDX-License-Identifier: Apache-2.0

--- a/mkversion
+++ b/mkversion
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env bash
 
 # Copyright 2020, Mark Callow
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
mkrelnotes requires bash so #! /usr/bin/env bash. mkversion can use #! /bin/sh.

Fixes #500.