### PR TITLE
Make separate feature for OpenGL load tests dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,9 @@ set_property( CACHE KTX_FEATURE_LOADTEST_APPS
 
 if(NOT KTX_FEATURE_LOADTEST_APPS MATCHES OFF)
     set(VCPKG_MANIFEST_FEATURES loadtests)
+    if (KTX_FEATURE_LOADTEST_APPS MATCHES OpenGL)
+        list(APPEND VCPKG_MANIFEST_FEATURES glloadtests)
+    endif()
     if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
         # Explicitly set the triplet to avoid potential trouble.
         # Automatic triplet selection in CI, which runs on x86_64, selects

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,19 +3,24 @@
   "name": "ktx-software",
   "features": {
     "loadtests": {
-      "description": "OpenGL & Vulkan Load Tests. All dependencies from vcpkg",
+      "description": "OpenGL & Vulkan Load Tests.",
       "dependencies": [
         "assimp",
-        {
-          "name": "glew",
-          "platform": "windows"
-        },
         {
           "name": "sdl2",
           "default-features": true,
           "features": [
             "vulkan"
           ]
+        }
+      ]
+    },
+    "glloadtests": {
+      "description": "OpenGL Load Tests.",
+      "dependencies": [
+        {
+          "name": "glew",
+          "platform": "windows"
         }
       ]
     }


### PR DESCRIPTION
So OpenGL load tests-specific dependency is only installed when those tests are configured.