### PR TITLE
Support setting image data from DirectByteBuffer

### DIFF
--- a/interface/java_binding/src/main/cpp/KtxTexture.cpp
+++ b/interface/java_binding/src/main/cpp/KtxTexture.cpp
@@ -292,7 +292,7 @@ extern "C" JNIEXPORT jint JNICALL Java_org_khronos_ktx_KtxTexture_setImageFromBu
                                 src,
                                 srcSize);
 
-    /* it is the caller's responsibility to make sure the buffer lives long enough */
+    push_buffer_list(env, thiz, srcBuffer);
 
     return result;
 }

--- a/interface/java_binding/src/main/java/org/khronos/ktx/KtxTexture.java
+++ b/interface/java_binding/src/main/java/org/khronos/ktx/KtxTexture.java
@@ -5,6 +5,8 @@
 
 package org.khronos.ktx;
 
+import java.nio.ByteBuffer;
+
 public abstract class KtxTexture {
     private final long instance;
     private long buffers;
@@ -46,14 +48,14 @@ public abstract class KtxTexture {
     /**
      * Destroy the KTX texture and free memory image resources
      *
-     * NOTE: If you try to use a {@link KTXTexture} after it's destroyed, that will cause a segmentation
+     * NOTE: If you try to use a {@link KtxTexture} after it's destroyed, that will cause a segmentation
      * fault (the texture pointer is set to NULL).
      */
     public native void destroy();
 
     /**
      * Set the image data - the passed data should be not modified after passing it! The bytes
-     * will be kept in memory until {@link KTXTexture#destroy} is called.
+     * will be kept in memory until {@link KtxTexture#destroy()} is called.
      *
      * @param level - The image level, should be 0 for non-mipmapped textures
      * @param layer - The texture layer, should be 0 for non-arrays
@@ -61,6 +63,16 @@ public abstract class KtxTexture {
      * @param src - The image data
      */
     public native int setImageFromMemory(int level, int layer, int faceSlice, byte[] src);
+
+    /**
+     * Set the image data - the passed buffer must not be modified until {@link KtxTexture#destroy()} is called.
+     *
+     * @param level - The image level, should be 0 for non-mipmapped textures
+     * @param layer - The texture layer, should be 0 for non-arrays
+     * @param faceSlice - The face slice, should be 0 for non-cubemaps
+     * @param src - The image data as a direct byte buffer.
+     */
+    public native int setImageFromBuffer(int level, int layer, int faceSlice, ByteBuffer src);
 
     /**
      * Write the KTX image to the given destination file in KTX format

--- a/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture1Test.java
+++ b/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture1Test.java
@@ -5,6 +5,7 @@
 
 package org.khronos.ktx.test;
 
+import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.khronos.ktx.*;
@@ -101,7 +102,7 @@ public class KtxTexture1Test {
     }
 
     @Test
-    public void testCreate() {
+    public void testCreateFromArray() {
         KtxTextureCreateInfo info = new KtxTextureCreateInfo();
 
         info.setGlInternalformat(KtxInternalformat.GL_COMPRESSED_RGBA_ASTC_4x4_KHR);
@@ -113,6 +114,23 @@ public class KtxTexture1Test {
 
         byte[] imageData = new byte[10 * 10];
         texture.setImageFromMemory(0, 0, 0, imageData);
+
+        texture.destroy();
+    }
+
+    @Test
+    public void testCreateFromBuffer() {
+        KtxTextureCreateInfo info = new KtxTextureCreateInfo();
+
+        info.setGlInternalformat(KtxInternalformat.GL_COMPRESSED_RGBA_ASTC_4x4_KHR);
+        info.setBaseWidth(10);
+        info.setBaseHeight(10);
+
+        KtxTexture1 texture = KtxTexture1.create(info, KtxCreateStorage.ALLOC);
+        assertNotNull(texture);
+
+        ByteBuffer imageData = ByteBuffer.allocateDirect(10 * 10);
+        texture.setImageFromBuffer(0, 0, 0, imageData);
 
         texture.destroy();
     }

--- a/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
+++ b/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
@@ -5,18 +5,25 @@
 
 package org.khronos.ktx.test;
 
-import java.nio.ByteBuffer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.khronos.ktx.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.khronos.ktx.KtxBasisParams;
+import org.khronos.ktx.KtxCreateStorage;
+import org.khronos.ktx.KtxErrorCode;
+import org.khronos.ktx.KtxSupercmpScheme;
+import org.khronos.ktx.KtxTexture2;
+import org.khronos.ktx.KtxTextureCreateFlagBits;
+import org.khronos.ktx.KtxTextureCreateInfo;
+import org.khronos.ktx.KtxTranscodeFormat;
+import org.khronos.ktx.VkFormat;
 
 @ExtendWith({ KtxTestLibraryLoader.class })
 public class KtxTexture2Test {
@@ -242,7 +249,14 @@ public class KtxTexture2Test {
 
         ByteBuffer imageData = ByteBuffer.allocateDirect(10 * 10);
         texture.setImageFromBuffer(0, 0, 0, imageData);
-
+        // GC sensitive code commented out because it flakes a lot, but this showcases
+        // the intended behavior.
+        // WeakReference<ByteBuffer> imageDataRef = new WeakReference<>(imageData);
+        // imageData = null;
+        // System.gc();
+        // assertNotNull(imageDataRef.get());
         texture.destroy();
+        // System.gc();
+        // assertNull(imageDataRef.get());
     }
 }

--- a/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
+++ b/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
@@ -5,6 +5,7 @@
 
 package org.khronos.ktx.test;
 
+import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.khronos.ktx.*;
@@ -212,7 +213,7 @@ public class KtxTexture2Test {
     }
 
     @Test
-    public void testCreate() {
+    public void testCreateFromArray() {
         KtxTextureCreateInfo info = new KtxTextureCreateInfo();
 
         info.setBaseWidth(10);
@@ -224,6 +225,23 @@ public class KtxTexture2Test {
 
         byte[] imageData = new byte[10 * 10];
         texture.setImageFromMemory(0, 0, 0, imageData);
+
+        texture.destroy();
+    }
+
+    @Test
+    public void testCreateFromBuffer() {
+        KtxTextureCreateInfo info = new KtxTextureCreateInfo();
+
+        info.setBaseWidth(10);
+        info.setBaseHeight(10);
+        info.setVkFormat(VkFormat.VK_FORMAT_ASTC_4x4_SRGB_BLOCK);
+
+        KtxTexture2 texture = KtxTexture2.create(info, KtxCreateStorage.ALLOC);
+        assertNotNull(texture);
+
+        ByteBuffer imageData = ByteBuffer.allocateDirect(10 * 10);
+        texture.setImageFromBuffer(0, 0, 0, imageData);
 
         texture.destroy();
     }


### PR DESCRIPTION
Allowing creation of KtxTexture from a DirectByteBuffer lets you interop with images written by other native libraries (for example, GDAL) without having to copy everything to and from the heap.