### PR TITLE
Revert "Exclude linux *.whl files from publishing to PyPI"

### DIFF
--- a/.github/workflows/publish-pyktx.yml
+++ b/.github/workflows/publish-pyktx.yml
@@ -78,7 +78,7 @@ jobs:
               https://api.github.com/repos/KhronosGroup/KTX-Software/releases/latest
       - name: Filter out pyktx- assets
         run: |
-          jq '.assets | map(select(.name | startswith("pyktx-") and (contains("linux") | not))) | map(.browser_download_url)' < latest.json > pyktx.json 
+          jq '.assets | map(select(.name | startswith("pyktx-"))) | map(.browser_download_url)' < latest.json > pyktx.json 
       - name: Create dist directory
         run: |
           mkdir dist


### PR DESCRIPTION
Reverts KhronosGroup/KTX-Software#845. Should not have been merged to main.