### PR TITLE
Fix JNI function name for `getDataSizeUncompressed`

### DIFF
--- a/interface/java_binding/src/main/cpp/KtxTexture.cpp
+++ b/interface/java_binding/src/main/cpp/KtxTexture.cpp
@@ -188,7 +188,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_khronos_ktx_KtxTexture_getDataSize(J
     return static_cast<jlong>(ktxTexture_GetDataSize(texture));
 }
 
-extern "C" JNIEXPORT jlong JNICALL Java_org_khronos_KTXTexture_getDataSizeUncompressed(JNIEnv *env, jobject thiz)
+extern "C" JNIEXPORT jlong JNICALL Java_org_khronos_ktx_KtxTexture_getDataSizeUncompressed(JNIEnv *env, jobject thiz)
 {
     ktxTexture *texture = get_ktx_texture(env, thiz);
     if (texture == NULL) 

--- a/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
+++ b/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
@@ -607,14 +607,24 @@ public class KtxTexture2Test {
                 .toAbsolutePath()
                 .normalize();
 
+        // The purpose of this test is to check the bindings for the 'native'
+        // functions that only return a value. When the binding for one of
+        // these functions is not implemented properly, then trying to call
+        // it will cause an 'UnsatisfiedLinkError'.
+        // This does not cover all 'native' functions: Some of them can only
+        // sensibly be called in the context of the other tests.
+
         KtxTexture2 texture = KtxTexture2.createFromNamedFile(testKtxFile.toString(),
                 KtxTextureCreateFlagBits.NO_FLAGS);
+
+        // Native getter methods from the 'KtxTexture2' class
         texture.getOETF();
         texture.getPremultipliedAlpha();
         texture.needsTranscoding();
         texture.getSupercompressionScheme();
         texture.getVkFormat();
 
+        // Native getter methods from the 'KtxTexture' class
         texture.isArray();
         texture.isCubemap();
         texture.isCompressed();

--- a/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
+++ b/interface/java_binding/src/test/java/org/khronos/ktx/test/KtxTexture2Test.java
@@ -599,4 +599,37 @@ public class KtxTexture2Test {
 
         t.destroy();
     }
+
+    @Test
+    public void testBindings() {
+        Path testKtxFile = Paths.get("")
+                .resolve("../../tests/testimages/astc_ldr_4x4_FlightHelmet_baseColor.ktx2")
+                .toAbsolutePath()
+                .normalize();
+
+        KtxTexture2 texture = KtxTexture2.createFromNamedFile(testKtxFile.toString(),
+                KtxTextureCreateFlagBits.NO_FLAGS);
+        texture.getOETF();
+        texture.getPremultipliedAlpha();
+        texture.needsTranscoding();
+        texture.getSupercompressionScheme();
+        texture.getVkFormat();
+
+        texture.isArray();
+        texture.isCubemap();
+        texture.isCompressed();
+        texture.getGenerateMipmaps();
+        texture.getBaseWidth();
+        texture.getBaseHeight();
+        texture.getBaseDepth();
+        texture.getNumDimensions();
+        texture.getNumLevels();
+        texture.getNumFaces();
+        texture.getDataSize();
+        texture.getDataSizeUncompressed();
+        texture.getElementSize();
+        texture.getRowPitch(0);
+        texture.getImageSize(0);
+    }
+
 }


### PR DESCRIPTION
A small fix for the JNI bindings:

 The function signature for `getDataSizeUncompressed` was given as 
`Java_org_khronos_KTXTexture_getDataSizeUncompressed` but must be
`Java_org_khronos_ktx_KtxTexture_getDataSizeUncompressed` (matching the full package- and class name)

Currently, calling this function would result in a
`java.lang.UnsatisfiedLinkError: org.khronos.ktx.KtxTexture.getDataSizeUncompressed()J`

I also added a test that _might_ look useless at the first glance: It just creates a texture, and calls all the `native` "getter" functions on that (without any assertion). The point of that test is that it would have _prevented_ this kind of error...

