### PR TITLE
Move Ktx*.cmake files to Development component.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.15)
 
+include(CMakePrintHelpers)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
 
 find_package(Bash REQUIRED)
@@ -1154,7 +1156,7 @@ install(EXPORT KTXTargets
     FILE KtxTargets.cmake
     NAMESPACE KTX::
     DESTINATION lib/cmake/ktx
-    COMPONENT library
+    COMPONENT dev
 )
 
 include(CMakePackageConfigHelpers)
@@ -1167,7 +1169,7 @@ install( FILES
     "cmake/KtxConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/KtxConfigVersion.cmake"
     DESTINATION lib/cmake/ktx
-    COMPONENT library
+    COMPONENT dev
 )
 
 # CPack

--- a/cmake/mkvk.cmake
+++ b/cmake/mkvk.cmake
@@ -21,14 +21,17 @@ if (NOT IOS AND NOT ANDROID)
 #    # find_package doesn't find the Vulkan SDK when building for IOS.
 #    # I haven't investigated why.
 #    find_package(Vulkan REQUIRED)
-    set(Vulkan_INCLUDE_DIR lib/dfdutils)
+
+# This file is included from so has the same scope as the including file.
+# If we change Vulkan_INCLUDE_DIR, other users will be effected.
+    set(mkvk_vulkan_include_dir lib/dfdutils)
 else()
     # Skip mkvk. There is no need to use iOS or Android to regenerate
     # the files.
     return()
 endif()
 
-set(vulkan_header "${Vulkan_INCLUDE_DIR}/vulkan/vulkan_core.h")
+set(vulkan_header "${mkvk_vulkan_include_dir}/vulkan/vulkan_core.h")
 
 # CAUTION: On Windows use a version of Perl built for Windows, i.e. not
 # one found in Cygwin or MSYS (Git for Windows). This is needed so the
@@ -72,7 +75,7 @@ list(APPEND mkvkformatfiles_output
 # parses successfully.
 
 list(APPEND mvffc_as_list
-    Vulkan_INCLUDE_DIR="${Vulkan_INCLUDE_DIR}" lib/mkvkformatfiles lib)
+    Vulkan_INCLUDE_DIR="${mkvk_vulkan_include_dir}" lib/mkvkformatfiles lib)
     list(JOIN mvffc_as_list " " mvffc_as_string)
     set(mkvkformatfiles_command "${BASH_EXECUTABLE}" -c "${mvffc_as_string}")
 

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright 2017-2020 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-include(CMakePrintHelpers)
-
 if(WIN32)
     cmake_print_variables(
         CMAKE_SYSTEM_VERSION


### PR DESCRIPTION
Fixes #838.

Contains 2 minor unrelated fixes due to overhead of PRs:
* Move include of CMakePrintHelpers to root CMakeLists.txt so it is available everywhere.
* Don't set Vulkan_INCLUDE_DIR in mkvk.cmake.
  - Fixes vkloadtests build when KTX_GENERATE_VK_FILES is ON.