### PR TITLE
fix(cmake): Fix public includes of `obj_basisu_cbind` by adding (only) BasisU include directories to its public interface.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,13 @@ elseif(APPLE OR LINUX)
     endif()
 endif()
 
+set(KTX_BASISU_INCLUDE_DIRS
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/transcoder>
+    $<INSTALL_INTERFACE:lib/basisu/transcoder>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/zstd>
+    $<INSTALL_INTERFACE:lib/basisu/zstd>
+)
+
 # Main library
 add_library( ktx ${LIB_TYPE}
     ${KTX_MAIN_SRC}
@@ -551,11 +558,7 @@ macro(common_libktx_settings target enable_write library_type)
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/transcoder>
-        $<INSTALL_INTERFACE:lib/basisu/transcoder>
-
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/zstd>
-        $<INSTALL_INTERFACE:lib/basisu/zstd>
+        ${KTX_BASISU_INCLUDE_DIRS}
 
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/utils>
         $<INSTALL_INTERFACE:utils>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,9 +468,6 @@ endif()
 
 set(KTX_BASISU_INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/transcoder>
-    $<INSTALL_INTERFACE:lib/basisu/transcoder>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/zstd>
-    $<INSTALL_INTERFACE:lib/basisu/zstd>
 )
 
 # Main library
@@ -559,6 +556,10 @@ macro(common_libktx_settings target enable_write library_type)
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${KTX_BASISU_INCLUDE_DIRS}
+        $<INSTALL_INTERFACE:lib/basisu/transcoder>
+
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/basisu/zstd>
+        $<INSTALL_INTERFACE:lib/basisu/zstd>
 
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/utils>
         $<INSTALL_INTERFACE:utils>

--- a/interface/basisu_c_binding/CMakeLists.txt
+++ b/interface/basisu_c_binding/CMakeLists.txt
@@ -25,6 +25,7 @@ target_include_directories(
     obj_basisu_cbind
 PUBLIC
     inc
+    ${KTX_BASISU_INCLUDE_DIRS}
 PRIVATE
     $<TARGET_PROPERTY:ktx,INCLUDE_DIRECTORIES>
     ${PROJECT_SOURCE_DIR}/utils

--- a/tests/transcodetests/CMakeLists.txt
+++ b/tests/transcodetests/CMakeLists.txt
@@ -10,10 +10,7 @@ set_code_sign(transcodetests)
 target_include_directories(
     transcodetests
 PRIVATE
-    $<TARGET_PROPERTY:ktx,INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:obj_basisu_cbind,INTERFACE_INCLUDE_DIRECTORIES>
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../other_include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../lib
+    ${PROJECT_SOURCE_DIR}/lib
 )
 
 target_link_libraries(
@@ -28,7 +25,6 @@ target_compile_definitions(
     transcodetests
 PRIVATE
     $<TARGET_PROPERTY:ktx,INTERFACE_COMPILE_DEFINITIONS>
-    $<TARGET_PROPERTY:obj_basisu_cbind,INTERFACE_COMPILE_DEFINITIONS>
 )
 
 target_compile_features(transcodetests PUBLIC cxx_std_11)


### PR DESCRIPTION
There are two commits.

The first commit adds BasisU specific include directories to the target `obj_basisu_cbind`'s public interface. Now targets that add `obj_basisu_cbind` as dependency automatically have the correct include directories setup.

The second commit makes use of the first's improvements, by simplifying `transcodetests` include directory setup.