### PR TITLE
Add --{assign.convert}-texcoord-origin option to ktx create

### DIFF
--- a/tools/imageio/exr.imageio/exrinput.cc
+++ b/tools/imageio/exr.imageio/exrinput.cc
@@ -236,6 +236,13 @@ void ExrInput::readImage(void* outputBuffer, size_t bufferByteCount,
             fmt::format("EXR load error: {}.", "Unsupported EXR version (2.0)"));
 
     // Load image data
+
+    // TinyEXR does an unnecessary y-flip when line_order != 0, i.e is
+    // "decreasing Y". Unnecessary because the source data_ptr, passed to
+    // DecodePixelData points at the location in the file of the scanline
+    // being decoded. The location of scanline y in the output never changes.
+    // Avoid this bug.
+    header.line_order = 0;
     ec = LoadEXRImageFromMemory(&image, &header, exrBuffer.data(), exrBuffer.size(), &err);
     if (ec != TINYEXR_SUCCESS)
         throw std::runtime_error(fmt::format("EXR load error: {} - {}.", ec, err));

--- a/tools/imageio/exr.imageio/exrinput.cc
+++ b/tools/imageio/exr.imageio/exrinput.cc
@@ -237,11 +237,11 @@ void ExrInput::readImage(void* outputBuffer, size_t bufferByteCount,
 
     // Load image data
 
-    // TinyEXR does an unnecessary y-flip when line_order != 0, i.e is
-    // "decreasing Y". Unnecessary because the source data_ptr, passed to
-    // DecodePixelData points at the location in the file of the scanline
-    // being decoded. The location of scanline y in the output never changes.
-    // Avoid this bug.
+    // TinyEXR decodes images so that the first bytes in the returned buffer
+    // are the top-left corner of the image with line_order == 0 "increasing Y"
+    // and the bottom-left corner, "decreasing Y", otherwise. Force a top-left
+    // origin regardless of the line_order in the file. See
+    // https://github.com/syoyo/tinyexr/issues/213 for more information.
     header.line_order = 0;
     ec = LoadEXRImageFromMemory(&image, &header, exrBuffer.data(), exrBuffer.size(), &err);
     if (ec != TINYEXR_SUCCESS)

--- a/tools/imageio/exr.imageio/exrinput.cc
+++ b/tools/imageio/exr.imageio/exrinput.cc
@@ -167,6 +167,8 @@ void ExrInput::open(ImageSpec& newspec) {
                             width,
                             height,
                             1,
+                            // We make TinyEXR decode to top-left.
+                            ImageSpec::Origin(ImageSpec::Origin::eLeft, ImageSpec::Origin::eTop),
                             header.num_channels,
                             bitDepth,
                             static_cast<khr_df_sample_datatype_qualifiers_e>(qualifiers),
@@ -239,7 +241,7 @@ void ExrInput::readImage(void* outputBuffer, size_t bufferByteCount,
 
     // TinyEXR decodes images so that the first bytes in the returned buffer
     // are the top-left corner of the image with line_order == 0 "increasing Y"
-    // and the bottom-left corner, "decreasing Y", otherwise. Force a top-left
+    // and the bottom-left corner otherwise, "decreasing Y". Force a top-left
     // origin regardless of the line_order in the file. See
     // https://github.com/syoyo/tinyexr/issues/213 for more information.
     header.line_order = 0;
@@ -270,6 +272,9 @@ void ExrInput::readImage(void* outputBuffer, size_t bufferByteCount,
             channels[3] = i;
         else
             warning(fmt::format("EXR load warning: Unrecognized channel \"{}\" is ignored.", header.channels[i].name));
+        // TODO: check for 1 channel "Y" and make greyscale texture.
+        // TODO: check for "Y", "RY" and "BY" (luminance/chroma) and reject as unsupported.
+        // TODO: check for "AR", "AG", "AB" and make texture with pre-multipled alpha provided there is also an A channel? Or reject?
     }
 
     // Copy the data

--- a/tools/imageio/imageio.h
+++ b/tools/imageio/imageio.h
@@ -81,6 +81,7 @@ class ImageSpec {
     uint32_t imageHeight;          ///< height of the pixel data
     uint32_t imageDepth;           ///< depth of pixel data, >1 indicates a "volume"
     Origin imageOrigin;            ///< logical corner of image that is the first pixel in the data stream
+
   public:
     ImageSpec() : imageWidth(0), imageHeight(0),
                   imageDepth(0), imageOrigin() { }

--- a/tools/imageio/jpg.imageio/jpginput.cc
+++ b/tools/imageio/jpg.imageio/jpginput.cc
@@ -213,6 +213,7 @@ JpegInput::readHeader()
     // return what the decode() method will return not what is in the file.
 
     images.emplace_back(ImageSpec(pJd->get_width(), pJd->get_height(), 1,
+                                ImageSpec::Origin(ImageSpec::Origin::eLeft, ImageSpec::Origin::eTop),
                                 pJd->get_num_components(), 8, // component bit length
                                 static_cast<khr_df_sample_datatype_qualifiers_e>(0),
                                 KHR_DF_TRANSFER_SRGB,

--- a/tools/imageio/npbm.imageio/npbminput.cc
+++ b/tools/imageio/npbm.imageio/npbminput.cc
@@ -404,12 +404,13 @@ void NpbmInput::parseGPHeader(filetype ftype)
     }
 
     images.emplace_back(ImageSpec(width, height, 1,
-                                     ftype == filetype::PPM ? 3 : 1, 8,
-                                     0, maxVal,
-                                     static_cast<khr_df_sample_datatype_qualifiers_e>(0),
-                                     KHR_DF_TRANSFER_ITU,
-                                     KHR_DF_PRIMARIES_BT709,
-                                     ftype == filetype::PPM
+                                  ImageSpec::Origin(ImageSpec::Origin::eLeft, ImageSpec::Origin::eTop),
+                                  ftype == filetype::PPM ? 3 : 1, 8,
+                                  0, maxVal,
+                                  static_cast<khr_df_sample_datatype_qualifiers_e>(0),
+                                  KHR_DF_TRANSFER_ITU,
+                                  KHR_DF_PRIMARIES_BT709,
+                                  ftype == filetype::PPM
                                           ? KHR_DF_MODEL_RGBSDA
                                           : KHR_DF_MODEL_YUVSDA),
                         ImageInputFormatType::npbm);

--- a/tools/imageio/png.imageio/pnginput.cc
+++ b/tools/imageio/png.imageio/pnginput.cc
@@ -227,7 +227,9 @@ PngInput::readHeader()
         break;
     }
 
-    images.emplace_back(ImageSpec(w, h, 1, componentCount,
+  images.emplace_back(ImageSpec(w, h, 1,
+                            ImageSpec::Origin(ImageSpec::Origin::eLeft, ImageSpec::Origin::eTop),
+                            componentCount,
                             bitDepth,
                             static_cast<khr_df_sample_datatype_qualifiers_e>(0),
                             KHR_DF_TRANSFER_UNSPECIFIED,

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -292,15 +292,15 @@ struct OptionsCreate {
             orig.x = sm.str(2).compare("left") ? ImageSpec::Origin::eRight
                                                : ImageSpec::Origin::eLeft;
             orig.y = sm.str(1).compare("bottom") ? ImageSpec::Origin::eTop
-                                                : ImageSpec::Origin::eBottom;
+                                                 : ImageSpec::Origin::eBottom;
             if (args[kCubemap].count()) {
                 if (orig.x != ImageSpec::Origin::eLeft || orig.y != ImageSpec::Origin::eTop) {
                     report.fatal_usage("--{} argument must be --top-left for a cubemap.", argName);
                 }
             }
             if (numDimensions == 3)
-              orig.z = sm.str(3).compare("front") ? ImageSpec::Origin::eFront
-                                                 : ImageSpec::Origin::eBack;
+                orig.z = sm.str(3).compare("front") ? ImageSpec::Origin::eFront
+                                                    : ImageSpec::Origin::eBack;
             result = std::move(orig);
         }
 


### PR DESCRIPTION
Bring toktx's --lower_left_maps_to_s0t0 and --upper_left_maps_to_s0t0
to ktx create.

Includes a fix to EXR input to stop it Y flipping files with decreasing Y line order.
It now always produces top-left origin images.