### PR TITLE
Document required queue properties. Fixes #627.

### DIFF
--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -778,7 +778,7 @@ VulkanAppSDL::createDevice()
     float queue_priorities[1] = {0.0};
     const vk::DeviceQueueCreateInfo queueInfo(
         {},
-        vkQueueFamilyIndex,
+        vkctx.swapchain.queueIndex,
         1,
         queue_priorities
     );

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h
@@ -131,8 +131,6 @@ class VulkanAppSDL : public AppBaseSDL {
     std::vector<const char*> extensionNames;
     std::vector<const char*> deviceValidationLayers;
 
-    uint32_t vkQueueFamilyIndex;
-
     VkCommandBuffer setupCmdBuffer;
     VkSurfaceKHR vsSurface;
 

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanSwapchain.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanSwapchain.cpp
@@ -130,7 +130,7 @@ VulkanSwapchain::initSurface(SDL_Window* window)
         ERROR_RETURN("Could not find a graphics or presenting queue!");
     }
 
-    // TODO : Add support for separate graphics and presenting queue
+    // TODO: Add support for separate graphics and presenting queue
     if (graphicsQueueIndex != presentQueueIndex)
     {
         ERROR_RETURN("Separate graphics and present queues not yet supported!");
@@ -154,7 +154,7 @@ VulkanSwapchain::initSurface(SDL_Window* window)
     // If the surface format list only includes one entry with
     // VK_FORMAT_UNDEFINED, there is no preferred format.
     // Assume VK_FORMAT_B8G8R8A8_RGB.
-    // TODO Consider passing in desired format from app.
+    // TODO: Consider passing in desired format from app.
     if ((formatCount == 1) && (surfaceFormats[0].format == VK_FORMAT_UNDEFINED))
     {
         colorFormat = VK_FORMAT_B8G8R8A8_SRGB;


### PR DESCRIPTION
Bug fix: when creating the VkDevice in VulkanAppSDL use the family index of the suitable queue determined by VulkanSwapchain::initSurface. It was using index  0.

Convert a few TODOs and XXXs to TODO: for proper parsing by Xcode's editor.