### PR TITLE
Update KTX-Software-CTS reference to specific commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "tests/cts"]
 	path = tests/cts
 	url = https://github.com/KhronosGroup/KTX-Software-CTS.git
-	branch = main
+	branch = b881ca6ff438b663b98952d3361e5e3fce14938c


### PR DESCRIPTION
This PR only updates the submodule reference for the KTX-Software-CTS repository, as it should always refer to a specific commit to avoid new tests causing failures on old code.

@MarkCallow, could you please merge this in? Apparently this was overlooked when merging the KTX-Tools branch into main.