### PR TITLE
Handle problems caused by runner and Docker image updates

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -213,6 +213,12 @@ jobs:
           core.exportVariable('VCPKG_BINARY_SOURCES', "clear;x-gha,readwrite");
           core.exportVariable('VCPKG_ROOT', process.env.VCPKG_INSTALLATION_ROOT || '');
 
+    - name: Setup PIP_CONSTRAINTS (workaround https://github.com/python-cffi/cffi/issues/117)
+      if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
+      run:
+          echo 'setuptools<74' > $env:BUILD_DIR/constraint.txt
+          echo "PIP_CONSTRAINT=$env:BUILD_DIR/constraint.txt" >> $env:GITHUB_ENV
+
     - name: Install Dependencies
       if: matrix.check_mkvk != 'ONLY'
       # This script only installs what's needed by ON FEATUREs.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -216,6 +216,7 @@ jobs:
     - name: Setup PIP_CONSTRAINTS (workaround https://github.com/python-cffi/cffi/issues/117)
       if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
       run: |
+          mkdir $env:BUILD_DIR # Doesn't exist until CMake configure
           echo 'setuptools<74' > $env:BUILD_DIR/constraint.txt
           echo "PIP_CONSTRAINT=$env:BUILD_DIR/constraint.txt" >> $env:GITHUB_ENV
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -216,9 +216,8 @@ jobs:
     - name: Setup PIP_CONSTRAINT (workaround https://github.com/python-cffi/cffi/issues/117)
       if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
       run: |
-          mkdir interface/python_binding/build # Doesn't exist until python build.
-          echo 'setuptools<74' > interface/python_binding/build/constraint.txt
-          echo "PIP_CONSTRAINT=interface/python_binding/build/constraint.txt" >> $env:GITHUB_ENV
+          echo 'setuptools<74' > $env:RUNNER_TEMP/constraint.txt
+          echo "PIP_CONSTRAINT=$env:RUNNER_TEMP/constraint.txt" >> $env:GITHUB_ENV
 
     - name: Install Dependencies
       if: matrix.check_mkvk != 'ONLY'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -213,12 +213,12 @@ jobs:
           core.exportVariable('VCPKG_BINARY_SOURCES', "clear;x-gha,readwrite");
           core.exportVariable('VCPKG_ROOT', process.env.VCPKG_INSTALLATION_ROOT || '');
 
-    - name: Setup PIP_CONSTRAINTS (workaround https://github.com/python-cffi/cffi/issues/117)
+    - name: Setup PIP_CONSTRAINT (workaround https://github.com/python-cffi/cffi/issues/117)
       if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
       run: |
-          mkdir $env:BUILD_DIR # Doesn't exist until CMake configure
-          echo 'setuptools<74' > $env:BUILD_DIR/constraint.txt
-          echo "PIP_CONSTRAINT=$env:BUILD_DIR/constraint.txt" >> $env:GITHUB_ENV
+          mkdir interface/python_binding/build # Doesn't exist until python build.
+          echo 'setuptools<74' > interface/python_binding/build/constraint.txt
+          echo "PIP_CONSTRAINT=interface/python_binding/build/constraint.txt" >> $env:GITHUB_ENV
 
     - name: Install Dependencies
       if: matrix.check_mkvk != 'ONLY'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -215,7 +215,7 @@ jobs:
 
     - name: Setup PIP_CONSTRAINTS (workaround https://github.com/python-cffi/cffi/issues/117)
       if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
-      run:
+      run: |
           echo 'setuptools<74' > $env:BUILD_DIR/constraint.txt
           echo "PIP_CONSTRAINT=$env:BUILD_DIR/constraint.txt" >> $env:GITHUB_ENV
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,8 +902,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         )
     endif()
     if (${clang_version} VERSION_GREATER_EQUAL "14.0")
-        # These are for Emscripten which is ahead of xcode in its clang
-        # version. Also future proofing for when xcode catches up.
         set_source_files_properties(
             ${BASISU_ENCODER_CXX_SRC}
             PROPERTIES COMPILE_OPTIONS "-Wno-sign-compare;-Wno-unused-variable;-Wno-unused-parameter;-Wno-deprecated-copy-with-user-provided-copy"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,9 +315,10 @@ endif()
 
 # For Visual Studio prior to 2022 (compiler < 19.30) /fp:strict
 # For Visual Studio 2022 (compiler >= 19.30) /fp:precise
-# For Visual Studio 2022 ClangCL seems to have accidentally enabled contraction by default,
-# so behaves differently to CL.exe. Use the -Xclang argument to workaround and allow access
-# GNU-style switch to control contraction and force disable.
+# For Visual Studio 2022 ClangCL has enabled contraction by default,
+# which is the same as standard clang, so behaves differently to
+# CL.exe. Use the -Xclang argument to access GNU-style switch to
+# control contraction and force disable.
 
 # On CMake 3.25 or older CXX_COMPILER_FRONTEND_VARIANT is not always set
 if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "")
@@ -338,6 +339,7 @@ set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
 set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
 # Compiler accepts GNU-style command line options
 set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
+#add_custom_target(debug_isgnufe1 COMMAND ${CMAKE_COMMAND} -E echo "is_gnufe1_exp = $<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
 
 # Compiler is Visual Studio cl.exe
 set(is_msvccl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:MSVC>>")
@@ -346,24 +348,18 @@ set(is_clangcl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:Clang>>")
 # Compiler is upstream clang with the standard frontend
 set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")
 
-if(${is_msvccl} AND $<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.30>)
-    add_compile_options(/fp:strict)
-endif()
-if(${is_msvccl} AND $<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>)
-    add_compile_options(/fp:precise)
-endif()
-if(${is_clangcl})
-    add_compile_options(/fp:precise)
-endif()
-if(${is_clangcl} AND $<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0.0>)
-    add_compile_options(-Xclang -ffp-contract=off)
-endif()
-if(${is_clang} AND $<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>)
-    add_compile_options(-ffp-model=precise)
-endif()
-if(${is_gnu_fe})
-    add_compile_options(-ffp-contract=off)
-endif()
+add_compile_options(
+    $<$<AND:${is_msvccl},$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.30>>:/fp:strict>
+    $<$<AND:${is_msvccl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,19.30>>:/fp:precise>
+    $<${is_clangcl}:/fp:precise>
+    $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0.0>>:-Xclang$<SEMICOLON>-ffp-contract=off>
+    $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,10.0.0>>:-ffp-model=precise>
+    $<${is_gnu_fe}:-ffp-contract=off>
+    # Hide noise from clang and clangcl 20 warning the 2nd fp option changes
+    # one of the settings made the first.
+    $<$<AND:${is_clang},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,20.0.0>>:-Wno-overriding-option>
+)
+#add_custom_target(debug_gnufe_ffpcontract COMMAND ${CMAKE_COMMAND} -E echo "ffp_contract = $<${is_gnu_fe}:-ffp-contract=off>")
 
 set(KTX_BUILD_DIR "${CMAKE_BINARY_DIR}")
 

--- a/external/astc-encoder/Source/cmake_core.cmake
+++ b/external/astc-encoder/Source/cmake_core.cmake
@@ -176,6 +176,7 @@ macro(astcenc_set_properties ASTCENC_TARGET_NAME ASTCENC_IS_VENEER)
             $<${is_gnu_fe}:-Wno-float-equal>
             $<${is_gnu_fe}:-Wno-deprecated-declarations>
             $<${is_gnu_fe}:-Wno-atomic-implicit-seq-cst>
+            $<${is_clang}:-Wno-overriding-option>
 
             # Clang 10 also throws up warnings we need to investigate (ours)
             $<${is_gnu_fe}:-Wno-cast-align>

--- a/scripts/build_wasm_docker.sh
+++ b/scripts/build_wasm_docker.sh
@@ -74,12 +74,18 @@ mkdir -p $BUILD_DIR
 # emcmake uses the "Unix Makefiles" generator on Linux which does not
 # support multiple configurations.
 echo "Configure and Build KTX-Software (Web $CONFIGURATION)"
+
+# Uncomment and set to desired targets if you don't want to build everything.
+#targets="--target debug_isgnufe1 --target debug_gnufe_ffpcontract"
+# Uncomment to have make run in verbose mode.
+#verbose_make="-- VERBOSE=1"
+
 docker exec -it emscripten sh -c "emcmake cmake -B$BUILD_DIR . \
     -D CMAKE_BUILD_TYPE=$CONFIGURATION \
     -D KTX_FEATURE_DOC=OFF \
     -D KTX_FEATURE_LOADTEST_APPS=$FEATURE_LOADTESTS \
     -D KTX_WERROR=$WERROR \
-  && cmake --build $BUILD_DIR"
+  && cmake --build $BUILD_DIR $targets $verbose_make"
 
 if [ "$PACKAGE" = "YES" ]; then
   echo "Pack KTX-Software (Web $CONFIGURATION)"


### PR DESCRIPTION
An Emscripten Docker image update to Clang 20 and an update to the GitHub Actions Windows runner image broke our CI builds. This PR provides fixes or workarounds. While working on the Clang 20 issue it was noticed that the FP options for `libktx` were not being set as intended, except for the ASTC encoder. This PR also fixes that problem so the same FP options are used throughout `libktx`. Lastly it contains improvements to `build_wasm_docker.sh` made while debugging and fixing the FP settings issue.

clang 20 has a new "overriding option" warning which is raised if one float-point option modifies a setting made by another. We are setting `-ffp-model=precise`, which leaves contraction on, and `-ffp-contract=off` thus we get the warning. This usage is normal for cross-platform invariance thus the fix is to disable the spam warning.

The Windows runner image update broke the python build due to removal of a long deprecated package from the Python/PIP `setuptools` package and our use of the `cffi` package which has a dependency on `setuptools` including the deleted package. See https://github.com/python-cffi/cffi/issues/117. This PR works around the problem by creating a `constraint.txt` file which is passed to PIP and tells it to limit the `setuptools` package to a version that still contains the deleted package.