### PR TITLE
Fix wrong alignment used when checking UASTC files

### DIFF
--- a/tests/ktx2check-tests.cmake
+++ b/tests/ktx2check-tests.cmake
@@ -44,6 +44,16 @@ PROPERTIES
     WILL_FAIL TRUE
 )
 
+add_test( NAME ktx2check-test-fail-when-last-file-valid
+    COMMAND ktx2check ../badktx2/bad_typesize.ktx2 astc_ldr_6x6_arraytex_7.ktx2
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
+)
+set_tests_properties(
+     ktx2check-test-fail-when-last-file-valid
+PROPERTIES
+    WILL_FAIL TRUE
+)
+
 add_test( NAME ktx2check-test-all
     # Invoke via sh workaround, since CMake puts asterisk in quotes
     # otherwise ( "*.ktx2" )

--- a/tools/ktx2check/ktx2check.cpp
+++ b/tools/ktx2check/ktx2check.cpp
@@ -1544,7 +1544,7 @@ ktxValidator::validateDfd(validationContext& ctx)
                                  bytesPlane0, 16);
                     }
                 } else {
-                     if (KHR_DFDVAL(bdb, BYTESPLANE0) != 0) {
+                     if (bytesPlane0 != 0) {
                           addIssue(logger::eError, DFD.NotUnsized, "UASTC");
                      }
                 }


### PR DESCRIPTION
which led to falsely failing UASTC files.

Also fixes incorrect success exit when checking multiple files and last file is valid. This hid the main problem from the test runner.