### PR TITLE
Add astc perceptual mode support

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -1207,7 +1207,7 @@ typedef struct ktxAstcParams {
          */
 
     ktx_bool_t perceptual;
-        /*!< The codec should optimize perceptual error, instead of direct
+        /*!< The codec should optimize for perceptual error, instead of direct
            RMS error. This aims to improves perceived image quality, but
            typically lowers the measured PSNR score. Perceptual methods are
            currently only available for normal maps and RGB color data.

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -1175,33 +1175,48 @@ typedef struct ktxAstcParams {
         /*!< Size of this struct. Used so library can tell which version
              of struct is being passed.
          */
+
     ktx_bool_t verbose;
         /*!< If true, prints Astc encoder operation details to
              @c stdout. Not recommended for GUI apps.
          */
+
     ktx_uint32_t threadCount;
-        /*!< Number of threads used for compression. Default is 1. */
+        /*!< Number of threads used for compression. Default is 1.
+         */
 
     /* astcenc params */
     ktx_uint32_t blockDimension;
         /*!< Combinations of block dimensions that astcenc supports
-          i.e. 6x6, 8x8, 6x5 etc*/
+          i.e. 6x6, 8x8, 6x5 etc
+         */
 
     ktx_uint32_t mode;
-        /*!< Can be {ldr/hdr} from astcenc*/
+        /*!< Can be {ldr/hdr} from astcenc
+         */
 
     ktx_uint32_t qualityLevel;
-        /*!< astcenc supports -fastest, -fast, -medium, -thorough, -exhaustive*/
+        /*!< astcenc supports -fastest, -fast, -medium, -thorough, -exhaustive
+         */
 
     ktx_bool_t normalMap;
         /*!< Tunes codec parameters for better quality on normal maps
           In this mode normals are compressed to X,Y components
           Discarding Z component, reader will need to generate Z
           component in shaders.
-        */
+         */
+
+    ktx_bool_t perceptual;
+        /*!< The codec should optimize perceptual error, instead of direct
+           RMS error. This aims to improves perceived image quality, but
+           typically lowers the measured PSNR score. Perceptual methods are
+           currently only available for normal maps and RGB color data.
+         */
+
     char inputSwizzle[4];
          /*!< A swizzle to provide as input to astcenc. It must match the regular
-             expression /^[rgba01]{4}$/.*/
+             expression /^[rgba01]{4}$/.
+          */
 } ktxAstcParams;
 
 KTX_API KTX_error_code KTX_APIENTRY
@@ -1338,28 +1353,35 @@ typedef struct ktxBasisParams {
                 KTX_PACK_UASTC_LEVEL_VERYSLOW | 48.24dB
          */
     ktx_bool_t uastcRDO;
-        /*!< Enable Rate Distortion Optimization (RDO) post-processing. */
+        /*!< Enable Rate Distortion Optimization (RDO) post-processing.
+         */
     float uastcRDOQualityScalar;
         /*!< UASTC RDO quality scalar (lambda). Lower values yield higher
              quality/larger LZ compressed files, higher values yield lower
              quality/smaller LZ compressed files. A good range to try is [.2,4].
-             Full range is [.001,50.0]. Default is 1.0. */
+             Full range is [.001,50.0]. Default is 1.0.
+         */
     ktx_uint32_t uastcRDODictSize;
         /*!< UASTC RDO dictionary size in bytes. Default is 4096. Lower
-             values=faster, but give less compression. Range is [64,65536]. */
+             values=faster, but give less compression. Range is [64,65536].
+         */
     float uastcRDOMaxSmoothBlockErrorScale;
         /*!< UASTC RDO max smooth block error scale. Range is [1,300].
              Default is 10.0, 1.0 is disabled. Larger values suppress more
-             artifacts (and allocate more bits) on smooth blocks. */
+             artifacts (and allocate more bits) on smooth blocks.
+         */
     float uastcRDOMaxSmoothBlockStdDev;
         /*!< UASTC RDO max smooth block standard deviation. Range is
              [.01,65536.0]. Default is 18.0. Larger values expand the range of
-             blocks considered smooth. */
+             blocks considered smooth.
+         */
     ktx_bool_t uastcRDODontFavorSimplerModes;
-        /*!< Do not favor simpler UASTC modes in RDO mode. */
+        /*!< Do not favor simpler UASTC modes in RDO mode.
+         */
     ktx_bool_t uastcRDONoMultithreading;
         /*!< Disable RDO multithreading (slightly higher compression,
-             deterministic). */
+             deterministic).
+         */
 
 } ktxBasisParams;
 

