### PR TITLE
Add proper casts, to enable building with vk 1.3

### DIFF
--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -1289,11 +1289,11 @@ VulkanAppSDL::prepareTextOverlay()
         std::vector<VkPipelineShaderStageCreateInfo> shaderStages;
         VkPipelineShaderStageCreateInfo shaderStage;
         std::string filepath = getAssetPath() + "shaders/textoverlay.vert.spv";
-        shaderStage = vkctx.loadShader(filepath, vk::ShaderStageFlagBits::eVertex);
+        shaderStage = static_cast<VkPipelineShaderStageCreateInfo>(vkctx.loadShader(filepath, vk::ShaderStageFlagBits::eVertex));
         shaderStages.push_back(shaderStage);
         shaderModules.push_back(shaderStage.module);
         filepath = getAssetPath() + "shaders/textoverlay.frag.spv";
-        shaderStage = vkctx.loadShader(filepath, vk::ShaderStageFlagBits::eFragment);
+        shaderStage = static_cast<VkPipelineShaderStageCreateInfo>(vkctx.loadShader(filepath, vk::ShaderStageFlagBits::eFragment));
         shaderStages.push_back(shaderStage);
         shaderModules.push_back(shaderStage.module);
 

--- a/tests/loadtests/vkloadtests/TexturedCube.cpp
+++ b/tests/loadtests/vkloadtests/TexturedCube.cpp
@@ -549,10 +549,10 @@ TexturedCube::preparePipeline()
     //shaderStages[1].pSpecializationInfo = nullptr;
 #else
     std::string filepath = getAssetPath() + "shaders/";
