### PR TITLE
docs: clarify pointer lifetimes for ktxTexture_SetImageFromMemory

### DIFF
--- a/lib/writer1.c
+++ b/lib/writer1.c
@@ -206,6 +206,9 @@ ktxTexture1_SetImageFromStdioStream(ktxTexture1* This, ktx_uint32_t level,
  *
  * @warning Do not use @c memcpy for this as it will not pad when necessary.
  *
+ * @note The caller is responsible for freeing the original image memory
+ *       referred to by @p src.
+ *
  * @param[in] This      pointer to the target ktxTexture object.
  * @param[in] level     mip level of the image to set.
  * @param[in] layer     array layer of the image to set.

--- a/lib/writer2.c
+++ b/lib/writer2.c
@@ -299,6 +299,9 @@ ktxTexture2_SetImageFromStdioStream(ktxTexture2* This, ktx_uint32_t level,
  * Level, layer, faceSlice rather than offset are specified to enable some
  * validation.
  *
+ * @note The caller is responsible for freeing the original image memory
+ *       referred to by @p src.
+ *
  * @param[in] This      pointer to the target ktxTexture object.
  * @param[in] level     mip level of the image to set.
  * @param[in] layer     array layer of the image to set.


### PR DESCRIPTION
**Problem** 
`ktxTexture1_SetImageFromMemory` and `ktxTexture2_SetImageFromMemory` accept a pointer to image memory but do not clearly document if ownership of those pointers is transferred or copied. 

**Solution**
This commit adds a Doxygen note informing users that the underlying image data is copied and that they are responsible for freeing the original copy of image memory.

**Testing**
Documentation updates were manually verified by building the project using the `KTX_FEATURE_DOC=ON` CMake option and viewing the generated Doxygen output using a local server.

Closes #914