### PR TITLE
Workaround pyparser install failure on Travis Ubuntu/arm64.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,9 @@ jobs:
           SUPPORT_SSE=ON SUPPORT_OPENCL=OFF WERROR=ON PACKAGE=YES
     - os: linux
       arch: arm64
+      # Suggested by Travis-CI support to workaround pyparser install
+      # failure with 2024.6.25 runner image.
+      group: previous
       dist: jammy
       addons:
         apt:


### PR DESCRIPTION
Unbelievable. While still wrangling with the workaround for the major GHA Windows runner image meltdown (PR #920 and blocked-by-this PR #923) Travis breaks their Ubuntu/arm64 runner image such that installs of python-related tools on to the VM are failing.

This is their suggested workaround. I don't yet know if it will be needed permanently.