### PR TITLE
Remove unused variable 's' and 'e' in ktxUpgrader::main

### DIFF
--- a/tools/ktx2ktx2/ktx2ktx2.cpp
+++ b/tools/ktx2ktx2/ktx2ktx2.cpp
@@ -187,7 +187,7 @@ ktxUpgrader::main(int argc, _TCHAR* argv[])
     processCommandLine(argc, argv);
     validateOptions();
 
-    std::vector<_tstring>::const_iterator it, s, e;
+    std::vector<_tstring>::const_iterator it;
     for (it = options.infiles.begin(); it < options.infiles.end(); it++) {
         _tstring infile = *it;
         _tstring outfile;


### PR DESCRIPTION
When use `MinGW` to compile, it will output error:

```Cmd
E:\TestDelete\WebAssemblyTest\KTX-Software\tools\ktx2ktx2\ktx2ktx2.cpp:190:47: error: unused variable '
    std::vector<_tstring>::const_iterator it, s, e;
                                              ^
E:\TestDelete\WebAssemblyTest\KTX-Software\tools\ktx2ktx2\ktx2ktx2.cpp:190:50: error: unused variable '
    std::vector<_tstring>::const_iterator it, s, e;
                                                 ^
```

then remove unused variable `s` and `e`. It will compile succes.
