### PR TITLE
Cast a macro argument to `int` to fix a C++20 error.

### DIFF
--- a/include/KHR/khr_df.h
+++ b/include/KHR/khr_df.h
@@ -106,7 +106,7 @@ typedef enum _khr_df_mask_e {
     ((BDB)[KHR_DF_WORD_ ## X] = \
      ((BDB)[KHR_DF_WORD_ ## X] & \
       ~((KHR_DF_MASK_ ## X) << (KHR_DF_SHIFT_ ## X))) | \
-     (((val) & (KHR_DF_MASK_ ## X)) << (KHR_DF_SHIFT_ ## X)))
+     (((int)(val) & (KHR_DF_MASK_ ## X)) << (KHR_DF_SHIFT_ ## X)))
 
 /* Offsets relative to the start of a sample */
 typedef enum _khr_df_sampleword_e {


### PR DESCRIPTION
Clang 20 errors for me on several expansions of the `KHR_DFDSETVAL` macro because it attempts to bitwise-and two different types of enums. For example:
```
/home/conscat/vulkan-experiments/KTX-Software/lib/basis_encode.cpp:256:5: error: invalid bitwise operation between different enumeration types ('_khr_df_vendorid_e' and '_khr_df_mask_e')
  256 |     KHR_DFDSETVAL(nbdb, VENDORID, KHR_DF_VENDORID_KHRONOS);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/conscat/vulkan-experiments/KTX-Software/include/KHR/khr_df.h:109:13: note: expanded from macro 'KHR_DFDSETVAL'
  109 |     (((val) & (KHR_DF_MASK_ ## X)) << (KHR_DF_SHIFT_ ## X)))
      |       ~~~~~ ^ ~~~~~~~~~~~~~~~~~~~
```
This PR simply casts the value to an int inside of the macro.