### PR TITLE
Set isCompressed at end of CompressBasisEx.

### DIFF
--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -82,6 +82,7 @@ function( CreateDocLibKTX )
         lib/mainpage.md
         LICENSE.md
         include
+        lib/astc_encode.cpp
         lib/basis_encode.cpp
         lib/basis_transcode.cpp
         lib/strings.c

--- a/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
+++ b/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
@@ -166,7 +166,7 @@ public class KtxTexture2Test {
 
         assertEquals(KtxErrorCode.SUCCESS, texture.compressBasis(1));
 
-        assertEquals(false, texture.isCompressed());
+        assertEquals(true, texture.isCompressed());
         assertEquals(KtxSupercmpScheme.BASIS_LZ, texture.getSupercompressionScheme());
 
         texture.destroy();
@@ -188,7 +188,7 @@ public class KtxTexture2Test {
 
         assertEquals(KtxErrorCode.SUCCESS, texture.compressBasisEx(new KtxBasisParams()));
 
-        assertEquals(false, texture.isCompressed());
+        assertEquals(true, texture.isCompressed());
         assertEquals(KtxSupercmpScheme.BASIS_LZ, texture.getSupercompressionScheme());
 
         texture.destroy();

--- a/lib/astc_encode.cpp
+++ b/lib/astc_encode.cpp
@@ -759,10 +759,6 @@ ktxTexture2_CompressAstcEx(ktxTexture2* This, ktxAstcParams* params) {
  *
  * Such textures can be directly uploaded to a GPU via a graphics API.
  *
- * @memberof ktxTexture2
- * @ingroup writer
- * @~English
- *
  * @param[in]   This    pointer to the ktxTexture2 object of interest.
  * @param[in]   quality Compression quality, a value from 0 - 100.
                         Higher=higher quality/slower speed.

--- a/lib/basis_encode.cpp
+++ b/lib/basis_encode.cpp
@@ -1018,6 +1018,7 @@ ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params)
         priv._requiredLevelAlignment = 1;
     }
     This->vkFormat = VK_FORMAT_UNDEFINED;
+    This->isCompressed = KTX_TRUE;
 
     // Block-compressed textures never need byte swapping so typeSize is 1.
     assert(This->_protected->_typeSize == 1);

--- a/tests/loadtests/glloadtests/shader-based/EncodeTexture.cpp
+++ b/tests/loadtests/glloadtests/shader-based/EncodeTexture.cpp
@@ -106,8 +106,8 @@ EncodeTexture::EncodeTexture(uint32_t width, uint32_t height,
         if (KTX_SUCCESS != ktxresult) {
             std::stringstream message;
 
-            message << "Encoding of ktxTexture2 to Basis failed: "
-                    << ktxErrorString(ktxresult);
+            message << "Encoding of ktxTexture2 to " << encodeTarget
+                    << " failed: " << ktxErrorString(ktxresult);
             throw std::runtime_error(message.str());
         }
     }

--- a/tests/loadtests/glloadtests/shader-based/EncodeTexture.h
+++ b/tests/loadtests/glloadtests/shader-based/EncodeTexture.h
@@ -50,7 +50,6 @@ class EncodeTexture : public GL3LoadTestSample {
     bool bInitialized;
     ktx_transcode_fmt_e transcodeTarget;
     enum encode_fmt_e { EF_ASTC = 1, EF_ETC1S = 2, EF_UASTC = 3 };
-    //ostream& operator<<(ostream& os, const Date& dt)
     friend ostream& operator<<(ostream& os, encode_fmt_e format);
     encode_fmt_e encodeTarget;
 };

--- a/tests/loadtests/glloadtests/shader-based/EncodeTexture.h
+++ b/tests/loadtests/glloadtests/shader-based/EncodeTexture.h
@@ -50,7 +50,24 @@ class EncodeTexture : public GL3LoadTestSample {
     bool bInitialized;
     ktx_transcode_fmt_e transcodeTarget;
     enum encode_fmt_e { EF_ASTC = 1, EF_ETC1S = 2, EF_UASTC = 3 };
+    //ostream& operator<<(ostream& os, const Date& dt)
+    friend ostream& operator<<(ostream& os, encode_fmt_e format);
     encode_fmt_e encodeTarget;
 };
 
+inline ostream& operator<<(ostream& os, EncodeTexture::encode_fmt_e format)
+{
+    switch (format) {
+      case EncodeTexture::EF_ASTC:
+        os << "astc";
+        break;
+      case EncodeTexture::EF_ETC1S:
+        os << "etc1s";
+        break;
+      case EncodeTexture::EF_UASTC:
+        os << "uastc";
+        break;
+    }
+    return os;
+}
 #endif /* ENCODE_TEXTURE_H */

--- a/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
+++ b/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
@@ -63,7 +63,7 @@ GLLoadTests::showFile(std::string& filename)
                                  " because there is no libassimp support.");
 #endif
     } else if (kTexture->numLevels > 1 || kTexture->generateMipmaps) {
-        // TODO: Add option to choose tis display showing the individual
+        // TODO: Add option to choose to display showing the individual
         // mipmaps vs. DrawTexture that displays a single rect using the
         // mipmaps, if present.
         createViewer = TextureMipmap::create;
@@ -115,8 +115,12 @@ const GLLoadTests::sampleInvocation siSamples[] = {
     },
 #if TEST_COMPRESSION
     { EncodeTexture::create,
-      "testimages/rgba-reference-u.ktx2",
+      "--encode etc1s testimages/rgba-reference-u.ktx2",
       "Encode to ETC1S+BasisLZ then Transcode of Compressed KTX2 RGBA not mipmapped"
+    },
+    { EncodeTexture::create,
+      "--encode uastc testimages/rgba-reference-u.ktx2",
+      "Encode to UASTC then Transcode of Compressed KTX2 RGBA not mipmapped"
     },
     { EncodeTexture::create,
       "--encode astc testimages/rgba-reference-u.ktx2",


### PR DESCRIPTION
Add test for the case that failed prior to the fix. Fixes #617.