### PR TITLE
git fallback to commit hash version ID

### DIFF
--- a/mkversion
+++ b/mkversion
@@ -39,6 +39,10 @@ function genversion() {
         # No containing tag. Get version number a previous tag.
         VN=$(git describe --match "v[0-9]*" $(git rev-list -1 HEAD $1) 2>/dev/null)
       fi
+      if [ -z "$VN" ]; then
+        # No tags at all, best we can do is tag the commit.
+        VN="$DEF_VER-$(git rev-parse --short HEAD 2>/dev/null)"
+      fi
     fi
     case "$VN" in
     *$LF*) (exit 1) ;;


### PR DESCRIPTION
Background:
This is an issue when `KTX-Software` is included as a git submodule in a Rust crate (a Rust project), and that crate is being built as a dependency specified as a git URL in another crate. The implementation within the Cargo package manager results in a very sparse checkout (i.e. without any tags), which cannot be associated with a version number via git.

The result is a completely empty version number macro. This fails silently on GCC & clang, but does not compile under MSVC.

Change:
The git path checks one additional time for an empty version name, before combining the default version with the current short hash to identify the code. This ensures the `VERSION` macro is not left empty if the tag information is missing.