### PR TITLE
Change MSVC std::mutex workaround

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -255,14 +255,6 @@ jobs:
       if: matrix.check_mkvk == 'ONLY'
       run: scripts/check_mkvk.ps1
 
-    # Works around issues with 2024.06.03.1.0 runner image. See
-    # https://github.com/actions/runner-images/issues/10004 and
-    # https://github.com/actions/runner-images/issues/10055
-    - name: Remove conflicting msvcp140.dll as workaround for runner image bugs.
-      shell: bash -l {0}
-      run: |
-          find "C:/hostedtoolcache/windows/Java_Temurin-Hotspot_jdk" -name "msvcp140.dll" -exec rm {} \;
-
     - name: Test Windows build
       # Tests built for arm64 can't be run as the CI runners are all x64.
       if: matrix.arch == 'x64' && matrix.options.tests == 'ON'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,7 +622,7 @@ macro(common_libktx_settings target enable_write library_type)
             # their own version of the VC++ redistributables chances are
             # high they will not have a modern enough version so JNI modules
             # linked with libktx will crash when multiple threads are used,
-            # which they are in the BasisU and ASTC encoders.
+            # as they are in the BasisU and ASTC encoders.
             #
             # To avoid this set a define to prevent the compiler using
             # constexpr mutex constructors. Remove this eventually after

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,8 +626,8 @@ macro(common_libktx_settings target enable_write library_type)
             # To avoid this set a define to prevent the compiler using
             # constexpr mutex constructors. Remove this eventually after
             # in-use JVM installations have at least this vcruntime.
-            "$<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>"
-            "$<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>"
+            $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+            $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
         PUBLIC # only for basisu_c_binding.
             BASISU_NO_ITERATOR_DEBUG_LEVEL
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,16 +616,17 @@ macro(common_libktx_settings target enable_write library_type)
             # Only set dllexport when building a shared library.
             $<$<STREQUAL:${library_type},SHARED>:KTX_API=__declspec\(dllexport\)>
             # Code compiled with the versions shown defaults to a constexpr
-            # std::mutex constructor and requires a vcruntime140.dll with at
-            # least version 140.0.33811 otherwise code creating a mutex
-            # crashes mysteriously. Since many JVM installations bundle their
-            # own version of the vcruntime chances are high they will not have
-            # a modern enough version so JNI modules linked to libktx will
-            # crash when multiple threads are used (BasisU and ASTC encoders).
+            # std::mutex constructor and requires a mscvp140.dll of at least
+            # version 14.40.33810.00 otherwise code creating a mutex
+            # crashes mysteriously. Since many JVM installations bundle 
+            # their own version of the VC++ redistributables chances are
+            # high they will not have a modern enough version so JNI modules
+            # linked with libktx will crash when multiple threads are used,
+            # which they are in the BasisU and ASTC encoders.
             #
             # To avoid this set a define to prevent the compiler using
             # constexpr mutex constructors. Remove this eventually after
-            # in-use JVM installations have at least this vcruntime. Remove
+            # in-use JVM installations have at least this VC runtime. Remove
             # also from ASTCENC_LIB_TARGET settings around line 1169.
             $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
             $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,7 +625,8 @@ macro(common_libktx_settings target enable_write library_type)
             #
             # To avoid this set a define to prevent the compiler using
             # constexpr mutex constructors. Remove this eventually after
-            # in-use JVM installations have at least this vcruntime.
+            # in-use JVM installations have at least this vcruntime. Remove
+            # also from ASTCENC_LIB_TARGET settings around line 1169.
             $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
             $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
         PUBLIC # only for basisu_c_binding.
