### PR TITLE
Fix Issues 911 & 912

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,7 @@ set(KTX_MAIN_SRC
     lib/texture.h
     lib/texture2.c
     lib/texture2.h
+    lib/texture_funcs.inl
     lib/uthash.h
     lib/vk2gl.h
     lib/vk_format.h

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -1011,6 +1011,8 @@ KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture1_CreateFromStream(ktxStream* stream,
                              ktxTextureCreateFlags createFlags,
                              ktxTexture1** newTex);
+KTX_API void KTX_APIENTRY
+ktxTexture1_Destroy(ktxTexture1* This);
 
 KTX_API ktx_bool_t KTX_APIENTRY
 ktxTexture1_NeedsTranscoding(ktxTexture1* This);
@@ -1076,6 +1078,9 @@ KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture2_CreateFromStream(ktxStream* stream,
                              ktxTextureCreateFlags createFlags,
                              ktxTexture2** newTex);
+
+KTX_API void KTX_APIENTRY
+ktxTexture2_Destroy(ktxTexture2* This);
 
 KTX_API KTX_error_code KTX_APIENTRY
 ktxTexture2_CompressBasis(ktxTexture2* This, ktx_uint32_t quality);

--- a/lib/astc_encode.cpp
+++ b/lib/astc_encode.cpp
@@ -521,8 +521,9 @@ launchThreads(int threadCount, void (*func)(int, int, void*), void *payload) {
  *                              The texture's images are 1D. Only 2D images can
  *                              be supercompressed.
  * @exception KTX_INVALID_OPERATION
- *                              ASTC  compressor failed to compress image for any
-                                reason.
+ *                              ASTC  compressor failed to compress image.
+ * @exception KTX_INVALID_OPERATION
+ *                              This->generateMipmaps is set.
  * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out compression.
  */
 extern "C" KTX_error_code
@@ -536,6 +537,9 @@ ktxTexture2_CompressAstcEx(ktxTexture2* This, ktxAstcParams* params) {
 
     if (params->structSize != sizeof(struct ktxAstcParams))
         return KTX_INVALID_VALUE;
+
+    if (This->generateMipmaps)
+        return KTX_INVALID_OPERATION;
 
     if (This->supercompressionScheme != KTX_SS_NONE)
         return KTX_INVALID_OPERATION; // Can't apply multiple schemes.

--- a/lib/basis_encode.cpp
+++ b/lib/basis_encode.cpp
@@ -396,13 +396,16 @@ static bool basisuEncoderInitialized = false;
  *                              The texture image's format is a packed format
  *                              (e.g. RGB565).
  * @exception KTX_INVALID_OPERATION
- *                              The texture image format's component size is not 8-bits.
+ *                              The texture image format's component size is
+ *                              not 8-bits.
  * @exception KTX_INVALID_OPERATION
- *                              @c normalMode is specified but the texture has only
- *                              one component.
+ *                              @c normalMode is specified but the texture has
+ *                              only one component.
  * @exception KTX_INVALID_OPERATION
- *                              Both preSwizzle and and inputSwizzle are specified
- *                              in @a params.
+ *                              Both preSwizzle and and inputSwizzle are
+ *                              specified in @a params.
+ * @exception KTX_INVALID_OPERATION
+ *                              This->generateMipmaps is set.
  * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out compression.
  */
 extern "C" KTX_error_code
@@ -415,6 +418,9 @@ ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params)
 
     if (params->structSize != sizeof(struct ktxBasisParams))
         return KTX_INVALID_VALUE;
+
+    if (This->generateMipmaps)
+        return KTX_INVALID_OPERATION;
 
     if (This->supercompressionScheme != KTX_SS_NONE)
         return KTX_INVALID_OPERATION; // Can't apply multiple schemes.

--- a/lib/texture_funcs.inl
+++ b/lib/texture_funcs.inl
@@ -28,7 +28,6 @@
 */
 
 
-void CLASS_FUNC(Destroy)(CLASS* This);
 KTX_error_code CLASS_FUNC(GetImageOffset)(CLASS* This, ktx_uint32_t level,
                                           ktx_uint32_t layer,
                                           ktx_uint32_t faceSlice,


### PR DESCRIPTION
Expose ktxTexture[12]_Destroy (#911).

Return `KTX_INVALID_OPERATION` if `generateMipmaps` is set on incoming texture when compressing to ASTC or BasisU. Per spec. block-compressed textures are not allowed to request runtime mip generation (#912).