### PR TITLE
Allow KTX_VERSION_FULL to be manually specified

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -63,6 +63,12 @@ add `-D BASISU_SUPPORT_OPENCL=ON` to the CMake configure command.
 >  There is very little advantage to using OpenCL in the context
 >  of `libktx`. It is disabled in the default build configuration.
 
+> **Note:**
+> 
+> When building from the `tar.gz` and not from the git repository directly, it is recommended to pass the variable `KTX_GIT_VERSION_FULL` with the associated git tag (e.g `v4.3.2`)
+> ```bash
+> cmake . -G Ninja -B build -DKTX_GIT_VERSION_FULL=v4.3.2
+> ```
 
 Building
 --------

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -113,7 +113,7 @@ endfunction()
 if(NOT KTX_GIT_VERSION_FULL)
     git_describe_raw(KTX_GIT_VERSION_FULL --abbrev=0 --match v[0-9]*)
 endif()
-#message("KTX full version: ${KTX_VERSION_FULL}")
+#message("KTX git full version: ${KTX_GIT_VERSION_FULL}")
 
 # generate_version(TOKTX_VERSION tools/toktx)
 # message("TOKTX_VERSION: ${TOKTX_VERSION}")

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -109,8 +109,9 @@ function(generate_version _var )
 endfunction()
 
 # Get latest tag from git if not passed to cmake
-if(NOT KTX_VERSION_FULL)
-    git_describe_raw(KTX_VERSION_FULL --abbrev=0 --match v[0-9]*)
+# This property can be passed to cmake when building from tar.gz
+if(NOT KTX_GIT_VERSION_FULL)
+    git_describe_raw(KTX_GIT_VERSION_FULL --abbrev=0 --match v[0-9]*)
 endif()
 #message("KTX full version: ${KTX_VERSION_FULL}")
 
@@ -119,7 +120,7 @@ endif()
 
 # First try a full regex ( vMAJOR.MINOR.PATCH-TWEAK )
 string(REGEX MATCH "^v([0-9]*)\.([0-9]*)\.([0-9]*)(-[^\.]*)"
-       KTX_VERSION ${KTX_VERSION_FULL})
+       KTX_VERSION ${KTX_GIT_VERSION_FULL})
 
 if(KTX_VERSION)
     set(KTX_VERSION_MAJOR ${CMAKE_MATCH_1})
@@ -129,7 +130,7 @@ if(KTX_VERSION)
 else()
     # If full regex failed, go for vMAJOR.MINOR.PATCH
     string(REGEX MATCH "^v([0-9]*)\.([0-9]*)\.([^\.]*)"
-            KTX_VERSION ${KTX_VERSION_FULL})
+            KTX_VERSION ${KTX_GIT_VERSION_FULL})
 
     if(KTX_VERSION)
         set(KTX_VERSION_MAJOR ${CMAKE_MATCH_1})
@@ -176,7 +177,7 @@ function( create_version_header dest_path target )
         add_custom_command(
             OUTPUT ${version_h_output}
             # On Windows this command has to be invoked by a shell in order to work
-            COMMAND ${BASH_EXECUTABLE} -c "\"scripts/mkversion\" \"-v\" \"${KTX_VERSION_FULL}\" \"-o\" \"version.h\" \"${dest_path}\""
+            COMMAND ${BASH_EXECUTABLE} -c "\"scripts/mkversion\" \"-v\" \"${KTX_GIT_VERSION_FULL}\" \"-o\" \"version.h\" \"${dest_path}\""
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Generate ${version_h_output}"
             VERBATIM
@@ -184,7 +185,7 @@ function( create_version_header dest_path target )
     else()
         add_custom_command(
             OUTPUT ${version_h_output}
-            COMMAND scripts/mkversion -v ${KTX_VERSION_FULL} -o version.h ${dest_path}
+            COMMAND scripts/mkversion -v ${KTX_GIT_VERSION_FULL} -o version.h ${dest_path}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Generate ${version_h_output}"
             VERBATIM

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -108,8 +108,10 @@ function(generate_version _var )
     set(${_var} "${KTX_VERSION}" PARENT_SCOPE)
 endfunction()
 
-# Get latest tag
-git_describe_raw(KTX_VERSION_FULL --abbrev=0 --match v[0-9]*)
+# Get latest tag from git if not passed to cmake
+if(NOT KTX_VERSION_FULL)
+    git_describe_raw(KTX_VERSION_FULL --abbrev=0 --match v[0-9]*)
+endif()
 #message("KTX full version: ${KTX_VERSION_FULL}")
 
 # generate_version(TOKTX_VERSION tools/toktx)
@@ -174,7 +176,7 @@ function( create_version_header dest_path target )
         add_custom_command(
             OUTPUT ${version_h_output}
             # On Windows this command has to be invoked by a shell in order to work
-            COMMAND ${BASH_EXECUTABLE} -c "\"scripts/mkversion\" \"-o\" \"version.h\" \"${dest_path}\""
+            COMMAND ${BASH_EXECUTABLE} -c "\"scripts/mkversion\" \"-v\" \"${KTX_VERSION_FULL}\" \"-o\" \"version.h\" \"${dest_path}\""
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Generate ${version_h_output}"
             VERBATIM
@@ -182,7 +184,7 @@ function( create_version_header dest_path target )
     else()
         add_custom_command(
             OUTPUT ${version_h_output}
-            COMMAND scripts/mkversion -o version.h ${dest_path}
+            COMMAND scripts/mkversion -v ${KTX_VERSION_FULL} -o version.h ${dest_path}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Generate ${version_h_output}"
             VERBATIM

--- a/scripts/mkversion
+++ b/scripts/mkversion
@@ -89,7 +89,10 @@ function setfile() {
 
 # Figure out the object name and write its version file.
 function writeversion() {
-  genversion $1
+  # Extract version from git if it is not passed via command line
+  if [-z "$VN"]; then
+    genversion $1
+  fi
   local vfp;
   if [ -z "$1" ]; then
     vfp=$VF
@@ -107,14 +110,14 @@ function writeversion() {
 }
 
 function usage() {
-    echo "Usage: $0 [-a] [-f] [-n] [-o <outfile>] [<object>]"
+    echo "Usage: $0 [-a] [-f] [-n] [-v version] [-o <outfile>] [<object>]"
     exit 1
 }
 
 force=0
 dry_run=0
 write_all=0;
-args=$(getopt afno: $*)
+args=$(getopt afnv:o: $*)
 
 set -- $args
 for i; do
@@ -125,6 +128,7 @@ for i; do
         shift;;
     -n) dry_run=1;
         shift;;
+    -v) VN=$2; shift; shift;;
     -o) VF=$2; shift; shift;;
     --) shift; break;;
   esac


### PR DESCRIPTION
Hello,

I would like to add ktx as a package to Alpine Linux, and one requirement is to be able to build from a tar.gz published from [v4.3.2](https://github.com/KhronosGroup/KTX-Software/releases/tag/v4.3.2)) but the current `cmake/version.cmake` is forcing to build from the original git repo, while when building within [Alpine aports](https://gitlab.alpinelinux.org/alpine/aports), we specify the version ourselves as part of the Alpine build system (automatically from the tar.gz downloaded).

This PR is making a small change to `cmake/version.cmake` to allow to pass `KTX_VERSION_FULL` to cmake.