### PR TITLE
Two Small Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -283,6 +283,12 @@ script:
     fi
     ;;
   esac
+  if [ "$DEPLOY_DOCS" = "YES" ]; then
+    # Some files in the pyktx docs have an _ prefix so Jekyll will
+    # not copy them from the gh-pages branch to the website. This
+    # file says no Jekyll files here. Treat all as ordinary files.
+    touch $BUILD_DIR/docs/html/.nojekyll
+  fi
 
 # See if this helps with truncated logs.
 #after_script:

--- a/tools/imageio/imageinput.cc
+++ b/tools/imageio/imageinput.cc
@@ -314,7 +314,9 @@ ImageInput::readImage(void* pBuffer, size_t bufferByteCount,
 {
     const auto& targetFormat = format.isUnknown() ? spec().format() : format;
     size_t outScanlineByteCount
-           = targetFormat.basic.bytesPlane0 * spec().width();
+           = targetFormat.pixelByteCount() * spec().width();
+    if (bufferByteCount < outScanlineByteCount * spec().height())
+        throw buffer_too_small();
 
     uint8_t* pDst = static_cast<uint8_t*>(pBuffer);
     for (uint32_t y = 0; y < spec().height(); y++) {

--- a/tools/imageio/jpg.imageio/jpginput.cc
+++ b/tools/imageio/jpg.imageio/jpginput.cc
@@ -362,16 +362,10 @@ void JpegInput::readImage(void* bufferOut, size_t bufferByteCount,
                           uint subimage, uint miplevel,
                           const FormatDescriptor& format)
 {
-    const auto& targetFormat = format.isUnknown() ? spec().format() : format;
-    size_t outImageByteCount
-           = targetFormat.basic.bytesPlane0 * spec().width() * spec().height();
-    if (bufferByteCount < outImageByteCount)
-        throw buffer_too_small();
-
     pJd->begin_decoding();
     decodingBegun = true;
     ImageInput::readImage(bufferOut, bufferByteCount,
                           subimage, miplevel,
-                          targetFormat);
+                          format);
 }
 


### PR DESCRIPTION
- Move buffer size check and refine size calculation when loading images.
- Force GitHub Jekyll to copy underscore-prefixed pyktx documentation files when deploying.