### PR TITLE
Fix ktxTexture2_DecodeAstc error returns and document them.

### DIFF
--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -588,27 +588,27 @@ launchThreads(int threadCount, void (*func)(int, int, void*), void *payload) {
 static ktx_error_code_e
 mapAstcError(astcenc_error astc_error) {
     switch (astc_error) {
-      case ASTCENC_SUCCESS:
+    case ASTCENC_SUCCESS:
         return KTX_SUCCESS;
-      case ASTCENC_ERR_OUT_OF_MEM:
+    case ASTCENC_ERR_OUT_OF_MEM:
         return KTX_OUT_OF_MEMORY;
-      case ASTCENC_ERR_BAD_BLOCK_SIZE: [[fallthrough]];
-	  case ASTCENC_ERR_BAD_DECODE_MODE: [[fallthrough]];
-      case ASTCENC_ERR_BAD_FLAGS: [[fallthrough]];
-      case ASTCENC_ERR_BAD_PARAM: [[fallthrough]];
-      case ASTCENC_ERR_BAD_PROFILE: [[fallthrough]];
-      case ASTCENC_ERR_BAD_QUALITY: [[fallthrough]];
-      case ASTCENC_ERR_BAD_SWIZZLE:
+    case ASTCENC_ERR_BAD_BLOCK_SIZE: [[fallthrough]];
+    case ASTCENC_ERR_BAD_DECODE_MODE: [[fallthrough]];
+    case ASTCENC_ERR_BAD_FLAGS: [[fallthrough]];
+    case ASTCENC_ERR_BAD_PARAM: [[fallthrough]];
+    case ASTCENC_ERR_BAD_PROFILE: [[fallthrough]];
+    case ASTCENC_ERR_BAD_QUALITY: [[fallthrough]];
+    case ASTCENC_ERR_BAD_SWIZZLE:
         assert(false && "libktx passing bad parameter to astcenc");
         return KTX_INVALID_VALUE;
-      case ASTCENC_ERR_BAD_CONTEXT:
+    case ASTCENC_ERR_BAD_CONTEXT:
         assert(false && "libktx has set up astcenc context incorrectly");
         return KTX_INVALID_OPERATION;
-      case ASTCENC_ERR_BAD_CPU_FLOAT:
+    case ASTCENC_ERR_BAD_CPU_FLOAT:
         assert(false && "Code compiled in way that float operations do not meet codec's assumptions.");
         // Most likely compiled with fast match enabled.
         return KTX_INVALID_OPERATION;
-      case ASTCENC_ERR_NOT_IMPLEMENTED:
+    case ASTCENC_ERR_NOT_IMPLEMENTED:
         assert(false && "ASTCENC_BLOCK_MAX_TEXELS not enough for specified block size");
         return KTX_UNSUPPORTED_FEATURE;
     }

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -606,7 +606,7 @@ mapAstcError(astcenc_error astc_error) {
         return KTX_INVALID_OPERATION;
     case ASTCENC_ERR_BAD_CPU_FLOAT:
         assert(false && "Code compiled such that float operations do not meet codec's assumptions.");
-        // Most likely compiled with fast match enabled.
+        // Most likely compiled with fast math enabled.
         return KTX_INVALID_OPERATION;
     case ASTCENC_ERR_NOT_IMPLEMENTED:
         assert(false && "ASTCENC_BLOCK_MAX_TEXELS not enough for specified block size");

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -592,12 +592,12 @@ mapAstcError(astcenc_error astc_error) {
         return KTX_SUCCESS;
     case ASTCENC_ERR_OUT_OF_MEM:
         return KTX_OUT_OF_MEMORY;
-    case ASTCENC_ERR_BAD_BLOCK_SIZE: [[fallthrough]];
-    case ASTCENC_ERR_BAD_DECODE_MODE: [[fallthrough]];
-    case ASTCENC_ERR_BAD_FLAGS: [[fallthrough]];
-    case ASTCENC_ERR_BAD_PARAM: [[fallthrough]];
-    case ASTCENC_ERR_BAD_PROFILE: [[fallthrough]];
-    case ASTCENC_ERR_BAD_QUALITY: [[fallthrough]];
+    case ASTCENC_ERR_BAD_BLOCK_SIZE: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_DECODE_MODE: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_FLAGS: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_PARAM: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_PROFILE: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_QUALITY: //[[fallthrough]];
     case ASTCENC_ERR_BAD_SWIZZLE:
         assert(false && "libktx passing bad parameter to astcenc");
         return KTX_INVALID_VALUE;
@@ -605,12 +605,18 @@ mapAstcError(astcenc_error astc_error) {
         assert(false && "libktx has set up astcenc context incorrectly");
         return KTX_INVALID_OPERATION;
     case ASTCENC_ERR_BAD_CPU_FLOAT:
-        assert(false && "Code compiled in way that float operations do not meet codec's assumptions.");
+        assert(false && "Code compiled such that float operations do not meet codec's assumptions.");
         // Most likely compiled with fast match enabled.
         return KTX_INVALID_OPERATION;
     case ASTCENC_ERR_NOT_IMPLEMENTED:
         assert(false && "ASTCENC_BLOCK_MAX_TEXELS not enough for specified block size");
         return KTX_UNSUPPORTED_FEATURE;
+    // gcc fails to detect that the switch handles all astcenc_error
+    // enumerators and raises a return-type error, "control reaches end of
+    // non-void function", hence this
+    default:
+        assert(false && "Unhandled astcenc error");
+        return KTX_INVALID_OPERATION;
     }
 }
 


### PR DESCRIPTION
This started due to a warning when building documentation that `astc_encode.cpp` was not being found. After fixing that I noticed issues with the documentation for `ktxTexture2_DecodeAstc` which I fixed in c16537c89aef25980aa1ed56b5bd371619e1ed11. That commit also fixed an issue where the function would fail with `KTX_INVALID_OPERATION` if a zlib or zstd supercompressed file had been opened without specifying the LOAD_DATA flag by removing the check for `KTX_SS_NONE`.

Subsequently I realized there still some supercompression scheme situations that need to be guarded against and I realized the function documentation was not listing the possible return values. While fixing these I spotted a write to stdout that this PR comments out. Libraries potentially used by GUI apps should not write to stdout. We could potentially add a flag parameter to request the ouput.

@wasimabbas-arm please review this PR.

Why do decoder failures return `KTX_INVALID_OPERATION`? Could you analyze the astcenc error and potentially map to other KTX_ errors? Alternatively should we add a new error such as `KTX_ASTC_DECODE_FAILED`? `KTX_INVALID_OPERATION` is intended for cases where the application has set things up in way that is invalid for the operation it is requesting.

Adding unit tests for this function to texturetests would be a good thing. Tests of the encode function would be good too, if not already existing.

