### PR TITLE
Fix KTX2 header initialization in included BasisU code

### DIFF
--- a/lib/basisu/encoder/basisu_comp.cpp
+++ b/lib/basisu/encoder/basisu_comp.cpp
@@ -1820,6 +1820,7 @@ namespace basisu
 		}
 
 		basist::ktx2_header header = {};
+		memset(&header, 0, sizeof(header));
 
 		memcpy(header.m_identifier, basist::g_ktx2_file_identifier, sizeof(basist::g_ktx2_file_identifier));
 		header.m_pixel_width = base_width;


### PR DESCRIPTION
KTX2 header wasn't initialized correctly which led to bugs. In my case, this code was succeeding, but `ktxTexture->baseDepth` was containing garbage because of it.

```
basisu::basis_compressor::error_code basisResult = basisCompressor.process();

if (basisResult == basisu::basis_compressor::cECSuccess)
{
    const basisu::vector<uint8_t>* ktx2Data = &basisCompressor.get_output_ktx2_file();
				
    ktxTexture2* ktxTexture;
    KTX_error_code result = ktxTexture2_CreateFromMemory(ktx2Data->data(), ktx2Data->size(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, &ktxTexture);
    if (result != KTX_SUCCESS)
    {
        throw std::runtime_error("Could not load the requested image file.");
    }
}
```

I'm not sure why this was changed though
https://github.com/KhronosGroup/KTX-Software/pull/687/files#diff-00fb4e838b1a5a861eb92b498116262bbf956d06d6ae0bab54b1b30fb4e2acbc