### PR TITLE
Fix legacy app input from pipes on Windows.

### DIFF
--- a/tests/ktx2check-tests.cmake
+++ b/tests/ktx2check-tests.cmake
@@ -95,12 +95,10 @@ add_test( NAME ktx2check-test-stdin-read
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-if(NOT WIN32) # Disable due to bug in Git for Windows 2.41.0.windows.1 pipe.
-  add_test( NAME ktx2check-test-pipe-read
-      COMMAND ${BASH_EXECUTABLE} -c "cat color_grid_uastc_zstd.ktx2 | $<TARGET_FILE:ktx2check>"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
-  )
-endif()
+add_test( NAME ktx2check-test-pipe-read
+    COMMAND ${BASH_EXECUTABLE} -c "cat color_grid_uastc_zstd.ktx2 | $<TARGET_FILE:ktx2check>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
+)
 
 add_test( NAME ktx2check-test-invalid-face-count-and-padding
     COMMAND ktx2check invalid_face_count_and_padding.ktx2

--- a/tools/imageio/exr.imageio/exrinput.cc
+++ b/tools/imageio/exr.imageio/exrinput.cc
@@ -4,6 +4,8 @@
 // Copyright 2022 The Khronos Group Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "imageio.h"
+
 #include <array>
 #include <cassert>
 #include <optional>
@@ -14,7 +16,6 @@
 #define TEXR_ASSERT(x) assert(x)
 #define TINYEXR_IMPLEMENTATION
 #include "tinyexr.h"
-#include "imageio.h"
 #include <KHR/khr_df.h>
 #include "dfd.h"
 

--- a/tools/imageio/imageinput.cc
+++ b/tools/imageio/imageinput.cc
@@ -73,9 +73,11 @@ ImageInput::open(const _tstring& filename,
 #if defined(_WIN32)
         // Set "stdin" to have binary mode. There is no way to this via cin.
         (void)_setmode( _fileno( stdin ), _O_BINARY );
-        // cin.seekg(0) erroneously succeeds for pipes on Windows, including
-        // in Cygwin since 3.4.x and anything dependent on Cygwin, e.g. Git
-        // for Windows (since 2.41.0) and MSYS2. Always buffer.
+        // Windows shells set the FILE_SYNCHRONOUS_IO_NONALERT option when
+        // creating pipes. Cygwin since 3.4.x does the same thing, a change
+        // which affects anything dependent on it, e.g. Git for Windows
+        // (since 2.41.0) and MSYS2. When this option is set, cin.seekg(0)
+        // erroneously returns success. Always buffer.
         doBuffer = true;
 #else
         // Can we seek in this cin?

--- a/tools/imageio/imageio.cc
+++ b/tools/imageio/imageio.cc
@@ -12,6 +12,8 @@
 //! @brief Create plugin maps.
 //!
 
+#include "imageio.h"
+
 #include <algorithm>
 #include <cctype>
 #include <iomanip>
@@ -23,8 +25,6 @@
 #include <vector>
 
 #include <stdarg.h>
-
-#include "imageio.h"
 
 #define PLUGENTRY(name)                          \
     ImageInput* name##InputCreate();             \

--- a/tools/imageio/imageoutput.cc
+++ b/tools/imageio/imageoutput.cc
@@ -12,6 +12,8 @@
 //! @brief ImageOutput class implementation
 //!
 
+#include "imageio.h"
+
 #include <algorithm>
 #include <cctype>
 #include <iomanip>
@@ -23,8 +25,6 @@
 #include <vector>
 
 #include <stdarg.h>
-
-#include "imageio.h"
 
 std::unique_ptr<ImageOutput>
 ImageOutput::create(const _tstring& filename)

--- a/tools/imageio/jpg.imageio/jpginput.cc
+++ b/tools/imageio/jpg.imageio/jpginput.cc
@@ -20,13 +20,12 @@
  * @author Mark Callow.
  */
 
-#include "stdafx.h"
+#include "imageio.h"
 
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
 
-#include "imageio.h"
 #include "encoder/jpgd.h"
 
 using namespace jpgd;

--- a/tools/imageio/png.imageio/pnginput.cc
+++ b/tools/imageio/png.imageio/pnginput.cc
@@ -14,14 +14,13 @@
  * @author Mark Callow
  */
 
-#include "stdafx.h"
+#include "imageio.h"
 
 #include <array>
 #include <iterator>
 #include <sstream>
 #include <stdexcept>
 
-#include "imageio.h"
 #include "lodepng.h"
 #include <KHR/khr_df.h>
 #include "dfd.h"

--- a/tools/imageio/png.imageio/pngoutput.cc
+++ b/tools/imageio/png.imageio/pngoutput.cc
@@ -14,13 +14,12 @@
  * @author Mark Callow
  */
 
-#include "stdafx.h"
+#include "imageio.h"
 
 #include <iterator>
 #include <sstream>
 #include <stdexcept>
 
-#include "imageio.h"
 #include "lodepng.h"
 #include <KHR/khr_df.h>
 #include "dfd.h"

--- a/tools/ktx/command.cpp
+++ b/tools/ktx/command.cpp
@@ -13,6 +13,9 @@
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 
+#if defined(_WIN32) && defined(DEBUG)
+#include <windows.h> // For functions used by launchDebugger 
+#endif
 
 // -------------------------------------------------------------------------------------------------
 
@@ -38,7 +41,52 @@ void Command::parseCommandLine(const std::string& name, const std::string& desc,
     } catch (const cxxopts::exceptions::parsing& ex) {
         fatal_usage("{}.", ex.what());
     }
+
+#if defined(_WIN32) && defined(DEBUG)
+    if (args["ld"].as<bool>())
+        launchDebugger();
+#endif
 }
+
+#if defined(_WIN32) && defined(DEBUG)
+// For use when debugging stdin with Visual Studio which does not have a
+// "wait for executable to be launched" choice in its debugger settings.
+bool Command::launchDebugger()
+{
+    // Get System directory, typically c:\windows\system32
+    std::wstring systemDir(MAX_PATH + 1, '\0');
+    UINT nChars = GetSystemDirectoryW(&systemDir[0], systemDir.length());
+    if (nChars == 0) return false; // failed to get system directory
+    systemDir.resize(nChars);
+
+    // Get process ID and create the command line
+    DWORD pid = GetCurrentProcessId();
+    std::wostringstream s;
+    s << systemDir << L"\\vsjitdebugger.exe -p " << pid;
+    std::wstring cmdLine = s.str();
+
+    // Start debugger process
+    STARTUPINFOW si;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&pi, sizeof(pi));
+
+    if (!CreateProcessW(NULL, &cmdLine[0], NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) return false;
+
+    // Close debugger process handles to eliminate resource leak
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+
+    // Wait for the debugger to attach
+    while (!IsDebuggerPresent()) Sleep(100);
+
+    // Stop execution so the debugger can take over
+    DebugBreak();
+    return true;
+}
+#endif
 
 std::string version(bool testrun) {
     return testrun ? STR(KTX_DEFAULT_VERSION) : STR(KTX_VERSION);

--- a/tools/ktx/command.cpp
+++ b/tools/ktx/command.cpp
@@ -55,7 +55,8 @@ bool Command::launchDebugger()
 {
     // Get System directory, typically c:\windows\system32
     std::wstring systemDir(MAX_PATH + 1, '\0');
-    UINT nChars = GetSystemDirectoryW(&systemDir[0], systemDir.length());
+    UINT nChars = GetSystemDirectoryW(&systemDir[0],
+                                static_cast<UINT>(systemDir.length()));
     if (nChars == 0) return false; // failed to get system directory
     systemDir.resize(nChars);
 

--- a/tools/ktx/command.h
+++ b/tools/ktx/command.h
@@ -139,6 +139,9 @@ protected:
 
     virtual void initOptions(cxxopts::Options& /*opts*/) { }
     virtual void processOptions(cxxopts::Options& /*opts*/, cxxopts::ParseResult& /*args*/) { };
+#if defined(_WIN32) && defined(DEBUG)
+    bool launchDebugger();
+#endif
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -162,7 +165,11 @@ struct OptionsGeneric {
         opts.add_options()
                 ("h,help", "Print this usage message and exit")
                 ("v,version", "Print the version number of this program and exit")
-                ("testrun", "Indicates test run. If enabled the tool will produce deterministic output whenever possible");
+                ("testrun", "Indicates test run. If enabled the tool will produce deterministic output whenever possible")
+#if defined(_WIN32) && defined(DEBUG)
+                ("ld", "Launch debugger on startup.")
+#endif
+                ;
     }
 
     void process(cxxopts::Options& opts, cxxopts::ParseResult& args, Reporter& report) {

--- a/tools/ktx2check/ktx2check.cpp
+++ b/tools/ktx2check/ktx2check.cpp
@@ -1196,9 +1196,11 @@ ktxValidator::validateFile(const _tstring& filename)
 #if defined(_WIN32)
         /* Set "stdin" to have binary mode */
         (void)_setmode( _fileno( stdin ), _O_BINARY );
-        // cin.seekg(0) erroneously succeeds for pipes on Windows, including
-        // in Cygwin since 3.4.x and anything dependent on Cygwin, e.g. Git
-        // for Windows (since 2.41.0) and MSYS2. Always buffer.
+        // Windows shells set the FILE_SYNCHRONOUS_IO_NONALERT option when
+        // creating pipes. Cygwin since 3.4.x does the same thing, a change
+        // which affects anything dependent on it, e.g. Git for Windows
+        // (since 2.41.0) and MSYS2. When this option is set, cin.seekg(0)
+        // erroneously returns success. Always buffer.
         doBuffer = true;
 #else
         // Can we seek in this cin?
@@ -1207,8 +1209,8 @@ ktxValidator::validateFile(const _tstring& filename)
 #endif
         if (doBuffer) {
             // Read entire file into a stringstream so we can seek.
-            buffer << std::cin.rdbuf();
-            buffer.seekg(0, std::ios::beg);
+            buffer << cin.rdbuf();
+            buffer.seekg(0, ios::beg);
             isp = &buffer;
         } else {
             isp = &cin;

--- a/tools/ktxsc/ktxsc.cpp
+++ b/tools/ktxsc/ktxsc.cpp
@@ -4,14 +4,7 @@
 // Copyright 2019-2020 Mark Callow
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(_WIN32)
-  // <windows.h> must appear before "scapp.h" for error-free mingw/gcc11 build.
-  // _CRT_SECURE_NO_WARNINGS must be defined before <windows.h> and <iostream>
-  // so we can't rely on the definition included by "scapp.h".
-  #define _CRT_SECURE_NO_WARNINGS
-  #define WINDOWS_LEAN_AND_MEAN
-  #include <windows.h>
-#endif
+#include "scapp.h"
 
 #include <cstdlib>
 #include <errno.h>
@@ -22,7 +15,6 @@
 #include <ktx.h>
 
 #include "argparser.h"
-#include "scapp.h"
 #include "version.h"
 
 #if defined(_MSC_VER)

--- a/utils/ktxapp.h
+++ b/utils/ktxapp.h
@@ -381,7 +381,7 @@ class ktxApp {
         cerr << endl;
     }
 
-#if 1//defined(_WIN32) && defined(DEBUG)
+#if defined(_WIN32) && defined(DEBUG)
     // For use when debugging stdin with Visual Studio which does not have a
     // "wait for executable to be launched" choice in its debugger settings.
     bool launchDebugger()

--- a/utils/ktxapp.h
+++ b/utils/ktxapp.h
@@ -381,14 +381,15 @@ class ktxApp {
         cerr << endl;
     }
 
-#if defined(_WIN32) && defined(DEBUG)
+#if 1//defined(_WIN32) && defined(DEBUG)
     // For use when debugging stdin with Visual Studio which does not have a
     // "wait for executable to be launched" choice in its debugger settings.
     bool launchDebugger()
     {
         // Get System directory, typically c:\windows\system32
         std::wstring systemDir(MAX_PATH + 1, '\0');
-        size_t nChars = GetSystemDirectoryW(&systemDir[0], systemDir.length());
+        UINT nChars = GetSystemDirectoryW(&systemDir[0],
+                                static_cast<UINT>(systemDir.length()));
         if (nChars == 0) return false; // failed to get system directory
         systemDir.resize(nChars);
 

--- a/utils/ktxapp.h
+++ b/utils/ktxapp.h
@@ -95,7 +95,7 @@ class ktxApp {
         cerr <<
             "  -h, --help    Print this usage message and exit.\n"
             "  -v, --version Print the version number of this program and exit.\n"
-#if 0 //defined(_WIN32) && defined(DEBUG)
+#if defined(_WIN32) && defined(DEBUG)
             "      --ld      Launch Visual Studio deugger at start up.\n"
 #endif
             ;
@@ -363,8 +363,10 @@ class ktxApp {
                 }
             }
         }
+#if defined(_WIN32) && defined(DEBUG)
         if (options.launchDebugger)
             launchDebugger();
+#endif
     }
 
     virtual bool processOption(argparser& parser, int opt) = 0;
@@ -386,7 +388,7 @@ class ktxApp {
     {
         // Get System directory, typically c:\windows\system32
         std::wstring systemDir(MAX_PATH + 1, '\0');
-        UINT nChars = GetSystemDirectoryW(&systemDir[0], systemDir.length());
+        size_t nChars = GetSystemDirectoryW(&systemDir[0], systemDir.length());
         if (nChars == 0) return false; // failed to get system directory
         systemDir.resize(nChars);
 

--- a/utils/ktxapp.h
+++ b/utils/ktxapp.h
@@ -6,6 +6,12 @@
 
 #include "stdafx.h"
 
+#if defined (_WIN32)
+  #define _CRT_SECURE_NO_WARNINGS
+  #define WINDOWS_LEAN_AND_MEAN
+  #include <windows.h>
+#endif
+
 #include <stdarg.h>
 #if (_MSVC_LANG >= 201703L || __cplusplus >= 201703L)
 #include <algorithm>
@@ -87,8 +93,12 @@ class ktxApp {
     virtual int main(int argc, _TCHAR* argv[]) = 0;
     virtual void usage() {
         cerr <<
-          "  -h, --help    Print this usage message and exit.\n"
-          "  -v, --version Print the version number of this program and exit.\n";
+            "  -h, --help    Print this usage message and exit.\n"
+            "  -v, --version Print the version number of this program and exit.\n"
+#if 0 //defined(_WIN32) && defined(DEBUG)
+            "      --ld      Launch Visual Studio deugger at start up.\n"
+#endif
+            ;
     };
 
   protected:
@@ -97,8 +107,9 @@ class ktxApp {
         _tstring outfile;
         int test;
         int warn;
+        int launchDebugger;
 
-        commandOptions() : test(false), warn(1) { }
+        commandOptions() : test(false), warn(1), launchDebugger(0) { }
     };
 
     ktxApp(std::string& version, std::string& defaultVersion,
@@ -259,7 +270,7 @@ class ktxApp {
         listName.erase(0, relativize ? 2 : 1);
 
         FILE *lf = nullptr;
-#ifdef _WIN32
+#if defined(_WIN32)
         _tfopen_s(&lf, listName.c_str(), "r");
 #else
         lf = _tfopen(listName.c_str(), "r");
@@ -352,6 +363,8 @@ class ktxApp {
                 }
             }
         }
+        if (options.launchDebugger)
+            launchDebugger();
     }
 
     virtual bool processOption(argparser& parser, int opt) = 0;
@@ -366,6 +379,46 @@ class ktxApp {
         cerr << endl;
     }
 
+#if defined(_WIN32) && defined(DEBUG)
+    // For use when debugging stdin with Visual Studio which does not have a
+    // "wait for executable to be launched" choice in its debugger settings.
+    bool launchDebugger()
+    {
+        // Get System directory, typically c:\windows\system32
+        std::wstring systemDir(MAX_PATH + 1, '\0');
+        UINT nChars = GetSystemDirectoryW(&systemDir[0], systemDir.length());
+        if (nChars == 0) return false; // failed to get system directory
+        systemDir.resize(nChars);
+
+        // Get process ID and create the command line
+        DWORD pid = GetCurrentProcessId();
+        std::wostringstream s;
+        s << systemDir << L"\\vsjitdebugger.exe -p " << pid;
+        std::wstring cmdLine = s.str();
+
+        // Start debugger process
+        STARTUPINFOW si;
+        ZeroMemory(&si, sizeof(si));
+        si.cb = sizeof(si);
+
+        PROCESS_INFORMATION pi;
+        ZeroMemory(&pi, sizeof(pi));
+
+        if (!CreateProcessW(NULL, &cmdLine[0], NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) return false;
+
+        // Close debugger process handles to eliminate resource leak
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+
+        // Wait for the debugger to attach
+        while (!IsDebuggerPresent()) Sleep(100);
+
+        // Stop execution so the debugger can take over
+        DebugBreak();
+        return true;
+    }
+#endif
+
     _tstring        name;
     _tstring&       version;
     _tstring&       defaultVersion;
@@ -378,6 +431,9 @@ class ktxApp {
         { "help", argparser::option::no_argument, NULL, 'h' },
         { "version", argparser::option::no_argument, NULL, 'v' },
         { "test", argparser::option::no_argument, &options.test, 1},
+#if defined(_WIN32) && defined(DEBUG)
+        { "ld", argparser::option::no_argument, &options.launchDebugger, 1},
+#endif
         // -NSDocumentRevisionsDebugMode YES is appended to the end
         // of the command by Xcode when debugging and "Allow debugging when
         // using document Versions Browser" is checked in the scheme. It

--- a/utils/stdafx.h
+++ b/utils/stdafx.h
@@ -5,7 +5,12 @@
 
 #pragma once
 
-#define _CRT_SECURE_NO_WARNINGS // For _WIN32. Must be before <stdio.h>.
+#if defined(_WIN32)
+  // _CRT_SECURE_NO_WARNINGS must be defined before <windows.h>,
+  // <stdio.h> and and <iostream>
+  #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include <assert.h>
 #include <stdio.h>
 #ifdef _WIN32


### PR DESCRIPTION
Was an unnoticed problem until Cygwin/MSYS2/Git for Windows started mimicing windows pipes in 3.4.x.