### PR TITLE
Exclude linux *.whl files from publishing to PyPI

### DIFF
--- a/.github/workflows/publish-pyktx.yml
+++ b/.github/workflows/publish-pyktx.yml
@@ -94,7 +94,7 @@ jobs:
           ci_scripts/download_release_assets.sh $option --filter "^pyktx" --output_dir dist
       - name: Delete linux wheels
         run: |
-          rm *linux*.whl
+          rm dist/*linux*.whl
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish-pyktx.yml
+++ b/.github/workflows/publish-pyktx.yml
@@ -78,7 +78,7 @@ jobs:
               https://api.github.com/repos/KhronosGroup/KTX-Software/releases/latest
       - name: Filter out pyktx- assets
         run: |
-          jq '.assets | map(select(.name | startswith("pyktx-"))) | map(.browser_download_url)' < latest.json > pyktx.json 
+          jq '.assets | map(select(.name | startswith("pyktx-") and (contains("linux") | not))) | map(.browser_download_url)' < latest.json > pyktx.json 
       - name: Create dist directory
         run: |
           mkdir dist


### PR DESCRIPTION
This is needed since we don't have a workflow to build manylinux wheels at moment, and [it's non-trivial to implement that](https://github.com/pypa/manylinux?tab=readme-ov-file#docker-images)

#845 