### PR TITLE
Build-system fixes

### DIFF
--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -196,9 +196,11 @@ set( LOAD_TEST_COMMON_RESOURCE_FILES
     ${MODELS}
 )
 
-include(glloadtests.cmake)
+if(KTX_FEATURE_GL_UPLOAD)
+    include(glloadtests.cmake)
+endif()
 
-if(NOT EMSCRIPTEN)
+if(KTX_FEATURE_VULKAN AND NOT EMSCRIPTEN)
     include(vkloadtests.cmake)
 endif()
 

--- a/tools/toktx/CMakeLists.txt
+++ b/tools/toktx/CMakeLists.txt
@@ -23,6 +23,7 @@ PRIVATE
     $<TARGET_PROPERTY:objUtil,INTERFACE_INCLUDE_DIRECTORIES>
     ${PROJECT_SOURCE_DIR}/lib
     ${PROJECT_SOURCE_DIR}/lib/basisu
+    ${PROJECT_SOURCE_DIR}/lib/dfdutils
     ${PROJECT_SOURCE_DIR}/other_include
 )
 


### PR DESCRIPTION
* Fix missing header when building toktx while `KTX_FEATURE_VULKAN` is disabled.
* Do not build glloadtests and vkloadtests when their corresponding loader is not enabled, otherwise it results in missing symbols. For example, do not build vkloadtests when `KTX_FEATURE_LOADTEST_APPS` is enabled but `KTX_FEATURE_VULKAN` is not.