### PR TITLE
Fixing vendor-specific/tied memory property flag detection

### DIFF
--- a/include/ktxvulkan.h
+++ b/include/ktxvulkan.h
@@ -251,6 +251,13 @@ KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture_VkUpload(ktxTexture* texture, ktxVulkanDeviceInfo* vdi,
                     ktxVulkanTexture *vkTexture);
 KTX_API KTX_error_code KTX_APIENTRY
+ktxTexture1_VkUploadEx_WithSuballocator(ktxTexture1* This, ktxVulkanDeviceInfo* vdi,
+                                        ktxVulkanTexture* vkTexture,
+                                        VkImageTiling tiling,
+                                        VkImageUsageFlags usageFlags,
+                                        VkImageLayout finalLayout,
+                                        ktxVulkanTexture_subAllocatorCallbacks* subAllocatorCallbacks);
+KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture1_VkUploadEx(ktxTexture1* This, ktxVulkanDeviceInfo* vdi,
                        ktxVulkanTexture* vkTexture,
                        VkImageTiling tiling,
@@ -259,6 +266,13 @@ ktxTexture1_VkUploadEx(ktxTexture1* This, ktxVulkanDeviceInfo* vdi,
 KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture1_VkUpload(ktxTexture1* texture, ktxVulkanDeviceInfo* vdi,
                     ktxVulkanTexture *vkTexture);
+KTX_API KTX_error_code KTX_APIENTRY
+ktxTexture2_VkUploadEx_WithSuballocator(ktxTexture2* This, ktxVulkanDeviceInfo* vdi,
+                                        ktxVulkanTexture* vkTexture,
+                                        VkImageTiling tiling,
+                                        VkImageUsageFlags usageFlags,
+                                        VkImageLayout finalLayout,
+                                        ktxVulkanTexture_subAllocatorCallbacks* subAllocatorCallbacks);
 KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture2_VkUploadEx(ktxTexture2* This, ktxVulkanDeviceInfo* vdi,
                        ktxVulkanTexture* vkTexture,

--- a/lib/vkloader.c
+++ b/lib/vkloader.c
@@ -1474,6 +1474,27 @@ ktxTexture_VkUpload(ktxTexture* texture, ktxVulkanDeviceInfo* vdi,
  * @~English
  * @brief Create a Vulkan image object from a ktxTexture1 object.
  *
+ * This simplly calls ktxTexture_VkUploadEx_WithSuballocator.
+ *
+ * @copydetails ktxTexture::ktxTexture_VkUploadEx_WithSuballocator
+ */
+KTX_error_code
+ktxTexture1_VkUploadEx_WithSuballocator(ktxTexture1* This, ktxVulkanDeviceInfo* vdi,
+                                        ktxVulkanTexture* vkTexture,
+                                        VkImageTiling tiling,
+                                        VkImageUsageFlags usageFlags,
+                                        VkImageLayout finalLayout,
+                                        ktxVulkanTexture_subAllocatorCallbacks* subAllocatorCallbacks)
+{
+    return ktxTexture_VkUploadEx_WithSuballocator(ktxTexture(This), vdi, vkTexture,
+                                                  tiling, usageFlags, finalLayout,
+                                                  subAllocatorCallbacks);
+}
+
+/** @memberof ktxTexture1
+ * @~English
+ * @brief Create a Vulkan image object from a ktxTexture1 object.
+ *
  * This simplly calls ktxTexture_VkUploadEx.
  *
  * @copydetails ktxTexture::ktxTexture_VkUploadEx
@@ -1508,6 +1529,27 @@ ktxTexture1_VkUpload(ktxTexture1* texture, ktxVulkanDeviceInfo* vdi,
                                  VK_IMAGE_TILING_OPTIMAL,
                                  VK_IMAGE_USAGE_SAMPLED_BIT,
                                  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+}
+
+/** @memberof ktxTexture2
+ * @~English
+ * @brief Create a Vulkan image object from a ktxTexture2 object.
+ *
+ * This simplly calls ktxTexture_VkUploadEx_WithSuballocator.
+ *
+ * @copydetails ktxTexture::ktxTexture_VkUploadEx_WithSuballocator
+ */
+KTX_error_code
+ktxTexture2_VkUploadEx_WithSuballocator(ktxTexture2* This, ktxVulkanDeviceInfo* vdi,
+                                        ktxVulkanTexture* vkTexture,
+                                        VkImageTiling tiling,
+                                        VkImageUsageFlags usageFlags,
+                                        VkImageLayout finalLayout,
+                                        ktxVulkanTexture_subAllocatorCallbacks* subAllocatorCallbacks)
+{
+    return ktxTexture_VkUploadEx_WithSuballocator(ktxTexture(This), vdi, vkTexture,
+                                                  tiling, usageFlags, finalLayout,
+                                                  subAllocatorCallbacks);
 }
 
 /** @memberof ktxTexture2

--- a/tests/loadtests/vkloadtests/Texture.cpp
+++ b/tests/loadtests/vkloadtests/Texture.cpp
@@ -122,7 +122,7 @@ Texture::Texture(VulkanContext& vkctx,
     if (useSubAlloc == UseSuballocator::Yes)
     {
         VkInstance vkInst = vkctx.instance;
-        VMA_CALLBACKS::InitVMA(vdi.physicalDevice, vdi.device, vkInst);
+        VMA_CALLBACKS::InitVMA(vdi.physicalDevice, vdi.device, vkInst, vdi.deviceMemoryProperties);
 
         ktxresult = ktxTexture_VkUploadEx_WithSuballocator(kTexture, &vdi, &texture,
                                                            static_cast<VkImageTiling>(tiling),

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
@@ -45,7 +45,8 @@ namespace VMA_CALLBACKS
     std::mt19937_64 mt64;
     VkPhysicalDeviceMemoryProperties cachedDevMemProps;
 
-    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance, VkPhysicalDeviceMemoryProperties& devMemProps)
+    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance, 
+                 VkPhysicalDeviceMemoryProperties& devMemProps)
     {
         cachedDevMemProps = devMemProps;
 

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
@@ -43,9 +43,12 @@ namespace VMA_CALLBACKS
 {
     VmaAllocator vmaAllocator;
     std::mt19937_64 mt64;
+    VkPhysicalDeviceMemoryProperties cachedDevMemProps;
 
-    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance)
+    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance, VkPhysicalDeviceMemoryProperties& devMemProps)
     {
+        cachedDevMemProps = devMemProps;
+
         VmaVulkanFunctions vulkanFunctions = {};
         vulkanFunctions.vkGetInstanceProcAddr = &vkGetInstanceProcAddr;
         vulkanFunctions.vkGetDeviceProcAddr = &vkGetDeviceProcAddr;
@@ -75,7 +78,8 @@ namespace VMA_CALLBACKS
     {
         uint64_t allocId = mt64();
         VmaAllocationCreateInfo pCreateInfo = {};
-        if (allocInfo->memoryTypeIndex == 8)
+        if ((cachedDevMemProps.memoryTypes[allocInfo->memoryTypeIndex].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ||
+            (cachedDevMemProps.memoryTypes[allocInfo->memoryTypeIndex].propertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
         {
             pCreateInfo.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
             pCreateInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
@@ -21,7 +21,7 @@
 
 namespace VMA_CALLBACKS
 {
-    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance);
+    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance, VkPhysicalDeviceMemoryProperties& devMemProps);
     void DestroyVMA();
     uint64_t AllocMemCWrapper(VkMemoryAllocateInfo* allocInfo, VkMemoryRequirements* memReq, uint64_t* numPages);
     VkResult BindBufferMemoryCWrapper(VkBuffer buffer, uint64_t allocId);

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
@@ -21,7 +21,8 @@
 
 namespace VMA_CALLBACKS
 {
-    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance, VkPhysicalDeviceMemoryProperties& devMemProps);
+    void InitVMA(VkPhysicalDevice& physicalDevice, VkDevice& device, VkInstance& instance, 
+                 VkPhysicalDeviceMemoryProperties& devMemProps);
     void DestroyVMA();
     uint64_t AllocMemCWrapper(VkMemoryAllocateInfo* allocInfo, VkMemoryRequirements* memReq, uint64_t* numPages);
     VkResult BindBufferMemoryCWrapper(VkBuffer buffer, uint64_t allocId);


### PR DESCRIPTION
Fixing vendor-specific/tied memory property flag detection for `vkloadtests`'s VMA wrapper.