### PR TITLE
Fix issues newly flagged by Doxygen 1.11.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -154,33 +154,41 @@ jobs:
       if: github.ref_type == 'tag' && matrix.check_mkvk != 'ONLY'
       run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
 
-    # Need doxygen if docs are supposed to be built.
-    # Note this suffers frequent failures due to Chocolatey attempts
+    # Need doxygen and graphviz if docs are supposed to be built.
+    # Note these suffer frequent failures due to Chocolatey attempts
     # to blackmail you into purchasing a license. Hence we retry a
     # few times. If this still fails, re-run the build.
-    - name: Install Doxygen
+    - name: Install Doxygen and Graphviz
       if: matrix.options.doc == 'ON'
       #run: choco install doxygen.install
+      #run: choco install graphviz
       run: |
-        $retryCount = 4
-        $success = $false
-        for ($i = 1; $i -le $retryCount; $i++) {
-            Write-Host "Attempt no: $i"
-            choco install doxygen.install --no-progress
-            if ($LASTEXITCODE -eq 0) {
-                $success = $true
-                Write-Host "Installation successful."
-                break
-            } else {
-                Write-Host "Installation failed. Retrying..."
-                Start-Sleep -Seconds (2*$i)
+        function Install-WithChoco {
+            param ( $Package )
+            $retryCount = 4
+            $success = $false
+            for ($i = 1; $i -le $retryCount; $i++) {
+                Write-Host "Attempt no $i for $Package"
+                # Without | Out-Host the choco output becomes output of this
+                # function because it is called from within `if`.
+                choco install $Package --no-progress --yes | Out-Host
+                if ($LASTEXITCODE -eq 0) {
+                    $success = $true
+                    Write-Host "$Package installation successful."
+                    break
+                } else {
+                    Write-Host "$Package installation failed. Retrying..."
+                    Start-Sleep -Seconds (2*$i)
+                }
             }
+            if (-not $success) {
+                Write-Host "$Package installation failed after $retryCount attempts."
+            }
+            return $success
         }
-        if (-not $success) {
-            Write-Host "Installation failed after $retryCount attempts."
+        if (-not ((Install-WithChoco doxygen.install) -and (Install-WithChoco graphviz))) {
             exit 1
         }
-
     - name: Install AzureSignTool
       if: matrix.check_mkvk != 'ONLY'
       id: install-ast

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ addons:
     update: false
     packages:
     - git-lfs
-    - doxygen
 
 env:
   global:
@@ -107,6 +106,7 @@ jobs:
       addons:
         apt:
           packages:
+            - graphviz
             - python3
             - python3-venv
       compiler: gcc
@@ -127,6 +127,7 @@ jobs:
       addons:
         apt:
           packages:
+            - graphviz
             - python3
             - python3-venv
       compiler: gcc
@@ -245,6 +246,10 @@ install:
       if [ "$LOADTESTS_USE_LOCAL_DEPENDENCIES" = "ON" ]; then
           brew install sdl2
           brew install assimp
+      fi
+      if [ "$FEATURE_DOC" = "ON" ]; then
+          brew install doxygen
+          brew install graphviz
       fi
       ./scripts/install_macos.sh
     fi

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -570,12 +570,22 @@ For iOS and macOS, install the Vulkan SDK by downloading the macOS installer and
 
 ### Doxygen
 
-Needed if you want to generate the _libktx_ and _ktxtools_ documentation.
+Needed if you want to generate _libktx_, _ktxtools_ and other documentation.
 
-You need a minimum of version 1.8.14 to generate the documentation correctly. You
-can download binaries and also find instructions for building it from source at
-[Doxygen downloads](http://www.stack.nl/~dimitri/doxygen/download.html). Make
+You need a minimum of version 1.8.14 to generate the documentation correctly.
+You can download binaries and also find instructions for building it from source
+at [Doxygen downloads](http://www.stack.nl/~dimitri/doxygen/download.html). Make
 sure the directory containing the `doxygen` executable is in your `$PATH`.
+
+### dot (Graphviz)
+
+Needed if you want Doxygen to generate include dependency, inverse include
+dependency, inheritance and other graphs in the generated documentation.
+
+You can download binaries from
+[Graphviz downloads](https://graphviz.org/download/).
+
+Optional. If not present documentation will be generated minus graphs. 
 
 ### libassimp
 

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -1,7 +1,15 @@
 # Copyright 2015-2020 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-find_package(Doxygen REQUIRED)
+# dot is optional as missing include dependency graphs and
+# inheritance graphs is not a big enough deal to justify
+# forcing people to install Graphviz.
+find_package(Doxygen REQUIRED OPTIONAL_COMPONENTS dot)
+if(NOT DOXYGEN_DOT_EXECUTABLE)
+    message(NOTICE "dot executable not found so Doxygen will not generate\n"
+                   "include dependency or inheritance graphs in the documentation.\n"
+                   "If you want these graphs, install Graphviz.")
+endif()
 
 set(docdest "${CMAKE_CURRENT_BINARY_DIR}/docs")
 

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -85,6 +85,7 @@ function( CreateDocLibKTX )
     set( DOXYGEN_EXPAND_ONLY_PREDEF YES )
 
     set( DOXYGEN_PREDEFINED
+    KTX_DOXYGEN_SKIP
     "KTXTEXTURECLASSDEFN=class_id classId\; \\
         struct ktxTexture_vtbl* vtbl\;             \\
         struct ktxTexture_vvtbl* vvtbl\;           \\

--- a/include/KHR/khr_df.h
+++ b/include/KHR/khr_df.h
@@ -17,10 +17,10 @@
 #ifndef _KHR_DATA_FORMAT_H_
 #define _KHR_DATA_FORMAT_H_
 
-/** @file khr_df.h
-
-    @brief Data Format enums and macros.
-*/
+/** @file
+ * @~English
+ * @brief Data Format enums and macros.
+ */
 
 /* Accessors */
 typedef enum _khr_word_e {

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -191,8 +191,8 @@ typedef enum ktx_error_code_e {
     KTX_ERROR_MAX_ENUM = KTX_DECOMPRESS_CHECKSUM_ERROR /*!< For safety checks. */
 } ktx_error_code_e;
 /**
- * @deprecated
  * @~English
+ * @deprecated Use #ktx_error_code_e.
  * @brief For backward compatibility
  */
 #define KTX_error_code ktx_error_code_e

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -719,12 +719,24 @@ typedef struct ktxTexture2 {
     struct ktxTexture2_private* _private;  /*!< Private data. */
 } ktxTexture2;
 
-/**
- * @brief Helper for casting ktxTexture1 and ktxTexture2 to ktxTexture.
+/*
+ * If Doxygen sees this macro it gets confused and fails to spot
+ * references to ktxTexture_*() functions in the running text. It
+ * also complains it can't find the reference when @ref is used
+ * with a fully qualified method name to make an intra-class
+ * reference in the @c ktxTexture class.
+ * See https://github.com/doxygen/doxygen/issues/10311.
  *
- * Use with caution.
+ * Not documenting the macro is the lesser of two evils.
  */
-#define ktxTexture(t) ((ktxTexture*)t)
+#if !defined(KTX_DOXYGEN_SKIP)
+    /**
+     * @brief Helper for casting ktxTexture1 and ktxTexture2 to ktxTexture.
+     *
+     * Use with caution.
+     */
+    #define ktxTexture(t) ((ktxTexture*)t)
+#endif
 
 /**
  * @memberof ktxTexture

--- a/include/ktx.h
+++ b/include/ktx.h
@@ -1403,7 +1403,7 @@ typedef struct ktxBasisParams {
              Only valid for linear textures.
          */
     ktx_bool_t separateRGToRGB_A;
-        /*!< @deprecated. This was and is a no-op. 2-component inputs have
+        /*!< @deprecated This was and is a no-op. 2-component inputs have
             always been automatically separated using an "rrrg" inputSwizzle.
             @sa inputSwizzle and normalMode.
          */
@@ -1598,25 +1598,25 @@ typedef enum ktx_transcode_fmt_e {
         // Old enums for compatibility with code compiled against previous
         // versions of libktx.
         KTX_TF_ETC1 = KTX_TTF_ETC1_RGB,
-            //!< @deprecated. Use #KTX_TTF_ETC1_RGB.
+            //!< @deprecated Use #KTX_TTF_ETC1_RGB.
         KTX_TF_ETC2 = KTX_TTF_ETC,
-            //!< @deprecated. Use #KTX_TTF_ETC.
+            //!< @deprecated Use #KTX_TTF_ETC.
         KTX_TF_BC1 = KTX_TTF_BC1_RGB,
-            //!< @deprecated. Use #KTX_TTF_BC1_RGB.
+            //!< @deprecated Use #KTX_TTF_BC1_RGB.
         KTX_TF_BC3 = KTX_TTF_BC3_RGBA,
-            //!< @deprecated. Use #KTX_TTF_BC3_RGBA.
+            //!< @deprecated Use #KTX_TTF_BC3_RGBA.
         KTX_TF_BC4 = KTX_TTF_BC4_R,
-            //!< @deprecated. Use #KTX_TTF_BC4_R.
+            //!< @deprecated Use #KTX_TTF_BC4_R.
         KTX_TF_BC5 = KTX_TTF_BC5_RG,
-            //!< @deprecated. Use #KTX_TTF_BC5_RG.
+            //!< @deprecated Use #KTX_TTF_BC5_RG.
         KTX_TTF_BC7_M6_RGB = KTX_TTF_BC7_RGBA,
-            //!< @deprecated. Use #KTX_TTF_BC7_RGBA.
+            //!< @deprecated Use #KTX_TTF_BC7_RGBA.
         KTX_TTF_BC7_M5_RGBA = KTX_TTF_BC7_RGBA,
-            //!< @deprecated. Use #KTX_TTF_BC7_RGBA.
+            //!< @deprecated Use #KTX_TTF_BC7_RGBA.
         KTX_TF_BC7_M6_OPAQUE_ONLY = KTX_TTF_BC7_RGBA,
-            //!< @deprecated. Use #KTX_TTF_BC7_RGBA
+            //!< @deprecated Use #KTX_TTF_BC7_RGBA
         KTX_TF_PVRTC1_4_OPAQUE_ONLY = KTX_TTF_PVRTC1_4_RGB
-            //!< @deprecated. Use #KTX_TTF_PVRTC1_4_RGB.
+            //!< @deprecated Use #KTX_TTF_PVRTC1_4_RGB.
 } ktx_transcode_fmt_e;
 
 /**

--- a/lib/astc_encode.cpp
+++ b/lib/astc_encode.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file astc_encode.cpp
+ * @file
  * @~English
  *
  * @brief Functions for compressing a texture to ASTC format.

--- a/lib/astc_encode.cpp
+++ b/lib/astc_encode.cpp
@@ -201,7 +201,7 @@ unorm8x4ArrayToImage(const uint8_t *data, uint32_t dim_x, uint32_t dim_y) {
 
 /**
  * @memberof ktxTexture
- * @ingroup write
+ * @ingroup writer
  * @~English
  * @brief       Creates default ASTC parameters
  *
@@ -222,7 +222,7 @@ astcDefaultOptions() {
 
 /**
  * @memberof ktxTexture
- * @ingroup write
+ * @ingroup writer
  * @~English
  * @brief       Should be used to get VkFormat from ASTC block enum
  *
@@ -291,7 +291,7 @@ astcVkFormat(ktx_uint32_t block_size, bool sRGB) {
 
 /**
  * @memberof ktxTexture
- * @ingroup write
+ * @ingroup writer
  * @~English
  * @brief Creates valid ASTC encoder action from string.
  *
@@ -320,7 +320,7 @@ astcEncoderAction(const ktxAstcParams &params, const uint32_t* bdb) {
 
 /**
  * @memberof ktxTexture
- * @ingroup write
+ * @ingroup writer
  * @~English
  * @brief Creates valid ASTC encoder swizzle from string.
  *

--- a/lib/basis_encode.cpp
+++ b/lib/basis_encode.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file basis_encode.cpp
+ * @file
  * @~English
  *
  * @brief Functions for supercompressing a texture with Basis Universal.

--- a/lib/basis_transcode.cpp
+++ b/lib/basis_transcode.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file basis_transcode.cpp
+ * @file
  * @~English
  *
  * @brief Functions for transcoding Basis Universal BasisLZ/ETC1S and UASTC textures.

--- a/lib/checkheader.c
+++ b/lib/checkheader.c
@@ -10,7 +10,7 @@
 
 /**
  * @internal
- * @file checkheader.c
+ * @file
  * @~English
  *
  * @brief Function to verify a KTX file header

--- a/lib/gl_funclist.inl
+++ b/lib/gl_funclist.inl
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file gl_funclist.h
+ * @file
  * @~English
  *
  * @brief List of OpenGL {,ES} functions used by libktx.

--- a/lib/gl_funcs.c
+++ b/lib/gl_funcs.c
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file gl_funcs.c
+ * @file
  * @~English
  *
  * @brief Retrieve OpenGL function pointers needed by libktx

--- a/lib/gl_funcs.h
+++ b/lib/gl_funcs.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file vk_funcs.h
+ * @file
  * @~English
  *
  * @brief Declare pointers for OpenGL {,ES} functions.

--- a/lib/hashlist.c
+++ b/lib/hashlist.c
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file hashlist.c
+ * @file
  * @~English
  *
  * @brief Functions for creating and using a hash list of key-value

--- a/lib/info.c
+++ b/lib/info.c
@@ -3,7 +3,7 @@
 
 /**
  * @internal
- * @file info.c
+ * @file
  * @~English
  *
  * @brief Functions for printing information about KTX or KTX2.

--- a/lib/miniz_wrapper.cpp
+++ b/lib/miniz_wrapper.cpp
@@ -9,7 +9,7 @@
 
 /**
  * @internal
- * @file miniz_wrapper.c
+ * @file
  * @~English
  *
  * @brief Wrapper functions for ZLIB compression/decompression using miniz.

--- a/lib/strings.c
+++ b/lib/strings.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file strings.c
+ * @file
  * @~English
  *
  * @brief Functions to return a string corresponding to various enumerations.

--- a/lib/texture.c
+++ b/lib/texture.c
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file texture.c
+ * @file
  * @~English
  *
  * @brief ktxTexture implementation.

--- a/lib/texture.h
+++ b/lib/texture.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file texture.h
+ * @file
  * @~English
  *
  * @brief Declare internal ktxTexture functions for sharing between

--- a/lib/texture1.c
+++ b/lib/texture1.c
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file texture2.c
+ * @file
  * @~English
  *
  * @brief ktxTexture1 implementation. Support for KTX format.

--- a/lib/texture1.h
+++ b/lib/texture1.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file texture1.h
+ * @file
  * @~English
  *
  * @brief Declare internal ktxTexture1 functions for sharing between

--- a/lib/texture2.c
+++ b/lib/texture2.c
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file texture2.c
+ * @file
  * @~English
  *
  * @brief ktxTexture2 implementation. Support for KTX2 format.

--- a/lib/texture2.c
+++ b/lib/texture2.c
@@ -1421,7 +1421,7 @@ ktxTexture2_CreateFromStdioStream(FILE* stdioStream,
  * @exception KTX_FILE_OPEN_FAILED The file could not be opened.
  * @exception KTX_INVALID_VALUE @p filename is @c NULL.
  *
- * For other exceptions, see ktxTexture_CreateFromStdioStream().
+ * For other exceptions, see ktxTexture2_CreateFromStdioStream().
  */
 KTX_error_code
 ktxTexture2_CreateFromNamedFile(const char* const filename,
@@ -1474,7 +1474,7 @@ ktxTexture2_CreateFromNamedFile(const char* const filename,
  *
  * @exception KTX_INVALID_VALUE Either @p bytes is NULL or @p size is 0.
  *
- * For other exceptions, see ktxTexture_CreateFromStdioStream().
+ * For other exceptions, see ktxTexture2_CreateFromStdioStream().
  */
 KTX_error_code
 ktxTexture2_CreateFromMemory(const ktx_uint8_t* bytes, ktx_size_t size,
@@ -1526,7 +1526,7 @@ ktxTexture2_CreateFromMemory(const ktx_uint8_t* bytes, ktx_size_t size,
  *
  * @exception KTX_INVALID_VALUE Either @p bytes is NULL or @p size is 0.
  *
- * For other exceptions, see ktxTexture_CreateFromStdioStream().
+ * For other exceptions, see ktxTexture2_CreateFromStdioStream().
  */
 KTX_error_code
 ktxTexture2_CreateFromStream(ktxStream* stream,

--- a/lib/texture2.c
+++ b/lib/texture2.c
@@ -1912,7 +1912,8 @@ ktxTexture2_GetOETF_e(ktxTexture2* This)
 /**
  * @memberof ktxTexture2
  * @~English
- * @brief Retrieve the opto-electrical transfer function of the imS
+ * @brief Retrieve the opto-electrical transfer function of the images.
+ * @deprecated Use ktxTexture2\_GetOETF\_e.
  *
  * @param[in]     This      pointer to the ktxTexture2 object of interest.
  *

--- a/lib/texture2.c
+++ b/lib/texture2.c
@@ -1913,7 +1913,7 @@ ktxTexture2_GetOETF_e(ktxTexture2* This)
  * @memberof ktxTexture2
  * @~English
  * @brief Retrieve the opto-electrical transfer function of the images.
- * @deprecated Use ktxTexture2\_GetOETF\_e.
+ * @deprecated Use ktxTexture2\_GetOETF\_e().
  *
  * @param[in]     This      pointer to the ktxTexture2 object of interest.
  *

--- a/lib/texture2.c
+++ b/lib/texture2.c
@@ -1912,8 +1912,7 @@ ktxTexture2_GetOETF_e(ktxTexture2* This)
 /**
  * @memberof ktxTexture2
  * @~English
- * @brief Retrieve the opto-electrical transfer function of the images.
- * @deprecated Retained for backward compatibility. Use ktxTexture2\_GetOETF\_e()
+ * @brief Retrieve the opto-electrical transfer function of the imS
  *
  * @param[in]     This      pointer to the ktxTexture2 object of interest.
  *

--- a/lib/texture2.h
+++ b/lib/texture2.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file texture2.h
+ * @file
  * @~English
  *
  * @brief Declare internal ktxTexture2 functions for sharing between

--- a/lib/texture_funcs.inl
+++ b/lib/texture_funcs.inl
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file texture_funcs.h
+ * @file
  * @~English
  *
  * @brief Templates for functions common to base & derived ktxTexture classes.

--- a/lib/vk2gl.h
+++ b/lib/vk2gl.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file vk2gl.h
+ * @file
  * @~English
  *
  * @brief Get GL format information matching a VkFormat

--- a/lib/vk_funcs.c
+++ b/lib/vk_funcs.c
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file vk_funcs.c
+ * @file
  * @~English
  *
  * @brief Retrieve Vulkan function pointers needed by libktx

--- a/lib/vk_funcs.h
+++ b/lib/vk_funcs.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file vk_funcs.h
+ * @file
  * @~English
  *
  * @brief Declare pointers for Vulkan functions.

--- a/lib/vkloader.c
+++ b/lib/vkloader.c
@@ -1444,9 +1444,8 @@ ktxTexture_VkUploadEx_WithSuballocator(ktxTexture* This, ktxVulkanDeviceInfo* vd
  * @~English
  * @brief Create a Vulkan image object from a ktxTexture object.
  *
- * Calls @ref ktxTexture::ktxTexture\_VkUploadEx_WithSuballocator
- * "ktxTexture_VkUploadEx_WithSuballocator()" with no supplied suballocator
- * callbacks. Use that for complete control.
+ * Calls ktxTexture\_VkUploadEx\_WithSuballocator() with no supplied
+ * suballocator callbacks. Use that for complete control.
  */
 KTX_error_code
 ktxTexture_VkUploadEx(ktxTexture* This, ktxVulkanDeviceInfo* vdi,
@@ -1464,8 +1463,8 @@ ktxTexture_VkUploadEx(ktxTexture* This, ktxVulkanDeviceInfo* vdi,
  * @~English
  * @brief Create a Vulkan image object from a ktxTexture object.
  *
- * Calls @ref ktxTexture::ktxTexture\_VkUploadEx "ktxTexture_VkUploadEx()" with
- * the most commonly used options: @c VK_IMAGE_TILING_OPTIMAL,
+ * Calls ktxTexture\_VkUploadEx() with the most commonly used options:
+ * @c VK_IMAGE_TILING_OPTIMAL,
  * @c VK_IMAGE_USAGE_SAMPLED_BIT and
  * @c VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL. Use that for complete
  * control.
@@ -1506,7 +1505,7 @@ ktxTexture1_VkUploadEx_WithSuballocator(ktxTexture1* This, ktxVulkanDeviceInfo* 
  * @~English
  * @brief Create a Vulkan image object from a ktxTexture1 object.
  *
- * @copydetails ktxTexture::ktxTexture_VkUploadEx
+ * This simply calls @ref ktxTexture::ktxTexture\_VkUploadEx "ktxTexture_VkUploadEx()".
  */
 KTX_error_code
 ktxTexture1_VkUploadEx(ktxTexture1* This, ktxVulkanDeviceInfo* vdi,
@@ -1565,8 +1564,6 @@ ktxTexture2_VkUploadEx_WithSuballocator(ktxTexture2* This, ktxVulkanDeviceInfo* 
  * @brief Create a Vulkan image object from a ktxTexture2 object.
  *
  * This simply calls @ref ktxTexture::ktxTexture\_VkUploadEx "ktxTexture_VkUploadEx()".
- *
- * @copydetails ktxTexture::ktxTexture_VkUploadEx
  */
 KTX_error_code
 ktxTexture2_VkUploadEx(ktxTexture2* This, ktxVulkanDeviceInfo* vdi,

--- a/lib/writer1.c
+++ b/lib/writer1.c
@@ -3,7 +3,7 @@
 
 /**
  * @internal
- * @file writer.c
+ * @file
  * @~English
  *
  * @brief Functions for creating KTX-format files from a set of images.

--- a/lib/writer2.c
+++ b/lib/writer2.c
@@ -3,7 +3,7 @@
 
 /**
  * @internal
- * @file writer.c
+ * @file
  * @~English
  *
  * @brief Functions for creating KTX-format files from a set of images.

--- a/tests/loadtests/appfwSDL/AppBaseSDL.cpp
+++ b/tests/loadtests/appfwSDL/AppBaseSDL.cpp
@@ -10,7 +10,7 @@
 
 /**
  * @internal
- * @file AppBaseSDL.cpp
+ * @file
  * @~English
  *
  * @brief Base class for SDL applications.

--- a/tests/loadtests/appfwSDL/AppBaseSDL.h
+++ b/tests/loadtests/appfwSDL/AppBaseSDL.h
@@ -13,7 +13,7 @@
 
 /**
  * @internal
- * @file AppBaseSDL.h
+ * @file
  * @~English
  *
  * @brief Declarations for App framework using SDL.

--- a/tests/loadtests/appfwSDL/GLAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/GLAppSDL.cpp
@@ -10,7 +10,7 @@
 
 /**
  * @internal
- * @file GLAppSDLGL.cpp
+ * @file
  * @~English
  *
  * @brief GLAppSDL app class.

--- a/tests/loadtests/appfwSDL/GLAppSDL.h
+++ b/tests/loadtests/appfwSDL/GLAppSDL.h
@@ -13,7 +13,7 @@
 
 /**
  * @internal
- * @file GLAppSDL.h
+ * @file
  * @~English
  *
  * @brief Declaration of GLAppSDL base class for GL apps.

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/vulkancheckres.h
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/vulkancheckres.h
@@ -19,7 +19,7 @@
 
 /**
  * @internal
- * @file vulkancheckres.h
+ * @file
  * @~English
  *
  * @brief Check result of a Vulkan command.

--- a/tests/loadtests/appfwSDL/main.cpp
+++ b/tests/loadtests/appfwSDL/main.cpp
@@ -10,7 +10,7 @@
 
 /**
  * @internal
- * @file main.c
+ * @file
  * @~English
  *
  * @brief main() function for SDL app framework.

--- a/tests/loadtests/common/ltexceptions.h
+++ b/tests/loadtests/common/ltexceptions.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file ltexceptions.h
+ * @file
  * @~English
  *
  * @brief Custom exceptions for the load tests.

--- a/tests/loadtests/common/vecmath.hpp
+++ b/tests/loadtests/common/vecmath.hpp
@@ -10,7 +10,7 @@
 #define VECMATH_9B7E1CFE346D11E6AFA2D7DC87495A69_H
 
 /**
- * @file vecmath.h
+ * @file
  * @~English
  *
  * @brief Vector math package modelled after GLSL.

--- a/tests/loadtests/glloadtests/GLLoadTests.cpp
+++ b/tests/loadtests/glloadtests/GLLoadTests.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file GLLoadTests.cpp
+ * @file
  * @~English
  *
  * @brief Implementation of app for running a set of OpenGL load tests.

--- a/tests/loadtests/glloadtests/GLLoadTests.h
+++ b/tests/loadtests/glloadtests/GLLoadTests.h
@@ -11,7 +11,7 @@
 
 /**
  * @internal
- * @file LoadTests.h
+ * @file
  * @~English
  *
  * @brief Definition of app for running a set of OpenGL load tests.

--- a/tests/loadtests/glloadtests/shader-based/DrawTexture.cpp
+++ b/tests/loadtests/glloadtests/shader-based/DrawTexture.cpp
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    DrawTexture.cpp
+ * @file
  * @brief   Tests texture loading by using glDrawTexture to draw the texture.
  *
  * @author  Mark Callow

--- a/tests/loadtests/glloadtests/shader-based/DrawTexture.h
+++ b/tests/loadtests/glloadtests/shader-based/DrawTexture.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    DrawTexture.h
+ * @file
  * @brief   Definition of texture loading test using glDrawTexture.
  *
  * @author  Mark Callow

--- a/tests/loadtests/glloadtests/shader-based/EncodeTexture.cpp
+++ b/tests/loadtests/glloadtests/shader-based/EncodeTexture.cpp
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    EncodeTexture.cpp
+ * @file
  * @brief    Encode a texture then texture a cube with it, transcoding if necessary.
  *
  * This is used principally to check the encoders are properly linked on platforms where the ktx tools are

--- a/tests/loadtests/glloadtests/shader-based/EncodeTexture.h
+++ b/tests/loadtests/glloadtests/shader-based/EncodeTexture.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    EncodeTexture.h
+ * @file
  * @brief   GLLoadTestSample derived class for encoding a texture and texturing a cube with it.
  *
  * @author Mark Callow, www.edgewise-consulting.com.

--- a/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
+++ b/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file LoadTestsGL3.cpp
+ * @file
  * @~English
  *
  * @brief Instantiate GLLoadTests app with set of tests for OpenGL 3.3+ and

--- a/tests/loadtests/glloadtests/shader-based/InstancedSampleBase.cpp
+++ b/tests/loadtests/glloadtests/shader-based/InstancedSampleBase.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file InstancedSampleBase.cpp
+ * @file
  * @~English
  *
  * @brief Base for samplesusing instancing such as array texture display.

--- a/tests/loadtests/glloadtests/shader-based/Texture3d.cpp
+++ b/tests/loadtests/glloadtests/shader-based/Texture3d.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file Texture3d.cpp
+ * @file
  * @~English
  *
  * @brief Definition of test sample for loading and displaying the slices of a 3d texture.

--- a/tests/loadtests/glloadtests/shader-based/Texture3d.h
+++ b/tests/loadtests/glloadtests/shader-based/Texture3d.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file Texture3d.h
+ * @file
  * @~English
  *
  * @brief Declaration of test sample for loading and displaying the slices of a 3d texture..

--- a/tests/loadtests/glloadtests/shader-based/TextureArray.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TextureArray.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file TextureArray.cpp
+ * @file
  * @~English
  *
  * @brief Definition of test sample for loading and displaying the layers of a 2D array texture.

--- a/tests/loadtests/glloadtests/shader-based/TextureArray.h
+++ b/tests/loadtests/glloadtests/shader-based/TextureArray.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file TextureArray.h
+ * @file
  * @~English
  *
  * @brief Declaration of test sample for loading and displaying the layers of a 2D array texture.

--- a/tests/loadtests/glloadtests/shader-based/TextureCubemap.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TextureCubemap.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file TextureCubemap.cpp
+ * @file
  * @~English
  *
  * @brief Test loading of 2D texture arrays.

--- a/tests/loadtests/glloadtests/shader-based/TextureCubemap.h
+++ b/tests/loadtests/glloadtests/shader-based/TextureCubemap.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file TextureCubemap.h
+ * @file
  * @~English
  *
  * @brief Test loading of a cubemap.

--- a/tests/loadtests/glloadtests/shader-based/TextureMipmap.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TextureMipmap.cpp
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file TextureMipmap.cpp
+ * @file
  * @~English
  *
  * @brief Definition of test sample for loading and displaying all the levels of a 2D mipmapped texture.

--- a/tests/loadtests/glloadtests/shader-based/TextureMipmap.h
+++ b/tests/loadtests/glloadtests/shader-based/TextureMipmap.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file TextureMipmap.h
+ * @file
  * @~English
  *
  * @brief Declaration of test sample for loading and displaying all the levels of a 2D mipmapped texture.

--- a/tests/loadtests/glloadtests/shader-based/TexturedCube.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TexturedCube.cpp
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    TexturedCube.cpp
+ * @file
  * @brief    Draw a textured cube.
  *
  * @author Mark Callow, www.edgewise-consulting.com.

--- a/tests/loadtests/glloadtests/shader-based/TexturedCube.h
+++ b/tests/loadtests/glloadtests/shader-based/TexturedCube.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    TexturedCube.h
+ * @file
  * @brief   GLLoadTestSample derived class for drawing a textured cube.
  *
  * @author Mark Callow, www.edgewise-consulting.com.

--- a/tests/loadtests/glloadtests/shader-based/mygl.h
+++ b/tests/loadtests/glloadtests/shader-based/mygl.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    mygl.h
+ * @file
  * @brief   Include appropriate version of gl.h for the shader-based tests.
  *
  * This is a separate header to avoid repetition of these conditionals.

--- a/tests/loadtests/glloadtests/shader-based/shaders.cpp
+++ b/tests/loadtests/glloadtests/shader-based/shaders.cpp
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file    shaders.c
+ * @file
  * @brief   Shaders used by the DrawTexture and TexturedCube samples.
  */
 

--- a/tests/loadtests/vkloadtests/Texture3d.h
+++ b/tests/loadtests/vkloadtests/Texture3d.h
@@ -11,7 +11,7 @@
 
 /**
  * @internal
- * @file Texture3d.h
+ * @file
  * @~English
  *
  * @brief Declaration of test sample for loading and displaying the slices of a 3d texture..

--- a/tests/loadtests/vkloadtests/TextureArray.h
+++ b/tests/loadtests/vkloadtests/TextureArray.h
@@ -11,7 +11,7 @@
 
 /**
  * @internal
- * @file TextureArray.h
+ * @file
  * @~English
  *
  * @brief Declaration of test sample for loading and displaying the layers of a 2D array texture.

--- a/tests/loadtests/vkloadtests/TextureMipmap.h
+++ b/tests/loadtests/vkloadtests/TextureMipmap.h
@@ -11,7 +11,7 @@
 
 /**
  * @internal
- * @file TextureMipmap.h
+ * @file
  * @~English
  *
  * @brief Declaration of test sample for loading and displaying all the levels of a 2D mipmapped texture.

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -3,7 +3,7 @@
 
 /**
  * @internal
- * @file texturetests.cc
+ * @file
  * @~English
  *
  * @brief Test ktxTexture API functions.

--- a/tests/unittests/image_unittests.cc
+++ b/tests/unittests/image_unittests.cc
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file unittests.cc
+ * @file
  * @~English
  *
  * @brief Tests of internal API functions.

--- a/tests/unittests/unittests.cc
+++ b/tests/unittests/unittests.cc
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file unittests.cc
+ * @file
  * @~English
  *
  * @brief Tests of internal API functions.

--- a/tests/unittests/wthelper.h
+++ b/tests/unittests/wthelper.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file wthelper.h
+ * @file
  * @~English
  *
  * @brief Helper class for writer tests.

--- a/tools/imageio/formatdesc.h
+++ b/tools/imageio/formatdesc.h
@@ -8,7 +8,7 @@
 
 /**
  * @internal
- * @file formatdesc.h
+ * @file
  * @~English
  *
  * @brief Data Format Descriptor for imageio.

--- a/tools/imageio/image.hpp
+++ b/tools/imageio/image.hpp
@@ -7,7 +7,7 @@
 //!
 //! @internal
 //! @~English
-//! @file image.hpp
+//! @file
 //!
 //! @brief Internal Image class
 //!

--- a/tools/imageio/imagecodec.hpp
+++ b/tools/imageio/imagecodec.hpp
@@ -8,7 +8,7 @@
 //!
 //! @internal
 //! @~English
-//! @file imagecodec.hpp
+//! @file
 //!
 //! @brief Internal Image Codec class
 //!

--- a/tools/imageio/imageinput.cc
+++ b/tools/imageio/imageinput.cc
@@ -7,7 +7,7 @@
 //!
 //! @internal
 //! @~English
-//! @file imageinput.cc
+//! @file
 //!
 //! @brief ImageInput:open function
 //!

--- a/tools/imageio/imageio.cc
+++ b/tools/imageio/imageio.cc
@@ -7,7 +7,7 @@
 //!
 //! @internal
 //! @~English
-//! @file imageio.cc
+//! @file
 //!
 //! @brief Create plugin maps.
 //!

--- a/tools/imageio/imageio.h
+++ b/tools/imageio/imageio.h
@@ -7,7 +7,7 @@
 //!
 //! @internal
 //! @~English
-//! @file imageio.h
+//! @file
 //!
 //! @brief Base classes for image input and output plugins
 //!

--- a/tools/imageio/imageoutput.cc
+++ b/tools/imageio/imageoutput.cc
@@ -7,7 +7,7 @@
 //!
 //! @internal
 //! @~English
-//! @file imageoutput.cc
+//! @file
 //!
 //! @brief ImageOutput class implementation
 //!

--- a/tools/imageio/imagespan.hpp
+++ b/tools/imageio/imagespan.hpp
@@ -8,7 +8,7 @@
 //!
 //! @internal
 //! @~English
-//! @file imagespan.hpp
+//! @file
 //!
 //! @brief Internal Image Span container and iterator classes
 //!

--- a/tools/imageio/png.imageio/pngoutput.cc
+++ b/tools/imageio/png.imageio/pngoutput.cc
@@ -7,7 +7,7 @@
 /**
  * @internal
  * @~English
- * @file pngoutput.cc
+ * @file
  *
  * @brief ImageOutput to  PNG format files.
  *

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -22,6 +22,10 @@
 #include "image.hpp"
 #include "imageio.h"
 
+/** @file
+ * @~English
+ * @brief @b create command implementation.
+ */
 
 // -------------------------------------------------------------------------------------------------
 
@@ -735,7 +739,7 @@ Create a KTX2 file from various input files.
 @par Version 4.0
  - Initial version
 
- @par Version 4.4
+@par Version 4.4
  - Reorganize encoding options.
  - Improve explanation of use of @b \--format with @b \--encode.
  - Improve explanation of ASTC encoding.

--- a/tools/ktx2check/ktx2check.cpp
+++ b/tools/ktx2check/ktx2check.cpp
@@ -106,7 +106,7 @@ Check the validity of a KTX 2 file.
     <dt>-w, \--warn-as-error</dt>
     <dd>Treat warnings as errors. Changes exit code from success to error.
     </dl>
-    @snippetdoc ktxapp.h ktxApp options
+    @snippet{doc} ktxapp.h ktxApp options
 
 @section ktx2check_exitstatus EXIT STATUS
     @b ktx2check exits 0 on success, 1 on command line errors and 2 on


### PR DESCRIPTION
Some were genuine issues that surprisingly weren't flagged before:
`astc_encode.cpp`, `ktx2check.c`.

One is a change to an existing Doxygen issue that caused a
previously working reference to not be found: `vkloader.c`.

Includes these other documentation related changes:

1. Change several ktxTexture references in ktxTexture2 to ktxTexture2 references.
2. Update CI to install `graphviz` of which `dot` is part. With `dot` Doxygen provides nice include dependency, inverse include dependency, inheritance and other graphs.
3. Make Doxygen skip the documentation for the ktxTexture macro as the existence of a same-named macro causes Doxygen to fail to make intra-class cross-references in the ktxTexture class.
4. Fine tune the deprecation statements.
5. Remove names from `@file` commands. These are unnecessary and error-prone. Three mismatches were spotted
during this work.

**IMPORTANT**  Documentation for releases must not be generated with Doxygen 1.11.0 as it has a bug that causes it to not add snippets to generated pages. See https://github.com/doxygen/doxygen/issues/10957.
