### PR TITLE
Make other_include a SYSTEM include for loadtests

### DIFF
--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -111,10 +111,15 @@ PUBLIC
     appfwSDL
     $<TARGET_PROPERTY:ktx,INCLUDE_DIRECTORIES>
     ${PROJECT_SOURCE_DIR}/lib
-    ${PROJECT_SOURCE_DIR}/other_include
     ${PROJECT_SOURCE_DIR}/utils
     common
     geom
+)
+
+target_include_directories(
+    appfwSDL
+SYSTEM PUBLIC
+    ${PROJECT_SOURCE_DIR}/other_include
 )
 
 if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "OpenGL")
@@ -136,11 +141,16 @@ if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "OpenGL")
   target_include_directories(
       GLAppSDL
   PUBLIC
-      ${PROJECT_SOURCE_DIR}/other_include
-      appfwSDL
+      $<TARGET_PROPERTY:appfwSDL,INCLUDE_DIRECTORIES>
       common
       glloadtests
       glloadtests/utils
+  )
+
+  target_include_directories(
+      GLAppSDL
+  SYSTEM PRIVATE
+      $<TARGET_PROPERTY:appfwSDL,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
   )
 
   if(OPENGL_FOUND)

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -22,10 +22,15 @@ function( create_gl_target target version sources common_resources test_images
     target_include_directories(
         ${target}
     PRIVATE
-        $<TARGET_PROPERTY:appfwSDL,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:GLAppSDL,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:ktx,INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:objUtil,INTERFACE_INCLUDE_DIRECTORIES>
+    )
+
+    target_include_directories(
+        ${target}
+    SYSTEM PRIVATE
+          ${PROJECT_SOURCE_DIR}/other_include
     )
 
     set_target_properties(${target} PROPERTIES

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -175,6 +175,11 @@ PRIVATE
     vkloadtests/utils
 )
 
+target_include_directories(vkloadtests
+  SYSTEM PRIVATE
+      ${PROJECT_SOURCE_DIR}/other_include
+)
+
 target_link_libraries(vkloadtests
     ktx
     ${KTX_ZLIB_LIBRARIES}


### PR DESCRIPTION
to stop warnings in assimp and other headers. Clang 16.0.5 has a new warning it raises on some of the assimp headers.