### PR TITLE
Fix: handle spaces and non-latin characters in filenames in loadtest apps.

### DIFF
--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -113,7 +113,7 @@ IFS=, ; for config in $CONFIGURATION
 do
   IFS=$oldifs # Because of ; IFS set above will still be present.
   # Build and test
-  #if [ "$config" = "Debug" ]; then continue; fi
+  if [ "$config" = "Debug" ]; then continue; fi
   echo "Build KTX-Software (macOS $ARCHS $config)"
   if [ -n "$MACOS_CERTIFICATES_P12" -a "$config" = "Release" ]; then
     cmake --build . --config $config | handle_compiler_output

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -113,7 +113,7 @@ IFS=, ; for config in $CONFIGURATION
 do
   IFS=$oldifs # Because of ; IFS set above will still be present.
   # Build and test
-  if [ "$config" = "Debug" ]; then continue; fi
+  #if [ "$config" = "Debug" ]; then continue; fi
   echo "Build KTX-Software (macOS $ARCHS $config)"
   if [ -n "$MACOS_CERTIFICATES_P12" -a "$config" = "Release" ]; then
     cmake --build . --config $config | handle_compiler_output

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/vulkantextoverlay.hpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/vulkantextoverlay.hpp
@@ -705,7 +705,7 @@ public:
 
         // Generate a uv mapped quad per char in the new text
         it = text.begin();
-        while (it != text.end())        {
+        while (it != text.end())
         {
             if (!advanceUTF8(it, text.end(), codepoint))
                 break;
@@ -744,7 +744,6 @@ public:
 
             if (numLetters == MAX_CHAR_COUNT)
                 break; // Truncate the text.
-        }
         }
     }
     // Unmap buffer and update command buffers

--- a/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
+++ b/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
@@ -15,6 +15,9 @@
  *        OpenGL ES 3.x
  */
 
+#include <string>
+#include <regex>
+
 #include "GLLoadTests.h"
 #include "EncodeTexture.h"
 #include "DrawTexture.h"
@@ -71,6 +74,9 @@ GLLoadTests::showFile(std::string& filename)
         createViewer = DrawTexture::create;
     }
     ktxTexture_Destroy(kTexture);
+
+    // Escape any spaces in filename.
+    filename = std::regex_replace( filename, std::regex(" "), "\\ " );
     std::string args = "--external " + filename;
     pViewer = createViewer(w_width, w_height, args.c_str(), sBasePath);
     return pViewer;

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -165,6 +165,12 @@ add_executable( vkloadtests
 
 set_code_sign(vkloadtests)
 
+# If VulkanAppSDL is ever made into its own target change the target here.
+target_compile_features(vkloadtests
+PRIVATE
+    cxx_std_14
+)
+
 target_include_directories(vkloadtests
 PRIVATE
     ${SDL2_INCLUDE_DIRS}

--- a/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
@@ -20,6 +20,8 @@
 
 #define _USE_MATH_DEFINES
 #include <math.h>
+#include <string>
+#include <regex>
 
 #include "VulkanLoadTests.h"
 #include "Texture.h"
@@ -355,6 +357,9 @@ VulkanLoadTests::showFile(std::string& filename)
         createViewer = Texture::create;
     }
     ktxTexture_Destroy(kTexture);
+
+    // Escape any spaces in filename.
+    filename = std::regex_replace( filename, std::regex(" "), "\\ " );
     std::string args = "--external " + filename;
     pViewer = createViewer(vkctx, w_width, w_height, args.c_str(), sBasePath);
     return pViewer;

--- a/utils/argparser.cpp
+++ b/utils/argparser.cpp
@@ -21,7 +21,10 @@
  */
 
 #include <assert.h>
+#include <iostream>
 #include "argparser.h"
+#include <regex>
+#include <locale>
 
 using namespace std;
 
@@ -30,18 +33,53 @@ using namespace std;
  */
 argvector::argvector(const string& sArgs)
 {
-    const string sep(" \t\n\r\v\f");
+    const string sep(" \t");
+    //std::locale old = std::locale::global(std::locale("ja_JP.UTF-8"));
+    // std::regex does not support negative lookbehind assertions. Darn!
+    // RE to extract argument between string start and separator.
+    // - Match 0 is whole matching string including separator.
+    // - Match 1 is the argument.
+    // Use negative character class as it is easiest way to handle
+    // utf-8 file names with non-Latin characters. $ must not be last
+    // in the character class or it will be taken literally not as
+    // end of string.
+    // Use raw literal to avoid excess backslashes.
+    regex re(R"--(^([^$ \t]+)(?:[ \t]+|$))--");
+    //regex re(R"--(^([\\/:._[:alnum:]-]+)(?:[ \t]+|$))--");
     size_t pos;
 
     pos = sArgs.find_first_not_of(sep);
     assert(pos != string::npos);
 
-    do {
-        size_t epos = sArgs.find_first_of(sep, pos);
-        size_t len = epos == string::npos ? epos : epos - pos;
-        push_back(sArgs.substr(pos, len));
-        pos = sArgs.find_first_not_of(sep, epos);
-    } while (pos != string::npos);
+    auto first = sArgs.begin() + pos;
+    auto last = sArgs.end();
+    bool continuation = false;
+    bool needContinuation = false;
+    for (smatch sm; regex_search(first, last, sm, re);) {
+        std::cout << "prefix: " << sm.prefix() << '\n';
+        std::cout << "suffix: " << sm.suffix() << '\n';
+        std::cout << "match size: " << sm.size() << '\n';
+        for(uint32_t i = 0; i < sm.size(); i++) {
+            std::cout << "match " << i << ": " << "\"" << sm.str(i) << "\"" << '\n';
+        }
+        string arg;
+        // All this because std::regex does not support negative lookbehind.
+        if (*(sm[1].second - 1) == '\\') {
+            arg = string(sm[1].first, sm[1].second - 1) + " ";
+            needContinuation = true;
+        } else {
+            arg = sm.str(1);
+            needContinuation = false;
+        }
+        if (continuation) {
+            this->back() += arg;
+        } else {
+            push_back(arg);
+        }
+        continuation = needContinuation;
+        first = sm.suffix().first;
+    }
+    //std::locale::global(old);
 }
 
 /*

--- a/utils/argparser.cpp
+++ b/utils/argparser.cpp
@@ -24,7 +24,6 @@
 #include <iostream>
 #include "argparser.h"
 #include <regex>
-#include <locale>
 
 using namespace std;
 


### PR DESCRIPTION
Non-latin characters were a problem only for vkloadtests because only it has a text overlay.