### PR TITLE
Remove image.hpp dependency

### DIFF
--- a/lib/astc_encode.cpp
+++ b/lib/astc_encode.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include <zstd.h>
 #include <KHR/khr_df.h>
 
@@ -32,7 +33,6 @@
 #include "vk_format.h"
 
 #include "astc-encoder/Source/astcenc.h"
-#include "../tools/toktx/image.hpp"
 
 // Provide pthreads support on windows
 #if defined(_WIN32) && !defined(__CYGWIN__)

--- a/tools/toktx/image.hpp
+++ b/tools/toktx/image.hpp
@@ -480,7 +480,10 @@ class ImageT : public Image {
         pixels = (Color*)malloc(bytes);
         if (!pixels)
             throw std::bad_alloc();
-        memset(&pixels, 0, bytes);
+
+        for (uint32_t b = 0; b < w * h; ++b)
+            for(uint32_t c = 0; c < componentCount; ++c)
+                memset(&pixels[b].comps[c], 0, sizeof(componentType));
     }
 
     ImageT(uint32_t w, uint32_t h, Color* pixels) : Image(w, h), pixels(pixels)

--- a/tools/toktx/image.hpp
+++ b/tools/toktx/image.hpp
@@ -480,7 +480,7 @@ class ImageT : public Image {
         pixels = (Color*)malloc(bytes);
         if (!pixels)
             throw std::bad_alloc();
-        memset(pixels, 0, bytes);
+        memset(&pixels, 0, bytes);
     }
 
     ImageT(uint32_t w, uint32_t h, Color* pixels) : Image(w, h), pixels(pixels)


### PR DESCRIPTION
Removes `image.hpp` from `astc_encode.cpp` and adds `vector` which is required.