### PR TITLE
Make test case names consistent

### DIFF
--- a/tests/ktx2check-tests.cmake
+++ b/tests/ktx2check-tests.cmake
@@ -4,20 +4,20 @@
 # Copyright 2020 Andreas Atteneder
 # SPDX-License-Identifier: Apache-2.0
 
-add_test( NAME ktx2check-test-help
+add_test( NAME ktx2check-test.help
     COMMAND ktx2check --help
 )
 set_tests_properties(
-    ktx2check-test-help
+    ktx2check-test.help
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Usage: ktx2check"
 )
 
-add_test( NAME ktx2check-test-version
+add_test( NAME ktx2check-test.version
     COMMAND ktx2check --version
 )
 set_tests_properties(
-    ktx2check-test-version
+    ktx2check-test.version
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^ktx2check v[0-9][0-9\\.]+"
 )
@@ -41,34 +41,34 @@ PROPERTIES
 # when the PASS RE fails to match we are guaranteed the exit code
 # test will fail. When it does match the exit code is not checked.
 
-add_test( NAME ktx2check-test-foobar
+add_test( NAME ktx2check-test.foobar
     COMMAND ktx2check --foobar
 )
 set_tests_properties(
-    ktx2check-test-foobar
+    ktx2check-test.foobar
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Usage: ktx2check"
 )
-add_test( NAME ktx2check-test-foobar-exit-code
+add_test( NAME ktx2check-test.foobar-exit-code
     COMMAND ktx2check --foobar
 )
 set_tests_properties(
-    ktx2check-test-foobar-exit-code
+    ktx2check-test.foobar-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )
 
-add_test( NAME ktx2check-test-fail-when-last-file-valid
+add_test( NAME ktx2check-test.fail-when-last-file-valid
     COMMAND ktx2check ../badktx2/bad_typesize.ktx2 astc_ldr_6x6_arraytex_7.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 set_tests_properties(
-     ktx2check-test-fail-when-last-file-valid
+     ktx2check-test.fail-when-last-file-valid
 PROPERTIES
     WILL_FAIL TRUE
 )
 
-add_test( NAME ktx2check-test-all
+add_test( NAME ktx2check-test.all
     # Invoke via sh workaround, since CMake puts asterisk in quotes
     # otherwise ( "*.ktx2" )
     COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:ktx2check> *.ktx2"
@@ -76,7 +76,7 @@ add_test( NAME ktx2check-test-all
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME ktx2check-test-all-quiet
+add_test( NAME ktx2check-test.all-quiet
     # Invoke via sh workaround, since CMake puts asterisk in quotes
     # otherwise ( "*.ktx2" )
     COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:ktx2check> --quiet *.ktx2"
@@ -84,96 +84,96 @@ add_test( NAME ktx2check-test-all-quiet
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 set_tests_properties(
-    ktx2check-test-all-quiet
+    ktx2check-test.all-quiet
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^$"
 )
 
-add_test( NAME ktx2check-test-stdin-read
+add_test( NAME ktx2check-test.stdin-read
     COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:ktx2check> < color_grid_uastc_zstd.ktx2
 "
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME ktx2check-test-pipe-read
+add_test( NAME ktx2check-test.pipe-read
     COMMAND ${BASH_EXECUTABLE} -c "cat color_grid_uastc_zstd.ktx2 | $<TARGET_FILE:ktx2check>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME ktx2check-test-invalid-face-count-and-padding
+add_test( NAME ktx2check-test.invalid-face-count-and-padding
     COMMAND ktx2check invalid_face_count_and_padding.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 
-add_test( NAME ktx2check-test-invalid-face-count-and-padding-quiet
+add_test( NAME ktx2check-test.invalid-face-count-and-padding-quiet
     COMMAND ktx2check --quiet invalid_face_count_and_padding.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
-add_test( NAME ktx2check-test-invalid-face-count-and-padding-quiet-exit-code
+add_test( NAME ktx2check-test.invalid-face-count-and-padding-quiet-exit-code
     COMMAND ktx2check --quiet invalid_face_count_and_padding.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 
-add_test( NAME ktx2check-test-incorrect-mip-layout-and-padding
+add_test( NAME ktx2check-test.incorrect-mip-layout-and-padding
     COMMAND ktx2check incorrect_mip_layout_and_padding.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 
-add_test( NAME ktx2check-test-incorrect-mip-layout-and-padding-quiet
+add_test( NAME ktx2check-test.incorrect-mip-layout-and-padding-quiet
     COMMAND ktx2check --quiet incorrect_mip_layout_and_padding.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
-add_test( NAME ktx2check-test-incorrect-mip-layout-and-padding-quiet-exit-code
+add_test( NAME ktx2check-test.incorrect-mip-layout-and-padding-quiet-exit-code
     COMMAND ktx2check incorrect_mip_layout_and_padding.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 
-add_test( NAME ktx2check-test-bad-typesize
+add_test( NAME ktx2check-test.bad-typesize
     COMMAND ktx2check bad_typesize.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 set_tests_properties(
-    ktx2check-test-bad-typesize
+    ktx2check-test.bad-typesize
 PROPERTIES
     PASS_REGULAR_EXPRESSION "ERROR: typeSize, 1, does not match data described by the DFD."
 )
-add_test( NAME ktx2check-test-bad-typesize-exit-code
+add_test( NAME ktx2check-test.bad-typesize-exit-code
     COMMAND ktx2check bad_typesize.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 
-add_test( NAME ktx2check-test-no-nul-on-value
+add_test( NAME ktx2check-test.no-nul-on-value
     COMMAND ktx2check no_nul_on_kvd_val.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 set_tests_properties(
-    ktx2check-test-no-nul-on-value
+    ktx2check-test.no-nul-on-value
 PROPERTIES
     PASS_REGULAR_EXPRESSION "WARNING: KTXswizzle value missing encouraged NUL termination."
 )
-add_test( NAME ktx2check-test-no-nul-on-value-exit-code
+add_test( NAME ktx2check-test.no-nul-on-value-exit-code
     COMMAND ktx2check no_nul_on_kvd_val.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
-add_test( NAME ktx2check-test-no-nul-on-value-warn-as-error-exit-code
+add_test( NAME ktx2check-test.no-nul-on-value-warn-as-error-exit-code
     COMMAND ktx2check -w no_nul_on_kvd_val.ktx2
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/badktx2
 )
 
 set_tests_properties(
-    ktx2check-test-invalid-face-count-and-padding-quiet
-    ktx2check-test-incorrect-mip-layout-and-padding-quiet
+    ktx2check-test.invalid-face-count-and-padding-quiet
+    ktx2check-test.incorrect-mip-layout-and-padding-quiet
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^$"
 )
 
 set_tests_properties(
-    ktx2check-test-bad-typesize-exit-code
-    ktx2check-test-invalid-face-count-and-padding
-    ktx2check-test-invalid-face-count-and-padding-quiet-exit-code
-    ktx2check-test-incorrect-mip-layout-and-padding
-    ktx2check-test-incorrect-mip-layout-and-padding-quiet-exit-code
-    ktx2check-test-no-nul-on-value-warn-as-error-exit-code
+    ktx2check-test.bad-typesize-exit-code
+    ktx2check-test.invalid-face-count-and-padding
+    ktx2check-test.invalid-face-count-and-padding-quiet-exit-code
+    ktx2check-test.incorrect-mip-layout-and-padding
+    ktx2check-test.incorrect-mip-layout-and-padding-quiet-exit-code
+    ktx2check-test.no-nul-on-value-warn-as-error-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )

--- a/tests/ktx2ktx2-tests.cmake
+++ b/tests/ktx2ktx2-tests.cmake
@@ -4,20 +4,20 @@
 # Copyright 2022 Mark Callow
 # SPDX-License-Identifier: Apache-2.0
 
-add_test( NAME ktx2ktx2-test-help
+add_test( NAME ktx2ktx2-test.help
     COMMAND ktx2ktx2 --help
 )
 set_tests_properties(
-    ktx2ktx2-test-help
+    ktx2ktx2-test.help
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Usage: ktx2ktx2"
 )
 
-add_test( NAME ktx2ktx2-test-version
+add_test( NAME ktx2ktx2-test.version
     COMMAND ktx2ktx2 --version
 )
 set_tests_properties(
-    ktx2ktx2-test-version
+    ktx2ktx2-test.version
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^ktx2ktx2 v[0-9][0-9\\.]+"
 )
@@ -26,65 +26,65 @@ PROPERTIES
 #
 # See comment under the same title in ./ktx2check-tests.cmake.
 
-add_test( NAME ktx2ktx2-test-foobar
+add_test( NAME ktx2ktx2-test.foobar
     COMMAND ktx2ktx2 --foobar
 )
 set_tests_properties(
-    ktx2ktx2-test-foobar
+    ktx2ktx2-test.foobar
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Usage: ktx2ktx2"
 )
-add_test( NAME ktx2ktx2-test-foobar-exit-code
+add_test( NAME ktx2ktx2-test.foobar-exit-code
     COMMAND ktx2ktx2 --foobar
 )
 set_tests_properties(
-    ktx2ktx2-test-foobar-exit-code
+    ktx2ktx2-test.foobar-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )
 
-add_test( NAME ktx2ktx2-test-many-in-one-out
+add_test( NAME ktx2ktx2-test.many-in-one-out
     COMMAND ktx2ktx2 -o foo a.ktx b.ktx c.ktx
 )
 set_tests_properties(
-    ktx2ktx2-test-many-in-one-out
+    ktx2ktx2-test.many-in-one-out
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Can't use -o when there are multiple infiles."
 )
 
-add_test( NAME ktx2ktx2-test-many-in-one-out-exit-code
+add_test( NAME ktx2ktx2-test.many-in-one-out-exit-code
     COMMAND ktx2ktx2 -o foo a.ktx b.ktx c.ktx
 )
 set_tests_properties(
-    ktx2ktx2-test-many-in-one-out-exit-code
+    ktx2ktx2-test.many-in-one-out-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )
 
 set( IMG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/testimages" )
 
-add_test( NAME ktx2ktx2-test-ktx2-in
+add_test( NAME ktx2ktx2-test.ktx2-in
     COMMAND ktx2ktx2 -o foo CesiumLogoFlat.ktx2
     WORKING_DIRECTORY ${IMG_DIR}
 )
 set_tests_properties(
-    ktx2ktx2-test-ktx2-in
+    ktx2ktx2-test.ktx2-in
 PROPERTIES
     PASS_REGULAR_EXPRESSION ".* is not a KTX v1 file."
 )
-add_test( NAME ktx2ktx2-test-ktx2-in-exit-code
+add_test( NAME ktx2ktx2-test.ktx2-in-exit-code
     COMMAND ktx2ktx2 -o foo CesiumLogoFlat.ktx2
     WORKING_DIRECTORY ${IMG_DIR}
 )
 set_tests_properties(
-    ktx2ktx2-test-ktx2-in-exit-code
+    ktx2ktx2-test.ktx2-in-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )
 
 function( cnvrtcmpktx test_name reference source args )
     set( workfile ktx2ktx2.${reference} )
-    add_test( NAME ktx2ktx2-cnvrt-${test_name}
+    add_test( NAME ktx2ktx2-test.cnvrt-${test_name}
         COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:ktx2ktx2> --test ${args} -o ${workfile} ${source} && diff ${reference} ${workfile} && rm ${workfile}"
         WORKING_DIRECTORY ${IMG_DIR}
     )
@@ -95,7 +95,7 @@ function( cnvrtcmpktx_implied_out test_name base_source args )
     set( reference ${base_source}.ktx2 )
     set( worksource ktx2ktx2.ip.${source} )
     set( workfile ktx2ktx2.ip.${reference} )
-    add_test( NAME ktx2ktx2-cnvrt-implied-out-${test_name}
+    add_test( NAME ktx2ktx2-test.cnvrt-implied-out-${test_name}
         COMMAND ${BASH_EXECUTABLE} -c "cp ${source} ${worksource} && $<TARGET_FILE:ktx2ktx2> --test ${args} ${worksource} && rm ${worksource} && diff ${reference} ${workfile} && rm ${workfile}"
         WORKING_DIRECTORY ${IMG_DIR}
     )

--- a/tests/ktxsc-tests.cmake
+++ b/tests/ktxsc-tests.cmake
@@ -7,20 +7,20 @@
 # toktx shares a common scapp class with ktxsc so the toktx tests suffice
 # for testing actual compression.
 
-add_test( NAME ktxsc-test-help
+add_test( NAME ktxsc-test.help
     COMMAND ktxsc --help
 )
 set_tests_properties(
-    ktxsc-test-help
+    ktxsc-test.help
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Usage: ktxsc"
 )
 
-add_test( NAME ktxsc-test-version
+add_test( NAME ktxsc-test.version
     COMMAND ktxsc --version
 )
 set_tests_properties(
-    ktxsc-test-version
+    ktxsc-test.version
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^ktxsc v[0-9][0-9\\.]+"
 )
@@ -29,65 +29,65 @@ PROPERTIES
 #
 # See comment under the same title in ./ktx2check-tests.cmake.
 
-add_test( NAME ktxsc-test-foobar
+add_test( NAME ktxsc-test.foobar
     COMMAND ktxsc --foobar
 )
 set_tests_properties(
-    ktxsc-test-foobar
+    ktxsc-test.foobar
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Usage: ktxsc"
 )
-add_test( NAME ktxsc-test-foobar-exit-code
+add_test( NAME ktxsc-test.foobar-exit-code
     COMMAND ktxsc --foobar
 )
 set_tests_properties(
-    ktxsc-test-foobar-exit-code
+    ktxsc-test.foobar-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )
 
-add_test( NAME ktxsc-test-many-in-one-out
+add_test( NAME ktxsc-test.many-in-one-out
     COMMAND ktxsc -o foo a.ktx2 b.ktx2 c.ktx2
 )
 set_tests_properties(
-    ktxsc-test-many-in-one-out
+    ktxsc-test.many-in-one-out
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^Can't use -o when there are multiple infiles."
 )
 
-add_test( NAME ktxsc-test-many-in-one-out-exit-code
+add_test( NAME ktxsc-test.many-in-one-out-exit-code
     COMMAND ktxsc -o foo a.ktx2 b.ktx2 c.ktx2
 )
 set_tests_properties(
-    ktxsc-test-many-in-one-out-exit-code
+    ktxsc-test.many-in-one-out-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )
 
 set( IMG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/testimages" )
 
-add_test( NAME ktxsc-test-ktx1-in
+add_test( NAME ktxsc-test.ktx1-in
     COMMAND ktxsc --zcmp 5 -o foo orient-up-metadata.ktx
     WORKING_DIRECTORY "${IMG_DIR}"
 )
 set_tests_properties(
-    ktxsc-test-ktx1-in
+    ktxsc-test.ktx1-in
 PROPERTIES
     PASS_REGULAR_EXPRESSION ".* is not a KTX v2 file."
 )
-add_test( NAME ktxsc-test-ktx1-in-exit-code
+add_test( NAME ktxsc-test.ktx1-in-exit-code
     COMMAND ktxsc --zcmp 5 -o foo orient-up-metadata.ktx
     WORKING_DIRECTORY ${IMG_DIR}
 )
 set_tests_properties(
-    ktxsc-test-ktx1-in-exit-code
+    ktxsc-test.ktx1-in-exit-code
 PROPERTIES
     WILL_FAIL TRUE
 )
 
 function( sccmpktx test_name reference source args )
     set( workfile ktxsc.${reference} )
-    add_test( NAME ktxsc-${test_name}
+    add_test( NAME ktxsc-test.${test_name}
         COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:ktxsc> --test ${args} -o ${workfile} ${source} && diff ${reference} ${workfile} && rm ${workfile}"
         WORKING_DIRECTORY ${IMG_DIR}
     )
@@ -95,7 +95,7 @@ endfunction()
 
 function( sccmpktxinplacecurdir test_name reference source args )
     set( workfile ktxsc.ip1.${reference} )
-    add_test( NAME ktxsc-inplace-curdir-${test_name}
+    add_test( NAME ktxsc-test.inplace-curdir-${test_name}
         COMMAND ${BASH_EXECUTABLE} -c "cp ${source} ${workfile} && $<TARGET_FILE:ktxsc> --test ${args} ${workfile} && diff ${reference} ${workfile} && rm ${workfile}"
         WORKING_DIRECTORY ${IMG_DIR}
     )
@@ -103,7 +103,7 @@ endfunction()
 
 function( sccmpktxinplacediffdir test_name reference source args )
     set( workfile ktxsc.ip2.${reference} )
-    add_test( NAME ktxsc-inplace-diffdir-${test_name}
+    add_test( NAME ktxsc-test.inplace-diffdir-${test_name}
         COMMAND ${BASH_EXECUTABLE} -c "cp ${source} ${workfile} && pushd ../.. && $<TARGET_FILE:ktxsc> --test ${args} ${IMG_DIR}/${workfile} && popd && diff ${reference} ${workfile} && rm ${workfile}"
         WORKING_DIRECTORY ${IMG_DIR}
     )

--- a/tests/streamtests/CMakeLists.txt
+++ b/tests/streamtests/CMakeLists.txt
@@ -36,7 +36,7 @@ PRIVATE
 )
 
 gtest_discover_tests( streamtests
-    TEST_PREFIX streamtest
+    TEST_PREFIX streamtest.
     # With the 5s default we get periodic timeouts on Travis & GitHub CI.
     DISCOVERY_TIMEOUT 20
     EXTRA_ARGS "${PROJECT_SOURCE_DIR}/tests/testimages/"

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -97,11 +97,11 @@ target_link_libraries(
 )
 
 gtest_discover_tests(unittests
-    TEST_PREFIX unittest
+    TEST_PREFIX unittest.
     # With the 5s default we get periodic timeouts on Travis & GitHub CI.
     DISCOVERY_TIMEOUT 20
 )
 gtest_discover_tests(texturetests
-    TEST_PREFIX texturetest
+    TEST_PREFIX texturetest.
     DISCOVERY_TIMEOUT 20
 )

--- a/tests/toktx-tests.cmake
+++ b/tests/toktx-tests.cmake
@@ -1,143 +1,143 @@
 # Copyright 2020 Andreas Atteneder
 # SPDX-License-Identifier: Apache-2.0
 
-add_test( NAME toktx-test-help
+add_test( NAME toktx-test.help
     COMMAND toktx --help
 )
 
-add_test( NAME toktx-test-version
+add_test( NAME toktx-test.version
     COMMAND toktx --version
 )
 set_tests_properties(
-    toktx-test-version
+    toktx-test.version
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^toktx v[0-9\\.]+"
 )
 
-add_test( NAME toktx-test-foobar
+add_test( NAME toktx-test.foobar
     COMMAND toktx --foobar
 )
 
-add_test( NAME toktx-automipmap-mipmaps
+add_test( NAME toktx-test.automipmap-mipmaps
     COMMAND toktx --automipmap --mipmaps a b
 )
-add_test( NAME toktx-alpha
+add_test( NAME toktx-test.alpha
     COMMAND toktx --alpha a b
 )
-add_test( NAME toktx-luminance
+add_test( NAME toktx-test.luminance
     COMMAND toktx --luminance a b
 )
-add_test( NAME toktx-zcmp-bcmp
+add_test( NAME toktx-test.zcmp-bcmp
     COMMAND toktx --zcmp --bcmp a b
 )
-add_test( NAME toktx-bcmp-uastc
+add_test( NAME toktx-test.bcmp-uastc
     COMMAND toktx --bcmp --uastc a b
 )
-add_test( NAME toktx-scale-resize
+add_test( NAME toktx-test.scale-resize
     COMMAND toktx --scale 0.5 --resize 10x40 a b
 )
-add_test( NAME toktx-mipmap-resize
+add_test( NAME toktx-test.mipmap-resize
     COMMAND toktx --mipmap --resize 10x40 a b c
 )
-add_test( NAME toktx-only-max-endpoints
+add_test( NAME toktx-test.only-max-endpoints
     COMMAND toktx --max_endpoints 5000 a b
 )
-add_test( NAME toktx-only-max-selectors
+add_test( NAME toktx-test.only-max-selectors
     COMMAND toktx --max_selectors 6000 a b
 )
 
-add_test( NAME toktx-swizzle-gt-4
+add_test( NAME toktx-test.swizzle-gt-4
     COMMAND toktx --swizzle rgbargba a b
 )
 
-add_test( NAME toktx-invalid-swizzle-char
+add_test( NAME toktx-test.invalid-swizzle-char
     COMMAND toktx --swizzle rrrh a b
 )
 
-add_test( NAME toktx-invalid-target-type
+add_test( NAME toktx-test.invalid-target-type
     COMMAND toktx --target_type RGBH a b
 )
 
-add_test( NAME toktx-set-oetf-second-file-no-error
+add_test( NAME toktx-test.set-oetf-second-file-no-error
     COMMAND toktx --lower_left_maps_to_s0t0 --mipmap --nometadata --assign_oetf linear -- - ../srcimages/level0.ppm ../srcimages/level1.ppm ../srcimages/level2.ppm ../srcimages/level3.ppm ../srcimages/level4.ppm ../srcimages/level5.ppm ../srcimages/level6.ppm
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME toktx-convert-oetf-second-file-no-error
+add_test( NAME toktx-test.convert-oetf-second-file-no-error
     COMMAND toktx --lower_left_maps_to_s0t0 --mipmap --nometadata --convert_oetf linear -- - ../srcimages/level0.ppm ../srcimages/level1.ppm ../srcimages/level2.ppm ../srcimages/level3.ppm ../srcimages/level4.ppm ../srcimages/level5.ppm ../srcimages/level6.ppm
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME toktx-change-target-type-second-file-no-error
+add_test( NAME toktx-test.change-target-type-second-file-no-error
     COMMAND toktx --lower_left_maps_to_s0t0 --mipmap --nometadata --target_type RGBA -- - ../srcimages/level0.ppm ../srcimages/level1.ppm ../srcimages/level2.ppm ../srcimages/level3.ppm ../srcimages/level4.ppm ../srcimages/level5.ppm ../srcimages/level6.ppm
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME toktx-different-colortype-second-file-error
+add_test( NAME toktx-test.different-colortype-second-file-error
     COMMAND toktx --lower_left_maps_to_s0t0 --mipmap --nometadata -- - ../srcimages/level0.ppm ../srcimages/level1-alpha.pam ../srcimages/level2.ppm ../srcimages/level3.ppm ../srcimages/level4.ppm ../srcimages/level5.ppm ../srcimages/level6.ppm
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME toktx-different-colortype-second-file-warning
+add_test( NAME toktx-test.different-colortype-second-file-warning
     COMMAND toktx --lower_left_maps_to_s0t0 --mipmap --nometadata --target_type RGBA -- - ../srcimages/level0.ppm ../srcimages/level1-alpha.pam ../srcimages/level2.ppm ../srcimages/level3.ppm ../srcimages/level4.ppm ../srcimages/level5.ppm ../srcimages/level6.ppm
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 
-add_test( NAME toktx-depth-layers
+add_test( NAME toktx-test.depth-layers
     COMMAND toktx --depth 4 --layers 4 a b c d e
 )
 
-add_test( NAME toktx-depth-genmipmap
+add_test( NAME toktx-test.depth-genmipmap
     COMMAND toktx --test --depth 7 --genmipmap --t2 3dtex_7_mipmap_reference_u.ktx2 ../srcimages/red16.png ../srcimages/orange16.png ../srcimages/yellow16.png ../srcimages/green16.png ../srcimages/blue16.png ../srcimages/indigo16.png ../srcimages/violet16.png
 )
 
-add_test( NAME toktx-layers-lt-one
+add_test( NAME toktx-test.layers-lt-one
     COMMAND toktx --layers 0 a b
 )
 
 set_tests_properties(
-    toktx-test-foobar
-    toktx-automipmap-mipmaps
-    toktx-alpha
-    toktx-luminance
-    toktx-zcmp-bcmp
-    toktx-bcmp-uastc
-    toktx-scale-resize
-    toktx-mipmap-resize
-    toktx-only-max-endpoints
-    toktx-only-max-selectors
-    toktx-swizzle-gt-4
-    toktx-invalid-swizzle-char
-    toktx-invalid-target-type
-    toktx-different-colortype-second-file-error
-    toktx-depth-layers
-    toktx-depth-genmipmap
-    toktx-layers-lt-one
+    toktx-test.foobar
+    toktx-test.automipmap-mipmaps
+    toktx-test.alpha
+    toktx-test.luminance
+    toktx-test.zcmp-bcmp
+    toktx-test.bcmp-uastc
+    toktx-test.scale-resize
+    toktx-test.mipmap-resize
+    toktx-test.only-max-endpoints
+    toktx-test.only-max-selectors
+    toktx-test.swizzle-gt-4
+    toktx-test.invalid-swizzle-char
+    toktx-test.invalid-target-type
+    toktx-test.different-colortype-second-file-error
+    toktx-test.depth-layers
+    toktx-test.depth-genmipmap
+    toktx-test.layers-lt-one
 PROPERTIES
     WILL_FAIL TRUE
 )
 
 set_tests_properties(
-    toktx-different-colortype-second-file-warning
+    toktx-test.different-colortype-second-file-warning
 PROPERTIES
     PASS_REGULAR_EXPRESSION "^toktx warning! Image in ../srcimages/level1-alpha.pam\\(0,0\\) has a different component count"
 )
 
 function( gencmpktx test_name reference source args env files )
     if(files)
-        add_test( NAME toktx-cmp-${test_name}
+        add_test( NAME toktx-test.cmp-${test_name}
             COMMAND ${BASH_EXECUTABLE} -c "printf \"${files}\" > ${source} && $<TARGET_FILE:toktx> --test ${args} toktx.${reference} @${source} && diff ${reference} toktx.${reference} && rm toktx.${reference}; rm ${source}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
         )
     else()
-        add_test( NAME toktx-cmp-${test_name}
+        add_test( NAME toktx-test.cmp-${test_name}
             COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:toktx> --test ${args} toktx.${reference} ${source} && diff ${reference} toktx.${reference} && rm toktx.${reference}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
         )
     endif()
 
     set_tests_properties(
-        toktx-cmp-${test_name}
+        toktx-test.cmp-${test_name}
     PROPERTIES
         ENVIRONMENT TOKTX_OPTIONS=${env}
     )
@@ -221,12 +221,12 @@ gencmpktx(
     "../srcimages/level0.ppm\\n../srcimages/level1.ppm\\n../srcimages/level2.ppm\\n../srcimages/level3.ppm\\n../srcimages/level4.ppm\\n../srcimages/level5.ppm\\n../srcimages/level6.ppm"
 )
 
-add_test( NAME toktx-cmp-rgb-reference-2
-    COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:toktx> --nometadata - ../srcimages/rgb.ppm > toktx-cmp-rgb-reference-2.ktx && diff rgb-reference.ktx toktx-cmp-rgb-reference-2.ktx; rm toktx-cmp-rgb-reference-2.ktx"
+add_test( NAME toktx-test.cmp-rgb-reference-2
+    COMMAND ${BASH_EXECUTABLE} -c "$<TARGET_FILE:toktx> --nometadata - ../srcimages/rgb.ppm > toktx-test.cmp-rgb-reference-2.ktx && diff rgb-reference.ktx toktx-test.cmp-rgb-reference-2.ktx; rm toktx-test.cmp-rgb-reference-2.ktx"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testimages
 )
 set_tests_properties(
-    toktx-cmp-rgb-reference-2
+    toktx-test.cmp-rgb-reference-2
 PROPERTIES
     ENVIRONMENT TOKTX_OPTIONS=--lower_left_maps_to_s0t0
 )

--- a/tests/transcodetests/CMakeLists.txt
+++ b/tests/transcodetests/CMakeLists.txt
@@ -34,7 +34,7 @@ PRIVATE
 target_compile_features(transcodetests PUBLIC cxx_std_11)
 
 gtest_discover_tests( transcodetests
-    TEST_PREFIX transcodetest
+    TEST_PREFIX transcodetest.
     # With the 5s default we get periodic timeouts on Travis & GitHub CI.
     DISCOVERY_TIMEOUT 15
     EXTRA_ARGS "${PROJECT_SOURCE_DIR}/tests/testimages/"


### PR DESCRIPTION
This change makes test case names consistent and also adds a dot everywhere as a suite separator to be able to make work with testing tools easier.