### PR TITLE
Add `ktx deflate` command

### DIFF
--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -157,6 +157,7 @@ function( CreateDocTools )
         tools/ktx/ktx_main.cpp
         tools/ktx/command_compare.cpp
         tools/ktx/command_create.cpp
+        tools/ktx/command_deflate.cpp
         tools/ktx/command_encode.cpp
         tools/ktx/command_extract.cpp
         tools/ktx/command_help.cpp

--- a/tools/ktx/CMakeLists.txt
+++ b/tools/ktx/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(ktxtools
         command.h
         command_compare.cpp
         command_create.cpp
+        command_deflate.cpp
         command_encode.cpp
         command_extract.cpp
         command_help.cpp

--- a/tools/ktx/command_deflate.cpp
+++ b/tools/ktx/command_deflate.cpp
@@ -206,7 +206,7 @@ void CommandDeflate::executeDeflate() {
 
         writer = findMetadataValue(KTX_WRITER_KEY);
         if (!writer.empty()) {
-            std::regex e("ktx (?:create|encode|transcode)");
+            std::regex e("ktx (?:create|encode)");
             if (std::regex_search(writer, e)) {
                 // File written by a ktx suite tool. Retrieve writerScParams.
                 writerScParams = findMetadataValue(KTX_WRITER_SCPARAMS_KEY);

--- a/tools/ktx/command_deflate.cpp
+++ b/tools/ktx/command_deflate.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "command.h"
+#include "platform_utils.h"
 #include "compress_utils.h"
 #include "formats.h"
 #include "sbufstream.h"
@@ -305,8 +306,9 @@ void CommandDeflate::executeDeflate() {
     updateMetadataValue(KTX_WRITER_SCPARAMS_KEY, writerScParams);
 
     // Save output file
-    if (std::filesystem::path(options.outputFilepath).has_parent_path())
-        std::filesystem::create_directories(std::filesystem::path(options.outputFilepath).parent_path());
+    const auto outputPath = std::filesystem::path(DecodeUTF8Path(options.outputFilepath));
+    if (outputPath.has_parent_path())
+        std::filesystem::create_directories(outputPath.parent_path());
 
     OutputStream outputFile(options.outputFilepath, *this);
     outputFile.writeKTX2(texture, *this);

--- a/tools/ktx/command_deflate.cpp
+++ b/tools/ktx/command_deflate.cpp
@@ -1,0 +1,196 @@
+// Copyright 2022-2023 The Khronos Group Inc.
+// Copyright 2022-2023 RasterGrid Kft.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "command.h"
+#include "compress_utils.h"
+#include "formats.h"
+#include "sbufstream.h"
+#include "utility.h"
+#include "validate.h"
+#include "ktx.h"
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <unordered_map>
+
+#include <cxxopts.hpp>
+#include <fmt/ostream.h>
+#include <fmt/printf.h>
+
+
+// -------------------------------------------------------------------------------------------------
+
+namespace ktx {
+
+// -------------------------------------------------------------------------------------------------
+
+/** @page ktx_deflate ktx deflate
+@~English
+
+Deflate (supercompress) a KTX2 file.
+
+@section ktx_deflate_synopsis SYNOPSIS
+    ktx deflate [option...] @e input-file @e output-file
+
+@section ktx_deflate_description DESCRIPTION
+    @b ktx @b deflate deflates (supercompresses) the KTX file specified as the
+    @e input-file and saves it as the @e output-file.
+    If the @e input-file is '-' the file will be read from the stdin.
+    If the @e output-path is '-' the output file will be written to the stdout.
+    If the input file is already supercompressed it will be inflated then
+    supercompressed again using the options specified here and a warning will
+    be issued. If the input file is invalid the first encountered validation
+    error is displayed to the stderr and the command exits with the relevant
+    non-zero status code.
+
+    @ktx @b deflate cannot be applied to KTX files that have been
+    supercompressed with BasisLZ.
+
+    The following options are available:
+    @snippet{doc} ktx/compress_utils.h command options_compress
+    <dl>
+        <dt>-q, --quiet</dt>
+        <dd>Silence warning about already supercompressed input fiile..</dd>
+        <dt>-e, --warnings-as-errors</dt>
+        <dd>Treat warnings as errors.</dd>
+    </dl>
+    @snippet{doc} ktx/command.h command options_generic
+
+@section ktx_deflate_exitstatus EXIT STATUS
+    @snippet{doc} ktx/command.h command exitstatus
+
+@section ktx_deflate_history HISTORY
+
+@par Version 4.0
+ - Initial version
+
+@section ktx_deflate_author AUTHOR
+    - Mark Callow [@MarkCallow]
+*/
+class CommandDeflate : public Command {
+    enum {
+        all = -1,
+    };
+
+    struct OptionsDeflate {
+        bool quiet = false;
+        bool warningsAsErrors = false;
+        void init(cxxopts::Options& opts);
+        void process(cxxopts::Options& opts, cxxopts::ParseResult& args, Reporter& report);
+    };
+
+    Combine<OptionsDeflate, OptionsCompress, OptionsSingleInSingleOut, OptionsGeneric> options;
+
+public:
+    virtual int main(int argc, _TCHAR* argv[]) override;
+    virtual void initOptions(cxxopts::Options& opts) override;
+    virtual void processOptions(cxxopts::Options& opts, cxxopts::ParseResult& args) override;
+
+private:
+    void executeDeflate();
+};
+
+// -------------------------------------------------------------------------------------------------
+
+int CommandDeflate::main(int argc, _TCHAR* argv[]) {
+    try {
+        parseCommandLine("ktx deflate",
+                "Deflate (supercompress) the KTX file specified as the input-file\n"
+                "    and save it as the output-file.",
+                argc, argv);
+        executeDeflate();
+        return +rc::SUCCESS;
+    } catch (const FatalError& error) {
+        return +error.returnCode;
+    } catch (const std::exception& e) {
+        fmt::print(std::cerr, "{} fatal: {}\n", commandName, e.what());
+        return +rc::RUNTIME_ERROR;
+    }
+}
+
+void CommandDeflate::OptionsDeflate::init(cxxopts::Options& opts) {
+    opts.add_options()
+        ("q,quiet", "Don't print warning when input file is already supercompressed.")
+        ("w, warnings-as-errors", "Exit with error when input file is already supercompressed");
+
+}
+
+void CommandDeflate::OptionsDeflate::process(cxxopts::Options&, cxxopts::ParseResult& args, Reporter&) {
+    quiet = args["quiet"].as<bool>();
+    warningsAsErrors = args["warnings-as-errors"].as<bool>();
+}
+
+void CommandDeflate::initOptions(cxxopts::Options& opts) {
+    options.init(opts);
+}
+
+void CommandDeflate::processOptions(cxxopts::Options& opts, cxxopts::ParseResult& args) {
+    options.process(opts, args, *this);
+    if (options.quiet && options.warningsAsErrors) {
+        fatal_usage("Cannot specify both --quiet and --warnings-as-errors");
+    }
+    if (!options.zstd && !options.zlib) {
+        fatal_usage("Must specifiy one of --zstd or --zlib.");
+    }
+}
+
+void CommandDeflate::executeDeflate() {
+    InputStream inputStream(options.inputFilepath, *this);
+    validateToolInput(inputStream, fmtInFile(options.inputFilepath), *this);
+
+    KTXTexture2 texture{nullptr};
+    StreambufStream<std::streambuf*> ktx2Stream{inputStream->rdbuf(), std::ios::in | std::ios::binary};
+    auto ret = ktxTexture2_CreateFromStream(ktx2Stream.stream(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, texture.pHandle());
+    if (ret != KTX_SUCCESS)
+        fatal(rc::INVALID_FILE, "Failed to create KTX2 texture: {}", ktxErrorString(ret));
+
+    if (texture->supercompressionScheme == KTX_SS_BASIS_LZ)
+        fatal(rc::INVALID_FILE, "Cannot deflate a KTX2 file supercompressed with {}.",
+            toString(ktxSupercmpScheme(texture->supercompressionScheme)));
+
+    if (texture->supercompressionScheme != KTX_SS_NONE && !options.quiet) {
+        warning("Modifying existing supercompression of {}.", options.inputFilepath);
+    }
+
+    // Modify KTXwriter metadata
+    const auto writer = fmt::format("{} {}", commandName, version(options.testrun));
+    ktxHashList_DeleteKVPair(&texture->kvDataHead, KTX_WRITER_KEY);
+    ktxHashList_AddKVPair(&texture->kvDataHead, KTX_WRITER_KEY,
+            static_cast<uint32_t>(writer.size() + 1), // +1 to include the \0
+            writer.c_str());
+
+    if (options.zstd) {
+        ret = ktxTexture2_DeflateZstd(texture, *options.zstd);
+        if (ret != KTX_SUCCESS)
+            fatal(rc::IO_FAILURE, "Zstd deflation failed. KTX Error: {}", ktxErrorString(ret));
+    }
+
+    if (options.zlib) {
+        ret = ktxTexture2_DeflateZLIB(texture, *options.zlib);
+        if (ret != KTX_SUCCESS)
+            fatal(rc::IO_FAILURE, "ZLIB deflation failed. KTX Error: {}", ktxErrorString(ret));
+    }
+
+    // Add KTXwriterScParams metadata
+    const auto writerScParams = fmt::format("{}{}", options.compressOptions);
+    if (writerScParams.size() > 0) {
+        // Options always contain a leading space
+        assert(writerScParams[0] == ' ');
+        ktxHashList_AddKVPair(&texture->kvDataHead, KTX_WRITER_SCPARAMS_KEY,
+            static_cast<uint32_t>(writerScParams.size()),
+            writerScParams.c_str() + 1); // +1 to exclude leading space
+    }
+
+    // Save output file
+    if (std::filesystem::path(options.outputFilepath).has_parent_path())
+        std::filesystem::create_directories(std::filesystem::path(options.outputFilepath).parent_path());
+
+    OutputStream outputFile(options.outputFilepath, *this);
+    outputFile.writeKTX2(texture, *this);
+}
+
+} // namespace ktx
+
+KTX_COMMAND_ENTRY_POINT(ktxDeflate, ktx::CommandDeflate)

--- a/tools/ktx/command_deflate.cpp
+++ b/tools/ktx/command_deflate.cpp
@@ -68,7 +68,7 @@ Deflate (supercompress) a KTX2 file.
  - Initial version
 
 @section ktx_deflate_author AUTHOR
-    - Mark Callow [@MarkCallow]
+    - Mark Callow [\@MarkCallow]
 */
 class CommandDeflate : public Command {
     enum {
@@ -162,7 +162,7 @@ void CommandDeflate::executeDeflate() {
             break;
           default:
             fatal(rc::INVALID_FILE,
-                  "Cannot deflate a KTX2 file supercompressed with {}.",
+                  "Cannot further deflate a KTX2 file supercompressed with {}.",
                   toString(texture->supercompressionScheme));
         }
     }

--- a/tools/ktx/command_deflate.cpp
+++ b/tools/ktx/command_deflate.cpp
@@ -127,7 +127,6 @@ void CommandDeflate::OptionsDeflate::process(cxxopts::Options&,
     if (quiet && warningsAsErrors) {
         report.fatal_usage("Cannot specify both --{} and --{}.",
                            this->kQuiet, this->kWarningsAsErrors);
-//                            OptionsDeflate::kQuiet, OptionsDeflate::kWarningsAsErrors);
     }
 }
 
@@ -245,8 +244,6 @@ void CommandDeflate::executeDeflate() {
     if (!writerScParams.empty()) {
         std::string writer = findMetadataValue(KTX_WRITER_KEY);
         if (!writer.empty()) {
-            // No need to match "deflate" or "transcode" as the code used
-            // when there are no ScParams handles that case.
             std::regex e("ktx (?:create|deflate|encode|transcode)");
             std::smatch deflateOptionMatch;
             if (std::regex_search(writer, e)) {

--- a/tools/ktx/command_deflate.cpp
+++ b/tools/ktx/command_deflate.cpp
@@ -125,7 +125,9 @@ void CommandDeflate::OptionsDeflate::process(cxxopts::Options&,
     quiet = args[kQuiet].as<bool>();
     warningsAsErrors = args[kWarningsAsErrors].as<bool>();
     if (quiet && warningsAsErrors) {
-        report.fatal_usage("Cannot specify both --quiet and --warnings-as-errors");
+        report.fatal_usage("Cannot specify both --{} and --{}.",
+                           this->kQuiet, this->kWarningsAsErrors);
+//                            OptionsDeflate::kQuiet, OptionsDeflate::kWarningsAsErrors);
     }
 }
 
@@ -135,9 +137,6 @@ void CommandDeflate::initOptions(cxxopts::Options& opts) {
 
 void CommandDeflate::processOptions(cxxopts::Options& opts, cxxopts::ParseResult& args) {
     options.process(opts, args, *this);
-
-    if (!options.zlib.has_value() && !options.zstd.has_value())
-        fatal_usage("Must specify --zlib or --zstd");
 }
 
 void CommandDeflate::executeDeflate() {

--- a/tools/ktx/command_deflate.cpp
+++ b/tools/ktx/command_deflate.cpp
@@ -137,6 +137,10 @@ void CommandDeflate::initOptions(cxxopts::Options& opts) {
 
 void CommandDeflate::processOptions(cxxopts::Options& opts, cxxopts::ParseResult& args) {
     options.process(opts, args, *this);
+    if (!options.zstd && !options.zlib) {
+        fatal_usage("Must specify --{}  or --{}.",
+                    OptionsCompress::kZStd, OptionsCompress::kZLib);
+    }
 }
 
 void CommandDeflate::executeDeflate() {

--- a/tools/ktx/ktx_main.cpp
+++ b/tools/ktx/ktx_main.cpp
@@ -38,6 +38,10 @@ Unified CLI frontend for the KTX-Software library.
         <dd>
             Create a KTX2 file from various input files.
         </dd>
+        <dt>@ref ktx_deflate "deflate"</dt>
+        <dd>
+            Deflate (supercompress) a KTX2 file.
+        </dd>
         <dt>@ref ktx_extract "extract"</dt>
         <dd>
             Extract selected images from a KTX2 file.
@@ -152,6 +156,7 @@ void Tools::printUsage(std::ostream& os, const cxxopts::Options& options) {
     fmt::print(os, "\n");
     fmt::print(os, "Available commands:\n");
     fmt::print(os, "  create     Create a KTX2 file from various input files\n");
+    fmt::print(os, "  deflate    Deflate (supercompress) a KTX2 file\n");
     fmt::print(os, "  extract    Extract selected images from a KTX2 file\n");
     fmt::print(os, "  encode     Encode a KTX2 file\n");
     fmt::print(os, "  transcode  Transcode a KTX2 file\n");
@@ -167,6 +172,7 @@ void Tools::printUsage(std::ostream& os, const cxxopts::Options& options) {
 } // namespace ktx ---------------------------------------------------------------------------------
 
 KTX_COMMAND_BUILTIN(ktxCreate)
+KTX_COMMAND_BUILTIN(ktxDeflate)
 KTX_COMMAND_BUILTIN(ktxExtract)
 KTX_COMMAND_BUILTIN(ktxEncode)
 KTX_COMMAND_BUILTIN(ktxTranscode)
@@ -177,6 +183,7 @@ KTX_COMMAND_BUILTIN(ktxHelp)
 
 std::unordered_map<std::string, ktx::pfnBuiltinCommand> builtinCommands = {
     { "create",     ktxCreate },
+    { "deflate",    ktxDeflate },
     { "extract",    ktxExtract },
     { "encode",     ktxEncode },
     { "transcode",  ktxTranscode },


### PR DESCRIPTION
For deflating an existing ktx 2.0 file.

Fixes part of #747. A complete fix requires either `ktx encode` support ASTC or a new ktx `encode-astc` command.