@@ -1165,6 +1166,15 @@ endif()
 set(ASTCENC_CLI OFF) # Only build as library not the CLI astcencoder
 add_subdirectory(external/astc-encoder)
 set_property(TARGET ${ASTCENC_LIB_TARGET} PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(
+    ${ASTCENC_LIB_TARGET}
+PRIVATE
+    # ASTC encoder uses std::mutex. For more info. see comment about
+    # same setting in libktx starting about line 618. To be eventually
+    # removed as noted in that comment.
+    $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+    $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+)
 
 if(KTX_FEATURE_STATIC_LIBRARY AND APPLE)
     # Make a single static library to simplify linking.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,12 @@ if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "")
     set(CMAKE_CXX_COMPILER_FRONTEND_VARIANT "${CMAKE_CXX_COMPILER_ID}")
 endif()
 
+#cmake_print_variables(
+#    CMAKE_CXX_COMPILER_ID
+#    CMAKE_CXX_COMPILER_VERSION
+#    CMAKE_CXX_COMPILER_FRONTEND_VARIANT
+#)
+
 # Compiler accepts MSVC-style command line options
 set(is_msvc_fe "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},MSVC>")
 # Compiler accepts GNU-style command line options
@@ -609,6 +615,19 @@ macro(common_libktx_settings target enable_write library_type)
         PRIVATE
             # Only set dllexport when building a shared library.
             $<$<STREQUAL:${library_type},SHARED>:KTX_API=__declspec\(dllexport\)>
+            # Code compiled with the versions shown defaults to a constexpr
+            # std::mutex constructor and requires a vcruntime140.dll with at
+            # least version 140.0.33811 otherwise code creating a mutex
+            # crashes mysteriously. Since many JVM installations bundle their
+            # own version of the vcruntime chances are high they will not have
+            # a modern enough version so JNI modules linked to libktx will
+            # crash when multiple threads are used (BasisU and ASTC encoders).
+            #
+            # To avoid this set a define to prevent the compiler using
+            # constexpr mutex constructors. Remove this eventually after
+            # in-use JVM installations have at least this vcruntime.
+            "$<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>"
+            "$<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>"
         PUBLIC # only for basisu_c_binding.
             BASISU_NO_ITERATOR_DEBUG_LEVEL
         )
@@ -805,10 +824,6 @@ PRIVATE
 # Turn off these warnings until Rich fixes the occurences.
 # It it not clear to me if generator expressions can be used here
 # hence the long-winded way.
-#message(STATUS
-#        "CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID} "
-#        "CMAKE_CXX_COMPILER_VERSION = ${CMAKE_CXX_COMPILER_VERSION}"
-#)
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 # Currently no need to disable any warnings in basisu code. Rich fixed them.
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/interface/java_binding/CMakeLists.txt
+++ b/interface/java_binding/CMakeLists.txt
@@ -34,6 +34,12 @@ add_library(ktx-jni SHARED
 
 configure_file(src/main/cpp/ktx-jni.manifest.in ktx-jni.manifest)
 
+# See comment for same setting in root CMakeLists.txt around line 618.
+target_compile_definitions(ktx-jni PRIVATE
+    $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+    $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
+)
+
 target_include_directories(ktx-jni SYSTEM PRIVATE
       ${JNI_INCLUDE_DIRS}
 )

--- a/interface/java_binding/CMakeLists.txt
+++ b/interface/java_binding/CMakeLists.txt
@@ -34,12 +34,6 @@ add_library(ktx-jni SHARED
 
 configure_file(src/main/cpp/ktx-jni.manifest.in ktx-jni.manifest)
 
-# See comment for same setting in root CMakeLists.txt around line 618.
-target_compile_definitions(ktx-jni PRIVATE
-    $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.40.33811>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
-    $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
-)
-
 target_include_directories(ktx-jni SYSTEM PRIVATE
       ${JNI_INCLUDE_DIRS}
 )

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Copyright 2017-2020 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-if(WIN32)
-    cmake_print_variables(
-        CMAKE_SYSTEM_VERSION
-        CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION
-    )
-endif()
+#if(WIN32)
+#    cmake_print_variables(
+#        CMAKE_SYSTEM_VERSION
+#        CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION
+#    )
+#endif()
 
 if(NOT APPLE_LOCKED_OS)
     set( fp_pref ${CMAKE_FIND_PACKAGE_PREFER_CONFIG} )


### PR DESCRIPTION
Instead of removing the older version of the vcruntime from the Temurin JVM installation in the GitHub Actions runner image, define `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` when compiling libktx and ${ASTCENC_LIB_TARGET}. This makes the code compatible with older VC runtimes removing the burden from users to ensure their JVM installation uses the latest VC runtime.

See https://github.com/actions/runner-images/issues/10055. For further background see https://github.com/actions/runner-images/issues/10004 and https://developercommunity.visualstudio.com/t/Access-violation-in-_Thrd_yield-after-up/10664660#T-N10669129-N10678728.

Includes 2 other minor changes:

1. Move the compiler info dump in `CMakeLists.txt` to before first use of the compiler info and recode it to use `cmake_print_variables`.
2. Disable dump of system and platform info in `tests/loadtests/CMakeLists.txt`.