### PR TITLE
Release memory before early exit.

### DIFF
--- a/lib/basis_transcode.cpp
+++ b/lib/basis_transcode.cpp
@@ -319,9 +319,13 @@ ktxTexture2_transcodeUastc(ktxTexture2* This,
              // Load pending. Complete it.
             result = ktxTexture2_LoadImageData(This, NULL, 0);
             if (result != KTX_SUCCESS)
+            {
+                ktxTexture2_Destroy(prototype);
                 return result;
+            }
         } else {
             // No data to transcode.
+            ktxTexture2_Destroy(prototype);
             return KTX_INVALID_OPERATION;
         }
     }


### PR DESCRIPTION
The `prototype` texture is released only before last `return` statement. Probably should be released before all returns.