-    shaderStages[0] = loadShader(filepath + "cube.vert.spv",
-                                vk::ShaderStageFlagBits::eVertex);
-    shaderStages[1] = loadShader(filepath + "cube.frag.spv",
-                                vk::ShaderStageFlagBits::eFragment);
+    shaderStages[0] = static_cast<VkPipelineShaderStageCreateInfo>(loadShader(filepath + "cube.vert.spv",
+                                vk::ShaderStageFlagBits::eVertex));
+    shaderStages[1] = static_cast<VkPipelineShaderStageCreateInfo>(loadShader(filepath + "cube.frag.spv",
+                                vk::ShaderStageFlagBits::eFragment));
 
 #endif
 

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
@@ -47,7 +47,7 @@ VulkanLoadTestSample::loadMesh(std::string filename,
 
     mesh->createBuffers(
         vkctx.device,
-        vkctx.memoryProperties,
+        static_cast<VkPhysicalDeviceMemoryProperties>(vkctx.memoryProperties),
         meshBuffer,
         vertexLayout,
         scale,


### PR DESCRIPTION
When attempting to build the vulkan loadtests, I recieved errors that
conversion between to types could not be made. This commit addresses
that.

Here is the error message I got:

```
[1/4] Building CXX object tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/VulkanLoadTestSample.cpp.o
FAILED: tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/VulkanLoadTestSample.cpp.o 
/usr/bin/c++ -DKTX_FEATURE_KTX1 -DKTX_FEATURE_KTX2 -DKTX_FEATURE_WRITE -I/usr/include/SDL2 -I/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL -I/home/rhermes/build/KTX-Software/include -I/home/rhermes/build/KTX-Software/lib/basisu/transcoder -I/home/rhermes/build/KTX-Software/lib/basisu/zstd -I/home/rhermes/build/KTX-Software/other_include -I/home/rhermes/build/KTX-Software/utils -I/home/rhermes/build/KTX-Software/lib/dfdutils -I/home/rhermes/build/KTX-Software/lib/basisu -I/home/rhermes/build/KTX-Software/lib/astc-encoder/Source -I/home/rhermes/build/KTX-Software/lib -I/home/rhermes/build/KTX-Software/tests/loadtests/common -I/home/rhermes/build/KTX-Software/tests/loadtests/geom -I/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL -I/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests -I/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/utils -fvisibility=hidden -Wall -Wextra -O3 -MD -MT tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/VulkanLoadTestSample.cpp.o -MF tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/VulkanLoadTestSample.cpp.o.d -o tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/VulkanLoadTestSample.cpp.o -c /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp: In member function ‘void VulkanLoadTestSample::loadMesh(std::string, vkMeshLoader::MeshBuffer*, std::vector<vkMeshLoader::VertexLayout>, float)’:
/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp:50:15: error: cannot convert ‘vk::PhysicalDeviceMemoryProperties’ to ‘VkPhysicalDeviceMemoryProperties’
   50 |         vkctx.memoryProperties,
      |         ~~~~~~^~~~~~~~~~~~~~~~
      |               |
      |               vk::PhysicalDeviceMemoryProperties
In file included from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/VulkanLoadTestSample.h:18,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp:19:
/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/utils/VulkanMeshLoader.hpp:435:42: note:   initializing argument 2 of ‘void VulkanMeshLoader::createBuffers(VkDevice, VkPhysicalDeviceMemoryProperties, vkMeshLoader::MeshBuffer*, std::vector<vkMeshLoader::VertexLayout>, float, bool, VkCommandBuffer, VkQueue)’
  435 |         VkPhysicalDeviceMemoryProperties deviceMemoryProperties,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
[2/4] Building CXX object tests/loadtests/CMakeFiles/vkloadtests.dir/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp.o
FAILED: tests/loadtests/CMakeFiles/vkloadtests.dir/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp.o 
/usr/bin/c++ -DKTX_FEATURE_KTX1 -DKTX_FEATURE_KTX2 -DKTX_FEATURE_WRITE -I/usr/include/SDL2 -I/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL -I/home/rhermes/build/KTX-Software/include -I/home/rhermes/build/KTX-Software/lib/basisu/transcoder -I/home/rhermes/build/KTX-Software/lib/basisu/zstd -I/home/rhermes/build/KTX-Software/other_include -I/home/rhermes/build/KTX-Software/utils -I/home/rhermes/build/KTX-Software/lib/dfdutils -I/home/rhermes/build/KTX-Software/lib/basisu -I/home/rhermes/build/KTX-Software/lib/astc-encoder/Source -I/home/rhermes/build/KTX-Software/lib -I/home/rhermes/build/KTX-Software/tests/loadtests/common -I/home/rhermes/build/KTX-Software/tests/loadtests/geom -I/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL -I/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests -I/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/utils -fvisibility=hidden -Wall -Wextra -O3 -MD -MT tests/loadtests/CMakeFiles/vkloadtests.dir/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp.o -MF tests/loadtests/CMakeFiles/vkloadtests.dir/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp.o.d -o tests/loadtests/CMakeFiles/vkloadtests.dir/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp.o -c /home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp: In member function ‘void VulkanAppSDL::prepareTextOverlay()’:
/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp:1292:82: error: no match for ‘operator=’ (operand types are ‘VkPipelineShaderStageCreateInfo’ and ‘vk::PipelineShaderStageCreateInfo’)
 1292 |         shaderStage = vkctx.loadShader(filepath, vk::ShaderStageFlagBits::eVertex);
      |                                                                                  ^
In file included from /usr/include/vulkan/vulkan.h:11,
                 from /usr/include/vulkan/vulkan.hpp:41,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h:18,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp:34:
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(const VkPipelineShaderStageCreateInfo&)’
 3220 | typedef struct VkPipelineShaderStageCreateInfo {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘const VkPipelineShaderStageCreateInfo&’
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(VkPipelineShaderStageCreateInfo&&)’
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘VkPipelineShaderStageCreateInfo&&’
/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp:1296:84: error: no match for ‘operator=’ (operand types are ‘VkPipelineShaderStageCreateInfo’ and ‘vk::PipelineShaderStageCreateInfo’)
 1296 |         shaderStage = vkctx.loadShader(filepath, vk::ShaderStageFlagBits::eFragment);
      |                                                                                    ^
In file included from /usr/include/vulkan/vulkan.h:11,
                 from /usr/include/vulkan/vulkan.hpp:41,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h:18,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp:34:
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(const VkPipelineShaderStageCreateInfo&)’
 3220 | typedef struct VkPipelineShaderStageCreateInfo {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘const VkPipelineShaderStageCreateInfo&’
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(VkPipelineShaderStageCreateInfo&&)’
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘VkPipelineShaderStageCreateInfo&&’
[3/4] Building CXX object tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/TexturedCube.cpp.o
FAILED: tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/TexturedCube.cpp.o 
/usr/bin/c++ -DKTX_FEATURE_KTX1 -DKTX_FEATURE_KTX2 -DKTX_FEATURE_WRITE -I/usr/include/SDL2 -I/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL -I/home/rhermes/build/KTX-Software/include -I/home/rhermes/build/KTX-Software/lib/basisu/transcoder -I/home/rhermes/build/KTX-Software/lib/basisu/zstd -I/home/rhermes/build/KTX-Software/other_include -I/home/rhermes/build/KTX-Software/utils -I/home/rhermes/build/KTX-Software/lib/dfdutils -I/home/rhermes/build/KTX-Software/lib/basisu -I/home/rhermes/build/KTX-Software/lib/astc-encoder/Source -I/home/rhermes/build/KTX-Software/lib -I/home/rhermes/build/KTX-Software/tests/loadtests/common -I/home/rhermes/build/KTX-Software/tests/loadtests/geom -I/home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL -I/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests -I/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/utils -fvisibility=hidden -Wall -Wextra -O3 -MD -MT tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/TexturedCube.cpp.o -MF tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/TexturedCube.cpp.o.d -o tests/loadtests/CMakeFiles/vkloadtests.dir/vkloadtests/TexturedCube.cpp.o -c /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.cpp
/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.cpp: In member function ‘void TexturedCube::preparePipeline()’:
/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.cpp:553:65: error: no match for ‘operator=’ (operand types are ‘std::array<VkPipelineShaderStageCreateInfo, 2>::value_type’ {aka ‘VkPipelineShaderStageCreateInfo’} and ‘vk::PipelineShaderStageCreateInfo’)
  553 |                                 vk::ShaderStageFlagBits::eVertex);
      |                                                                 ^
In file included from /usr/include/vulkan/vulkan.h:11,
                 from /usr/include/vulkan/vulkan.hpp:41,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h:18,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/VulkanLoadTestSample.h:14,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.h:14,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.cpp:35:
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(const VkPipelineShaderStageCreateInfo&)’
 3220 | typedef struct VkPipelineShaderStageCreateInfo {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘const VkPipelineShaderStageCreateInfo&’
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(VkPipelineShaderStageCreateInfo&&)’
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘VkPipelineShaderStageCreateInfo&&’
/home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.cpp:555:67: error: no match for ‘operator=’ (operand types are ‘std::array<VkPipelineShaderStageCreateInfo, 2>::value_type’ {aka ‘VkPipelineShaderStageCreateInfo’} and ‘vk::PipelineShaderStageCreateInfo’)
  555 |                                 vk::ShaderStageFlagBits::eFragment);
      |                                                                   ^
In file included from /usr/include/vulkan/vulkan.h:11,
                 from /usr/include/vulkan/vulkan.hpp:41,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h:18,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/VulkanLoadTestSample.h:14,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.h:14,
                 from /home/rhermes/build/KTX-Software/tests/loadtests/vkloadtests/TexturedCube.cpp:35:
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(const VkPipelineShaderStageCreateInfo&)’
 3220 | typedef struct VkPipelineShaderStageCreateInfo {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘const VkPipelineShaderStageCreateInfo&’
/usr/include/vulkan/vulkan_core.h:3220:16: note: candidate: ‘constexpr VkPipelineShaderStageCreateInfo& VkPipelineShaderStageCreateInfo::operator=(VkPipelineShaderStageCreateInfo&&)’
/usr/include/vulkan/vulkan_core.h:3220:16: note:   no known conversion for argument 1 from ‘vk::PipelineShaderStageCreateInfo’ to ‘VkPipelineShaderStageCreateInfo&&’
```