### PR TITLE
Add casts to fix new clang 20 warning:

### DIFF
--- a/external/basisu/encoder/basisu_comp.cpp
+++ b/external/basisu/encoder/basisu_comp.cpp
@@ -1820,7 +1820,7 @@ namespace basisu
 		}
 
 		basist::ktx2_header header = {};
-		memset(&header, 0, sizeof(header));
+		memset((void*)&header, 0, sizeof(header));
 
 		memcpy(header.m_identifier, basist::g_ktx2_file_identifier, sizeof(basist::g_ktx2_file_identifier));
 		header.m_pixel_width = base_width;
@@ -1914,7 +1914,7 @@ namespace basisu
 			etc1s_global_data_header.m_tables_byte_length = backend_output.m_slice_image_tables.size();
 
 			basisu::vector<basist::ktx2_etc1s_image_desc> etc1s_image_descs(total_levels * total_layers * total_faces);
-			memset(etc1s_image_descs.data(), 0, etc1s_image_descs.size_in_bytes());
+			memset((void*)etc1s_image_descs.data(), 0, etc1s_image_descs.size_in_bytes());
 
 			for (uint32_t slice_index = 0; slice_index < m_slice_descs.size(); slice_index++)
 			{
@@ -2057,7 +2057,7 @@ namespace basisu
 		}
 
 		basisu::vector<basist::ktx2_level_index> level_index_array(total_levels);
-		memset(level_index_array.data(), 0, level_index_array.size_in_bytes());
+		memset((void*)level_index_array.data(), 0, level_index_array.size_in_bytes());
 				
 		m_output_ktx2_file.clear();
 		m_output_ktx2_file.reserve(m_output_basis_file.size());

--- a/external/basisu/transcoder/basisu.h
+++ b/external/basisu/transcoder/basisu.h
@@ -126,7 +126,7 @@ namespace basisu
 	void debug_printf(const char *pFmt, ...);
 		
 
-	template <typename T> inline void clear_obj(T& obj) { memset(&obj, 0, sizeof(obj)); }
+	template <typename T> inline void clear_obj(T& obj) { memset((void*)&obj, 0, sizeof(obj)); }
 
 	template <typename T0, typename T1> inline T0 lerp(T0 a, T0 b, T1 c) { return a + (b - a) * c; }
 

--- a/external/basisu/transcoder/basisu_transcoder.cpp
+++ b/external/basisu/transcoder/basisu_transcoder.cpp
@@ -16610,11 +16610,11 @@ namespace basist
 		m_pData = nullptr;
 		m_data_size = 0;
 
-		memset(&m_header, 0, sizeof(m_header));
+		memset((void*)&m_header, 0, sizeof(m_header));
 		m_levels.clear();
 		m_dfd.clear();
 		m_key_values.clear();
-		memset(&m_etc1s_header, 0, sizeof(m_etc1s_header));
+		memset((void*)&m_etc1s_header, 0, sizeof(m_etc1s_header));
 		m_etc1s_image_descs.clear();
 				
 		m_format = basist::basis_tex_format::cETC1S;
@@ -16661,7 +16661,7 @@ namespace basist
 		m_pData = static_cast<const uint8_t *>(pData);
 		m_data_size = data_size;
 
-		memcpy(&m_header, pData, sizeof(m_header));
+		memcpy((void*)&m_header, pData, sizeof(m_header));
 
 		// We only support UASTC and ETC1S
 		if (m_header.m_vk_format != KTX2_VK_FORMAT_UNDEFINED)
@@ -16757,7 +16757,7 @@ namespace basist
 			return false;
 		}
 
-		memcpy(&m_levels[0], m_pData + sizeof(ktx2_header), level_index_size_in_bytes);
+		memcpy((void*)&m_levels[0], m_pData + sizeof(ktx2_header), level_index_size_in_bytes);
 		
 		// Sanity check the level offsets and byte sizes
 		for (uint32_t i = 0; i < m_levels.size(); i++)
@@ -17270,7 +17270,7 @@ namespace basist
 
 		const uint8_t* pSrc = m_pData + m_header.m_sgd_byte_offset;
 
-		memcpy(&m_etc1s_header, pSrc, sizeof(ktx2_etc1s_global_data_header));
+		memcpy((void*)&m_etc1s_header, pSrc, sizeof(ktx2_etc1s_global_data_header));
 		pSrc += sizeof(ktx2_etc1s_global_data_header);
 
 		if ((!m_etc1s_header.m_endpoints_byte_length) || (!m_etc1s_header.m_selectors_byte_length) || (!m_etc1s_header.m_tables_byte_length))
@@ -17303,7 +17303,7 @@ namespace basist
 			return false;
 		}
 		
-		memcpy(m_etc1s_image_descs.data(), pSrc, sizeof(ktx2_etc1s_image_desc) * image_count);
+		memcpy((void*)m_etc1s_image_descs.data(), pSrc, sizeof(ktx2_etc1s_image_desc) * image_count);
 		pSrc += sizeof(ktx2_etc1s_image_desc) * image_count;
 
 		// Sanity check the ETC1S image descs


### PR DESCRIPTION
attempting to memcpy non-trivially copyable type.