### PR TITLE
fix: INSTALL_RPATH for linux using lib64

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -55,7 +55,7 @@ function(set_tool_properties tool_target)
             # Check DT_RUNPATH with one of
             # - readelf -d <file> | head -20
             # - objdump -x <file> | grep 'R.*PATH'
-            INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../lib"
+            INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         )
     endif()
 endfunction()


### PR DESCRIPTION
I found that the RPATH is not properly set for linux distributions that use lib64 as the default library directory(e.g., RedHat or CentOS)

I changed the RPATH to follow the directory which libktx is actually installed.