--- a/lib/astc_encode.cpp
+++ b/lib/astc_encode.cpp
@@ -618,6 +618,9 @@ ktxTexture2_CompressAstcEx(ktxTexture2* This, ktxAstcParams* params) {
     profile = astcEncoderAction(*params, BDB);
     swizzle = astcSwizzle(*params);
 
+    if(params->perceptual)
+        flags |= ASTCENC_FLG_USE_PERCEPTUAL;
+
     astcenc_config   astc_config;
     astcenc_context *astc_context;
     astcenc_error astc_error = astcenc_config_init(profile,

--- a/utils/scapp.h
+++ b/utils/scapp.h
@@ -193,6 +193,11 @@ astcEncoderMode(const char* mode) {
                      <tr><td>exhaustive </td> <td>(equivalent to quality = 100) </td></tr>
                  </table>
                  </dd>
+        <dt>--astc_perceptual</dt>
+                 <dd>The codec should optimize for perceptual error, instead of direct
+                 RMS error. This aims to improve perceived image quality, but
+                 typically lowers the measured PSNR score. Perceptual methods are
+                 currently only available for normal maps and RGB color data.</dd>
       </dl>
       <dl>
       <dt>etc1s:</dt>
@@ -542,6 +547,11 @@ class scApp : public ktxApp {
           "                   medium     | (equivalent to quality =  60)\n"
           "                   thorough   | (equivalent to quality =  98)\n"
           "                   exhaustive | (equivalent to quality = 100)\n"
+          "      --astc_perceptual\n"
+          "               The codec should optimize for perceptual error, instead of direct\n"
+          "               RMS error. This aims to improve perceived image quality, but\n"
+          "               typically lowers the measured PSNR score. Perceptual methods are\n"
+          "               currently only available for normal maps and RGB color data.\n"
           "    etc1s:\n"
           "               Supercompress the image data with ETC1S / BasisLZ.\n"
           "               RED images will become RGB with RED in each component. RG images\n"
@@ -732,11 +742,12 @@ scApp::scApp(string& version, string& defaultVersion,
       { "astc_blk_d", argparser::option::required_argument, NULL, 1012 },
       { "astc_mode", argparser::option::required_argument, NULL, 1013 },
       { "astc_quality", argparser::option::required_argument, NULL, 1014 },
-      { "encode", argparser::option::required_argument, NULL, 1015 },
-      { "normalize", argparser::option::no_argument, NULL, 1016 },
+      { "astc_perceptual", argparser::option::no_argument, NULL, 1015 },
+      { "encode", argparser::option::required_argument, NULL, 1016 },
+      { "normalize", argparser::option::no_argument, NULL, 1017 },
       // Deprecated options
       { "bcmp", argparser::option::no_argument, NULL, 'b' },
-      { "uastc", argparser::option::optional_argument, NULL, 1017 }
+      { "uastc", argparser::option::optional_argument, NULL, 1018 }
   };
   const int lastOptionIndex = sizeof(my_option_list)
                               / sizeof(argparser::option);
@@ -918,14 +929,17 @@ scApp::processOption(argparser& parser, int opt)
         options.ktx2 = 1;
         break;
       case 1015:
+        options.astcopts.perceptual = true;
+        break;
+      case 1016:
         setEncoder(parser.optarg);
         options.ktx2 = 1;
         hasArg = true;
         break;
-      case 1016:
+      case 1017:
         options.normalize = true;
         break;
-      case 1017:
+      case 1018:
         if (options.etc1s) {
              cerr << "Only one of `--encode etc1s | --bcmp` and `--uastc [<level>]` can be specified."
                   << endl;


### PR DESCRIPTION
Adds `--astc_perceptual` command line options which enables ASTCENC_FLG_USE_PERCEPTUAL mode for the astc encoder.