### PR TITLE
Allow creation of single layer array textures.

### DIFF
--- a/tests/testimages/arraytex_1_reference_u.ktx2
+++ b/tests/testimages/arraytex_1_reference_u.ktx2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dda7bb7fa111e1be29dd114122235126850104787723fb3ce076132abd702ae
+size 1308

--- a/tests/testimages/genref
+++ b/tests/testimages/genref
@@ -120,6 +120,8 @@ $toktx --test --layers 7 --encode astc --astc_blk_d 6x6             astc_ldr_6x6
 $toktx --test --layers 7 --encode astc --astc_blk_d 6x6 --genmipmap astc_ldr_6x6_arraytex_7_mipmap.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
 $toktx --test --depth 7  --encode astc --astc_blk_d 6x6             astc_ldr_6x6_3dtex_7.ktx2           ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
 
+$toktx --test --layers 1 --t2 arraytex_1_reference_u.ktx2 ../srcimages/red16.png
+$toktx --test --depth 7 --t2 3dtex_7_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
 $toktx --test --layers 7 --t2 arraytex_7_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
 $toktx --test --depth 7 --t2 3dtex_7_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
 $toktx --test --layers 7 --genmipmap --t2 arraytex_7_mipmap_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png

--- a/tests/toktx-tests.cmake
+++ b/tests/toktx-tests.cmake
@@ -83,12 +83,20 @@ add_test( NAME toktx-different-colortype-second-file-warning
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
+add_test( NAME toktx-depth-lt-two
+    COMMAND toktx --depth 1 a b
+)
+
 add_test( NAME toktx-depth-layers
     COMMAND toktx --depth 4 --layers 4 a b c d e
 )
 
 add_test( NAME toktx-depth-genmipmap
     COMMAND toktx --test --depth 7 --genmipmap --t2 3dtex_7_mipmap_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
+)
+
+add_test( NAME toktx-layers-lt-one
+    COMMAND toktx --layers 0 a b
 )
 
 set_tests_properties(
@@ -107,7 +115,9 @@ set_tests_properties(
     toktx-invalid-target-type
     toktx-different-colortype-second-file-error
     toktx-depth-layers
+    toktx-depth-lt-two
     toktx-depth-genmipmap
+    toktx-layers-lt-one
 PROPERTIES
     WILL_FAIL TRUE
 )
@@ -250,5 +260,6 @@ gencmpktx( astc_ldr_6x6_arraytex_7_mipmap astc_ldr_6x6_arraytex_7_mipmap.ktx2 ".
 gencmpktx( astc_ldr_6x6_3dtex_7 astc_ldr_6x6_3dtex_7.ktx2 "../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png" "--test --depth 7 --encode astc --astc_blk_d 6x6" "" "")
 
 gencmpktx( 3dtex_7_reference_u 3dtex_7_reference_u.ktx2 "../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png" "--test --t2 --depth 7" "" "")
+gencmpktx( arraytex_1_reference_u arraytex_1_reference_u.ktx2 "../srcimages/red16.png" "--test --t2 --layers 1" "" "")
 gencmpktx( arraytex_7_reference_u arraytex_7_reference_u.ktx2 "../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png" "--test --t2 --layers 7" "" "")
 gencmpktx( arraytex_7_mipmap_reference_u arraytex_7_mipmap_reference_u.ktx2 "../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png" "--test --t2 --layers 7 --genmipmap" "" "")

--- a/tools/toktx/toktx.cc
+++ b/tools/toktx/toktx.cc
@@ -79,7 +79,7 @@ using namespace std;
 Create a KTX file from JPEG, PNG or netpbm format files.
 
 @section toktx_synopsis SYNOPSIS
-    toktx [options] @e outfile [@e infile.{pam,pgm,ppm} ...]
+    toktx [options] @e outfile [@e infile.{jpg,png,pam,pgm,ppm} ...]
 
 @section toktx_description DESCRIPTION
     Create a Khronos format texture file (KTX) from a set of JPEG (.jpg),
@@ -88,10 +88,10 @@ Create a KTX file from JPEG, PNG or netpbm format files.
     @e outfile is '-' the output will be written to stdout.
 
     @b toktx reads each named @e infile. which must be in .jpg, .png, .pam,
-    .ppm or .pgm format. @e infiles prefixed with '@' are read as text files listing
-    actual file names to process with one file path per line. Paths must be
-    absolute or relative to the current directory when @b toktx is run. If
-    '\@@' is used instead, paths must be absolute or relative to the location
+    .ppm or .pgm format. @e infiles prefixed with '@' are read as text files
+    listing actual file names to process with one file path per line. Paths
+    must be absolute or relative to the current directory when @b toktx is run.
+    If '\@@' is used instead, paths must be absolute or relative to the location
     of the list file.
 
     The target texture type (number of components in the output texture) is
@@ -117,12 +117,12 @@ Create a KTX file from JPEG, PNG or netpbm format files.
     prompting you to convert the input to linear.
 
     The primaries, transfer function (OETF) and the texture's sRGB-ness is set
-    based on the input file unless @b --assign_oetf linear or @b --assign_oetf srgb
-    is specified. For .jpg files @b toktx always sets BT709/sRGB primaries and the
-    sRGB OETF in the output file and creates sRGB format textures. Netpbm files
-    always use BT.709/sRGB primaries and the BT.709 OETF. @b toktx tranforms
-    these images to the sRGB OETF, sets BT709/sRGB primaries and the sRGB OETF
-    in the output file and creates sRGB format textures.
+    based on the input file unless @b --assign_oetf linear or @b --assign_oetf
+    srgb is specified. For .jpg files @b toktx always sets BT709/sRGB primaries
+    and the sRGB OETF in the output file and creates sRGB format textures.
+    Netpbm files always use BT.709/sRGB primaries and the BT.709 OETF. @b toktx
+    tranforms these images to the sRGB OETF, sets BT709/sRGB primaries and the
+    sRGB OETF in the output file and creates sRGB format textures.
 
     For .png files the OETF is set as follows:
 
@@ -133,17 +133,18 @@ Create a KTX file from JPEG, PNG or netpbm format files.
         <dd>primaries are set to BT.709 and OETF to sRGB. gAMA and cHRM chunks
         are ignored.</dd>
     <dt>iCCP chunk present:</dt>
-        <dd>General ICC profiles are not yet supported by toktx or the KTX2 format.
-        In future these images may be transformed to linear or sRGB OETF as
-        appropriate for the profile. sRGB chunk must not be present.</dd>
+        <dd>General ICC profiles are not yet supported by toktx or the KTX2
+        format. In future these images may be transformed to linear or sRGB
+        OETF as appropriate for the profile. sRGB chunk must not be present.
+        </dd>
     <dt>gAMA and/or cHRM chunks present without sRGB or iCCP:</dt>
-        <dd>If gAMA is < 60000 the image is transformed to and the OETF is set to
-        sRGB. otherwise the image is transformed to and the OETF is set to
+        <dd>If gAMA is < 60000 the image is transformed to and the OETF is set
+        to sRGB. otherwise the image is transformed to and the OETF is set to
         linear. The color primaries in cHRM are matched to one of the
         standard sets listed in the Khronos Data Format Specification (the
         KHR_DF_PRIMARIES values from khr_df.h) and the primaries
-        field of the output file's DFD is set to the matched value. If no match is
-        found the primaries field is set to UNSPECIFIED.</dd>
+        field of the output file's DFD is set to the matched value. If no match
+        is found the primaries field is set to UNSPECIFIED.</dd>
     </dl>
 
     The following options are always available:
@@ -168,7 +169,7 @@ Create a KTX file from JPEG, PNG or netpbm format files.
     <dd>KTX file is for a 3D texture with a depth of @e number where
         @e number &gt; 1. Provide the file(s) for z=0 first then those for
         z=1, etc. It is an error to specify this together with
-        @b --layers &gt; 1 or @b --cubemap.</dd>
+        @b --layers or @b --cubemap.</dd>
     <dt>--genmipmap</dt>
     <dd>Causes mipmaps to be generated for each input file. This option is
         mutually exclusive with @b --automipmap and @b --mipmap. When set,
@@ -191,15 +192,15 @@ Create a KTX file from JPEG, PNG or netpbm format files.
     </dd>
     <dt>--layers &lt;number&gt;</dt>
     <dd>KTX file is for an array texture with @e number of layers where
-        @e number &gt; 1. Provide the file(s) for layer 0 first then those
+        @e number &gt; 0. Provide the file(s) for layer 0 first then those
         for layer 1, etc. It is an error to specify this together with
-        @b --depth &gt; 1.</dd>
+        @b --depth.</dd>
     <dt>--levels &lt;number&gt;</dt>
     <dd>KTX file is for a mipmap pyramid with @e number of levels rather than
-        a full pyramid. @e number must be &lt;= the maximum number of levels
-        determined from the size of the base image. Provide the base level
-        image first, if using @b --mipmap. This option is mutually exclusive
-        with @b --automipmap.</dd>
+        a full pyramid. @e number must be &gt; 1 and  &lt;= the maximum number
+        of levels determined from the size of the base level image. Provide the
+        base level image first, if using @b --mipmap. This option is mutually
+        exclusive with @b --automipmap.</dd>
     <dt>--mipmap</dt>
     <dd>KTX file is for a mipmap pyramid with one @b infile being explicitly
         provided for each level. Provide the images in the order of layer
@@ -234,22 +235,23 @@ Create a KTX file from JPEG, PNG or netpbm format files.
         ignores the orientation value, the image will appear upside down.
         This option is ignored with @b --cubemap. </dd>
     <dt>--assign_oetf &lt;linear|srgb&gt;</dt>
-    <dd>Force the created texture to have the specified transfer function. If this is
-        specified, implicit or explicit color space information from the input file(s)
-        will be ignored and no color transformation will be performed. USE WITH
-        CAUTION preferably only when you know the file format information is
-        wrong.</dd>
+    <dd>Force the created texture to have the specified transfer function. If
+        this is specified, implicit or explicit color space information from the
+        input file(s) will be ignored and no color transformation will be
+        performed. USE WITH CAUTION preferably only when you know the file
+        format information is wrong.</dd>
     <dt>--assign_primaries &lt;bt709|none|srgb&gt;</dt>
     <dd>Force the created texture to have the specified primaries. If this is
-        specified, implicit or explicit color space information from the input file(s)
-        will be ignored and no color transformation will be performed. USE WITH
-        CAUTION preferably only when you know the file format information is
-        wrong.</dd>
+        specified, implicit or explicit color space information from the input
+        file(s) will be ignored and no color transformation will be performed.
+        USE WITH CAUTION preferably only when you know the file format
+        information is wrong.</dd>
     <dt>--convert_oetf &lt;linear|srgb&gt;</dt>
-    <dd>Convert the input images to the specified transfer function, if the current
-        transfer function is different. If both this and @b --assign_oetf are
-        specified, conversion will be performed from the assigned transfer function
-        to the transfer function specified by this option, if different.
+    <dd>Convert the input images to the specified transfer function, if the
+        current transfer function is different. If both this and
+        @b --assign_oetf are specified, conversion will be performed from the
+        assigned transfer function to the transfer function specified by this
+        option, if different.
     <dt>--linear</dt>
     <dd>Deprecated. Use @b --assign_oetf linear.</dd>
     <dt>--srgb</dt>
@@ -393,7 +395,7 @@ class toktxApp : public scApp {
             useStdin = 0;
             test = 0;
             depth = 1;
-            layers = 1;
+            layers = 0;
             levels = 1;
             convert_oetf = KHR_DF_TRANSFER_UNSPECIFIED;
             assign_oetf = KHR_DF_TRANSFER_UNSPECIFIED;
@@ -486,7 +488,7 @@ void
 toktxApp::usage()
 {
     cerr <<
-        "Usage: " << name << " [options] <outfile> [<infile>.{pam,pgm,ppm} ...]\n"
+        "Usage: " << name << " [options] <outfile> [<infile>.{jpg,png,pam,pgm,ppm} ...]\n"
         "\n"
         "  <outfile>    The destination ktx file. \".ktx\" will appended if necessary.\n"
         "               If it is '-' the output will be written to stdout.\n"
@@ -547,7 +549,7 @@ toktxApp::usage()
         "               KTX file is for a 3D texture with a depth of number where\n"
         "               number > 1. Provide the file(s) for z=0 first then those for\n"
         "               z=1, etc. It is an error to specify this together with\n"
-        "               --layers > 1 or --cubemap.\n"
+        "               --layers or --cubemap.\n"
         "  --genmipmap  Causes mipmaps to be generated for each input file. This option\n"
         "               is mutually exclusive with --automipmap and --mipmap. When set\n"
         "               the following mipmap-generation related options become valid,\n"
@@ -566,14 +568,14 @@ toktxApp::usage()
         "               are wrap, reflect and clamp. The default is clamp.\n"
         "  --layers <number>\n"
         "               KTX file is for an array texture with number of layers\n"
-        "               where number > 1. Provide the file(s) for layer 0 first then\n"
+        "               where number > 0. Provide the file(s) for layer 0 first then\n"
         "               those for layer 1, etc. It is an error to specify this\n"
-        "               together with --depth > 1.\n"
+        "               together with --depth.\n"
         "  --levels <number>\n"
         "               KTX file is for a mipmap pyramid with <number> of levels rather\n"
-        "               than a full pyramid. number must be <= the maximum number of\n"
-        "               levels determined from the size of the base image. This option is\n"
-        "               mutually exclusive with @b --automipmap.\n"
+        "               than a full pyramid. number must be > 1 and <= the maximum number\n"
+        "               of levels determined from the size of the base image. This option\n"
+        "               is mutually exclusive with @b --automipmap.\n"
         "  --mipmap     KTX file is for a mipmap pyramid with one infile being explicitly\n"
         "               provided for each level. Provide the images in the order of layer\n"
         "               then face or depth slice then level with the base-level image\n"
@@ -715,10 +717,12 @@ toktxApp::main(int argc, _TCHAR *argv[])
     else
       createInfo.numFaces = 1;
 
-    createInfo.numLayers = options.layers;
-    createInfo.isArray = options.layers > 1;
-
-    // TO DO: handle 3D textures.
+    if (options.layers) {
+        createInfo.numLayers = options.layers;
+        createInfo.isArray = KTX_TRUE;
+    } else {
+        createInfo.numLayers = 1;
+    }
 
     faceSlice = layer = level = 0;
     std::vector<_tstring>::const_iterator it;
@@ -1181,7 +1185,7 @@ toktxApp::main(int argc, _TCHAR *argv[])
                 if (faceSlice == (options.cubemap ? 6 : levelDepth)) {
                     faceSlice = 0;
                     layer++;
-                    if (layer == options.layers) {
+                    if (layer == createInfo.numLayers) {
                         // We're done.
                         break;
                     }
@@ -1473,7 +1477,7 @@ toktxApp::validateOptions()
         usage();
         exit(1);
     }
-    if (options.layers > 1 && options.depth > 1) {
+    if (options.layers && options.depth > 1) {
         error("cannot have 3D array textures.");
         usage();
         exit(1);
@@ -1574,17 +1578,35 @@ toktxApp::processEnvOptions() {
 bool
 toktxApp::processOption(argparser& parser, int opt)
 {
+    // N.B. It is not possible for an optarg string to be a negative number
+    // because the leading '-' will make the parser think it is an option
+    // leading to a "missing required argument" error before this is ever called.
     switch (opt) {
       case 0:
         break;
       case 'a':
-        options.layers = strtoi(parser.optarg.c_str());
+        options.layers = (uint32_t)strtoi(parser.optarg.c_str());
+        if (options.layers == 0) {
+            cerr << name << ": "
+                 << "To create an array texture set --layers > 0." << endl;
+            exit(1);
+        }
         break;
       case 'd':
-        options.depth = strtoi(parser.optarg.c_str());
+        options.depth = (uint32_t)strtoi(parser.optarg.c_str());
+        if (options.depth < 2) {
+            cerr << name << ": "
+                 << "To create a 3d texture set --depth > 1." << endl;
+            exit(1);
+        }
         break;
       case 'l':
-        options.levels = strtoi(parser.optarg.c_str());
+        options.levels = (uint32_t)strtoi(parser.optarg.c_str());
+        if (options.levels < 2) {
+            cerr << name << ": "
+                 << "--levels must be > 1." << endl;
+            exit(1);
+        }
         break;
       case 'f':
         options.gmopts.filter = parser.optarg;

--- a/utils/scapp.h
+++ b/utils/scapp.h
@@ -334,10 +334,13 @@ astcEncoderMode(const char* mode) {
       nml.xy = nml.xy * 2.0 - 1.0;           // Unpack to [-1,1]
       nml.z = sqrt(1 - dot(nml.xy, nml.xy)); // Compute Z
                  </pre>
-                 For ASTC encoding, '--encode astc', encoder parameters are
+                 For ASTC encoding, '@b --encode astc', encoder parameters are
                  tuned for better quality on normal maps. For ETC1S encoding,
-                 '@b --encode etc1s', RDO is disabled (no selector RDO, no
+                 @b '--encode etc1s', RDO is disabled (no selector RDO, no
                  endpoint RDO) to provide better quality.</dd>
+
+                 In @em toktx you can prevent conversion of the normal map to
+                 two components by specifying '@b --input_swizzle rgb1'.
     <dt>--normalize</dt>
                  <dd>Normalize input normals to have a unit length. Only valid
                  for linear textures with 2 or more components. For 2-component
@@ -685,6 +688,8 @@ class scApp : public ktxApp {
           "               on normal maps. .  For ETC1S encoding, '--encode etc1s',i RDO is\n"
           "               disabled (no selector RDO, no endpoint RDO) to provide better\n"
           "               quality.\n\n"
+          "               In toktx you can prevent conversion of the normal map to\n"
+          "               two components by specifying '--input_swizzle rgb1'.\n\n"
           "  --normalize\n"
           "               Normalize input normals to have a unit length. Only valid for\n"
           "               linear textures with 2 or more components. For 2-component inputs\n"


### PR DESCRIPTION
Fixes #596.

Add checks for valid argument values for depth, layers and levels.

Update toktx documentation.
   * Add note about how to disable 2-component normal map conversion.
   * Reformat some of the source.