### PR TITLE
Fix RPM default directory permission

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -99,6 +99,11 @@ sudo apt install build-essential cmake libzstd-dev ninja-build doxygen libsdl2-d
 
 `mesa-opencl-icd` should be replaced by the appropriate package for your GPU.
 
+On Fedora and RedHat these can be installed via
+
+```bash
+sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libzstd-devel ninja-build doxygen SDL2-devel mesa-libGL mesa-libGL-devel mesa-vulkan-drivers assimp-devel opencl-headers mesa-libOpenCL
+```
 
 KTX requires `glslc`, which comes with [Vulkan SDK](#vulkan-sdk) (in sub-
 folder `x86_64/bin/glslc`). Make sure the complete path to the tool is in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1246,6 +1246,16 @@ elseif(LINUX)
     set(CPACK_GENERATOR DEB RPM TBZ2)
     set(CPACK_PACKAGE_CHECKSUM SHA1)
     set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ReadMe.txt")
+
+    # This fixes the directory permission derived from Ubuntu ${BUILD_DIR} of 0775 to 0755.
+    # otherwise when installing the RPM, it conflicts with the base filesystem.rpm that is
+    # setting the directory permissions and owns them to 0755.
+    # See GitHub Issue #287
+    # NOTE: Alternatively It would be better build the RPM through a docker or RedHat OS in the CI
+    set(CPACK_RPM_DEFAULT_DIR_PERMISSIONS
+    OWNER_READ OWNER_WRITE OWNER_EXECUTE
+    GROUP_READ GROUP_EXECUTE
+    WORLD_READ WORLD_EXECUTE)
 elseif(WIN32)
     set(CPACK_GENERATOR "NSIS")
     # Add logo to top left of installer pages. Despite the installer-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1253,9 +1253,9 @@ elseif(LINUX)
     # See GitHub Issue #827.
     # NOTE: Alternatively It would be better build the RPM through a docker or RedHat OS in the CI
     set(CPACK_RPM_DEFAULT_DIR_PERMISSIONS
-    OWNER_READ OWNER_WRITE OWNER_EXECUTE
-    GROUP_READ GROUP_EXECUTE
-    WORLD_READ WORLD_EXECUTE)
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE)
 elseif(WIN32)
     set(CPACK_GENERATOR "NSIS")
     # Add logo to top left of installer pages. Despite the installer-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,7 +646,7 @@ macro(common_libktx_settings target enable_write library_type)
         find_package(Threads REQUIRED)
         target_link_libraries(
             ${target}
-        PRIVATE
+        PUBLIC
             dl
             Threads::Threads
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,7 +646,7 @@ macro(common_libktx_settings target enable_write library_type)
         find_package(Threads REQUIRED)
         target_link_libraries(
             ${target}
-        PUBLIC
+        PRIVATE
             dl
             Threads::Threads
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1250,7 +1250,7 @@ elseif(LINUX)
     # This fixes the directory permission derived from Ubuntu ${BUILD_DIR} of 0775 to 0755.
     # otherwise when installing the RPM, it conflicts with the base filesystem.rpm that is
     # setting the directory permissions and owns them to 0755.
-    # See GitHub Issue #287
+    # See GitHub Issue #827.
     # NOTE: Alternatively It would be better build the RPM through a docker or RedHat OS in the CI
     set(CPACK_RPM_DEFAULT_DIR_PERMISSIONS
     OWNER_READ OWNER_WRITE OWNER_EXECUTE

--- a/other_projects/cxxopts/cmake/cxxopts.cmake
+++ b/other_projects/cxxopts/cmake/cxxopts.cmake
@@ -159,5 +159,14 @@ function(cxxopts_install_logic)
             DESTINATION "${CMAKE_INSTALL_LIBDIR_ARCHIND}/pkgconfig"
     )
 
+    # this should fix directory permission derived from Travis-CI ubuntu ${BUILD_DIR} from 0775 to 0755.
+    # otherwise when installing the RPM, it will conflicting with the base filesystem.rpm that is
+    # setting the directory permission and owns them to 0755
+    # NOTE: Alternatively would be better build the RPM through a docker or RedHat OS in the CI
+    set(CPACK_RPM_DEFAULT_DIR_PERMISSIONS
+    OWNER_READ OWNER_WRITE OWNER_EXECUTE
+    GROUP_READ GROUP_EXECUTE
+    WORLD_READ WORLD_EXECUTE)
+
     include(CPack)
 endfunction()

--- a/other_projects/cxxopts/cmake/cxxopts.cmake
+++ b/other_projects/cxxopts/cmake/cxxopts.cmake
@@ -159,10 +159,11 @@ function(cxxopts_install_logic)
             DESTINATION "${CMAKE_INSTALL_LIBDIR_ARCHIND}/pkgconfig"
     )
 
-    # this should fix directory permission derived from Travis-CI ubuntu ${BUILD_DIR} from 0775 to 0755.
+    # this fixes the directory permission derived from Travis-CI ubuntu ${BUILD_DIR} from 0775 to 0755.
     # otherwise when installing the RPM, it will conflicting with the base filesystem.rpm that is
     # setting the directory permission and owns them to 0755
-    # NOTE: Alternatively would be better build the RPM through a docker or RedHat OS in the CI
+    # see GitHub Issue #287
+    # NOTE: Alternatively It would be better build the RPM through a docker or RedHat OS in the CI
     set(CPACK_RPM_DEFAULT_DIR_PERMISSIONS
     OWNER_READ OWNER_WRITE OWNER_EXECUTE
     GROUP_READ GROUP_EXECUTE

--- a/other_projects/cxxopts/cmake/cxxopts.cmake
+++ b/other_projects/cxxopts/cmake/cxxopts.cmake
@@ -159,15 +159,5 @@ function(cxxopts_install_logic)
             DESTINATION "${CMAKE_INSTALL_LIBDIR_ARCHIND}/pkgconfig"
     )
 
-    # this fixes the directory permission derived from Travis-CI ubuntu ${BUILD_DIR} from 0775 to 0755.
-    # otherwise when installing the RPM, it will conflicting with the base filesystem.rpm that is
-    # setting the directory permission and owns them to 0755
-    # see GitHub Issue #287
-    # NOTE: Alternatively It would be better build the RPM through a docker or RedHat OS in the CI
-    set(CPACK_RPM_DEFAULT_DIR_PERMISSIONS
-    OWNER_READ OWNER_WRITE OWNER_EXECUTE
-    GROUP_READ GROUP_EXECUTE
-    WORLD_READ WORLD_EXECUTE)
-
     include(CPack)
 endfunction()


### PR DESCRIPTION
This fixes #827,  the conflicting permissions in the directories, those lead to impossibility to install the package.


