### PR TITLE
Minor documentation fixes

### DIFF
--- a/include/ktx.h
+++ b/include/ktx.h
@@ -326,7 +326,7 @@ typedef struct ktxTexture {
  * KTX_TRUE if the texture is a cubemap or cubemap array.
  */
 /**
- * @typedef ktxTexture::isCubemap
+ * @typedef ktxTexture::isCompressed
  * @~English
  *
  * KTX_TRUE if the texture's format is a block compressed format.

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -338,7 +338,7 @@ typedef struct ktxTexture {
  * KTX_TRUE if mipmaps should be generated for the texture by
  * ktxTexture_GLUpload() or ktxTexture_VkUpload().
  */
-/**n
+/**
  * @typedef ktxTexture::baseWidth
  * @~English
  * @brief Width of the texture's base level.

--- a/lib/texture.c
+++ b/lib/texture.c
@@ -828,7 +828,7 @@ ktxTexture_rowInfo(ktxTexture* This, ktx_uint32_t level,
 /**
  * @memberof ktxTexture
  * @~English
- * @brief Return pitch betweeb rows of a texture image level in bytes.
+ * @brief Return pitch between rows of a texture image level in bytes.
  *
  * For uncompressed textures the pitch is the number of bytes between
  * rows of texels. For compressed textures it is the number of bytes

--- a/pkgdoc/jswrappersDoxyLayout.xml
+++ b/pkgdoc/jswrappersDoxyLayout.xml
@@ -37,7 +37,7 @@
     <tab type="user" url="../index.html" title="Package"/>
     <tab type="user" url="../ktxtools/index.html" title="KTX Tools Reference"/>
     <tab type="user" url="../libktx/index.html" title="libktx Reference"/>
-    <tab type="user"  url="pyktx/index.html" title="pyktx Reference"/>
+    <tab type="user"  url="../pyktx/index.html" title="pyktx Reference"/>
     <!-- navindex processing does not look in the .tag file so @ref is NG.
     URL to file is fragile.
     <tab type="user" url="@ref license" title="License"/> -->

--- a/pkgdoc/libktxDoxyLayout.xml
+++ b/pkgdoc/libktxDoxyLayout.xml
@@ -39,7 +39,7 @@
     <tab type="user" url="../ktxtools/index.html" title="KTX Tools Reference"/>
     <tab type="user" url="../ktxjswrappers/index.html"
         title="KTX Javascript Wrappers Reference"/>
-    <tab type="user"  url="pyktx/index.html" title="pyktx Reference"/>
+    <tab type="user"  url="../pyktx/index.html" title="pyktx Reference"/>
     <!-- navindex processing does not look in the .tag file so @ref is NG.
     URL to file is fragile.
     <tab type="user" url="@ref license" title="License"/> -->

--- a/pkgdoc/toolsDoxyLayout.xml
+++ b/pkgdoc/toolsDoxyLayout.xml
@@ -38,7 +38,7 @@
     <tab type="user" url="../libktx/index.html" title="libktx Reference"/>
     <tab type="user" url="../ktxjswrappers/index.html"
         title="KTX Javascript Wrappers Reference"/>
-    <tab type="user"  url="pyktx/index.html" title="pyktx Reference"/>
+    <tab type="user"  url="../pyktx/index.html" title="pyktx Reference"/>
     <!-- navindex processing does not look in the .tag file so @ref is NG.
     URL to file is fragile.
     <tab type="user" url="@ref license" title="License"/> -->

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -762,7 +762,7 @@ Create a KTX2 file from various input files.
         </dl>
     </dl>
     <dl>
-        <dt>\--encode basis-lz | uastc<</dt>
+        <dt>\--encode basis-lz | uastc</dt>
         <dd>Encode the texture with the specified codec before saving it.
             This option matches the functionality of the @ref ktx_encode "ktx encode" command.
             With each encoding option the following encoder specific options become valid,


### PR DESCRIPTION
Sorry, I'm pedantic. Some minor documentation fixes:

- Wrong link, `isCubemap` should be `isCompressed`: https://github.com/KhronosGroup/KTX-Software/blob/7a45c4e6159c0815e4663a529a1e718136a16e39/include/ktx.h#L329
- Unnecessary `n` at https://github.com/KhronosGroup/KTX-Software/blob/7a45c4e6159c0815e4663a529a1e718136a16e39/include/ktx.h#L341
- Typo: "betweeb" should be "between" at https://github.com/KhronosGroup/KTX-Software/blob/7a45c4e6159c0815e4663a529a1e718136a16e39/lib/texture.c#L831
- Unnecessary `<` at https://github.com/KhronosGroup/KTX-Software/blob/7a45c4e6159c0815e4663a529a1e718136a16e39/tools/ktx/command_create.cpp#L765
- The link to pyktx is missing `../` in https://github.com/KhronosGroup/KTX-Software/blob/7a45c4e6159c0815e4663a529a1e718136a16e39/pkgdoc/toolsDoxyLayout.xml#L41  and related files (I.e. on https://github.khronos.org/KTX-Software/libktx/index.html , the link to pyktx is a 404), see https://github.com/search?q=repo%3AKhronosGroup%2FKTX-Software%20%22pyktx%20Reference%22&type=code

Beyond that:

I'm pretty sure that the `codecName`  at https://github.com/KhronosGroup/KTX-Software/blob/7a45c4e6159c0815e4663a529a1e718136a16e39/tools/ktx/encode_utils.h#L269 is not used and could be removed. But this would not be a plain _documentation_ fix. So I'd rather ask whether this can be removed (and whether this should/could be part of this PR)

