### PR TITLE
Fix JNI package names in KtxTexture2.cpp

### DIFF
--- a/interface/java_binding/src/main/cpp/KtxTexture2.cpp
+++ b/interface/java_binding/src/main/cpp/KtxTexture2.cpp
@@ -7,17 +7,17 @@
 #include <iostream>
 #include "libktx-jni.h"
 
-extern "C" JNIEXPORT jint JNICALL Java_org_khronos_KtxTexture2_getOETF(JNIEnv *env, jobject thiz)
+extern "C" JNIEXPORT jint JNICALL Java_org_khronos_ktx_KtxTexture2_getOETF(JNIEnv *env, jobject thiz)
 {
     return ktxTexture2_GetOETF(get_ktx2_texture(env, thiz));
 }
 
-extern "C" JNIEXPORT jboolean JNICALL Java_org_khronos_KtxTexture2_getPremultipliedAlpha(JNIEnv *env, jobject thiz)
+extern "C" JNIEXPORT jboolean JNICALL Java_org_khronos_ktx_KtxTexture2_getPremultipliedAlpha(JNIEnv *env, jobject thiz)
 {
     return ktxTexture2_GetPremultipliedAlpha(get_ktx2_texture(env, thiz));
 }
 
-extern "C" JNIEXPORT jboolean JNICALL Java_org_khronos_KtxTexture2_needsTranscoding(JNIEnv *env, jobject thiz)
+extern "C" JNIEXPORT jboolean JNICALL Java_org_khronos_ktx_KtxTexture2_needsTranscoding(JNIEnv *env, jobject thiz)
 {
     return ktxTexture2_NeedsTranscoding(get_ktx2_texture(env, thiz));
 }


### PR DESCRIPTION
The name of the functions in the JNI KtxTexture2.cpp didn't match
the java package which cause linker error.