### PR TITLE
GitHub Action fixes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
+        generator: [ 'Visual Studio 17 2022' ]
         toolset: [v143, CLangCL]
         arch: [ x64 ]
         check_mkvk: [ NO ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -255,6 +255,14 @@ jobs:
       if: matrix.check_mkvk == 'ONLY'
       run: scripts/check_mkvk.ps1
 
+    # Works around issues with 2024.06.03.1.0 runner image. See
+    # https://github.com/actions/runner-images/issues/10004 and
+    # https://github.com/actions/runner-images/issues/10055
+    - name: Remove conflicting msvcp140.dll as workaround for runner image bugs.
+      shell: bash -l {0}
+      run: |
+          find "C:/hostedtoolcache/windows/Java_Temurin-Hotspot_jdk" -name "msvcp140.dll" -exec rm {} \;
+
     - name: Test Windows build
       # Tests built for arm64 can't be run as the CI runners are all x64.
       if: matrix.arch == 'x64' && matrix.options.tests == 'ON'

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -15,7 +15,7 @@ for ($i=0; $i -lt $args.length; $i++)
 function Set-ConfigVariable {
   param ( $VariableName, $DefaultValue )
   $res = get-variable $VariableName -ValueOnly -ErrorAction 'SilentlyContinue'
-  if ($res -eq $null) {
+  if ([string]::IsNullOrEmpty($res)) {
     $res = [Environment]::GetEnvironmentVariable($VariableName)
     if ($res -eq $null) {
         $res = $DefaultValue


### PR DESCRIPTION
Fix for new GHA 2024.06.10.1.0 runner image behavior w.r.t setting env. vars from build matrix.

Workaround 2024.06.03.1.0 GHA runner image bug that continues in 2024.06.10.1.0. See https://github.com/actions/runner-images/issues/10004.