### PR TITLE
Add normalise option to command create

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ if(MSVC)
     # Enable UTF-8 support
     add_compile_options( $<$<C_COMPILER_ID:MSVC>:/utf-8> )
     add_compile_options( $<$<CXX_COMPILER_ID:MSVC>:/utf-8> )
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-cast-function-type-mismatch>)
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
        OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options( -Wall -Wextra $<$<BOOL:${KTX_WERROR}>:-Werror>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,6 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
        OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options( -Wall -Wextra $<$<BOOL:${KTX_WERROR}>:-Werror>)
     add_compile_options( $<IF:$<CONFIG:Debug>,-O0$<SEMICOLON>-g,-O3> )
-    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-cast-function-type-mismatch>)
     if(EMSCRIPTEN)
         add_link_options( $<IF:$<CONFIG:Debug>,-gsource-map,-O3> )
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,11 +303,11 @@ if(MSVC)
     # Enable UTF-8 support
     add_compile_options( $<$<C_COMPILER_ID:MSVC>:/utf-8> )
     add_compile_options( $<$<CXX_COMPILER_ID:MSVC>:/utf-8> )
-    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-cast-function-type-mismatch>)
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
        OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options( -Wall -Wextra $<$<BOOL:${KTX_WERROR}>:-Werror>)
     add_compile_options( $<IF:$<CONFIG:Debug>,-O0$<SEMICOLON>-g,-O3> )
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Wno-cast-function-type-mismatch>)
     if(EMSCRIPTEN)
         add_link_options( $<IF:$<CONFIG:Debug>,-gsource-map,-O3> )
     else()

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -51,9 +51,9 @@ pthread_create(pthread_t* thread, const pthread_attr_t* attribs,
     (void)attribs;
 #ifdef __clang__
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wcast-function-type-mismatche"
+    #pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
 #endif
-    LPTHREAD_START_ROUTINE func = (LPTHREAD_START_ROUTINE)threadfunc;
+    LPTHREAD_START_ROUTINE func = reinterpret_cast<LPTHREAD_START_ROUTINE>(threadfunc);
 #ifdef __clang__
     #pragma clang diagnostic pop
 #endif

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -49,7 +49,13 @@ static int
 pthread_create(pthread_t* thread, const pthread_attr_t* attribs,
                void* (*threadfunc)(void*), void* thread_arg) {
     (void)attribs;
-    LPTHREAD_START_ROUTINE func = (LPTHREAD_START_ROUTINE)threadfunc;
+#ifdef _MSVC_LANG
+    #pragma warning disable
+#endif
+    LPTHREAD_START_ROUTINE func = reinterpret_cast<LPTHREAD_START_ROUTINE>(threadfunc);
+#ifdef _MSVC_LANG
+    #pragma warning restore
+#endif
     *thread = CreateThread(nullptr, 0, func, thread_arg, 0, nullptr);
     return 0;
 }

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -49,7 +49,14 @@ static int
 pthread_create(pthread_t* thread, const pthread_attr_t* attribs,
                void* (*threadfunc)(void*), void* thread_arg) {
     (void)attribs;
+#ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wcast-function-type-mismatche"
+#endif
     LPTHREAD_START_ROUTINE func = (LPTHREAD_START_ROUTINE)threadfunc;
+#ifdef __clang__
+    #pragma clang diagnostic pop
+#endif
     *thread = CreateThread(nullptr, 0, func, thread_arg, 0, nullptr);
     return 0;
 }

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -49,13 +49,7 @@ static int
 pthread_create(pthread_t* thread, const pthread_attr_t* attribs,
                void* (*threadfunc)(void*), void* thread_arg) {
     (void)attribs;
-#ifdef _MSVC_LANG
-    #pragma warning disable
-#endif
-    LPTHREAD_START_ROUTINE func = reinterpret_cast<LPTHREAD_START_ROUTINE>(threadfunc);
-#ifdef _MSVC_LANG
-    #pragma warning restore
-#endif
+    LPTHREAD_START_ROUTINE func = (LPTHREAD_START_ROUTINE)threadfunc;
     *thread = CreateThread(nullptr, 0, func, thread_arg, 0, nullptr);
     return 0;
 }

--- a/lib/gl_funcs.c
+++ b/lib/gl_funcs.c
@@ -149,15 +149,9 @@ ktxFindOpenGL() {
 
     if (found) {
         // Need wglGetProcAddr for non-OpenGL-2 functions.
-#ifdef _MSVC_LANG
-    #pragma warning disable
-#endif
         pfnWglGetProcAddress =
             (PFNGLGETPROCADDRESS)GetProcAddress(module,
                                                "wglGetProcAddress");
-#ifdef _MSVC_LANG
-    #pragma warning restore
-#endif
         if (pfnWglGetProcAddress != NULL)
             return module;
     }

--- a/lib/gl_funcs.c
+++ b/lib/gl_funcs.c
@@ -149,9 +149,17 @@ ktxFindOpenGL() {
 
     if (found) {
         // Need wglGetProcAddr for non-OpenGL-2 functions.
+#ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wcast-function-type-mismatche"
+#endif
         pfnWglGetProcAddress =
             (PFNGLGETPROCADDRESS)GetProcAddress(module,
                                                "wglGetProcAddress");
+#ifdef __clang__
+    #pragma clang diagnostic pop
+#endif
+
         if (pfnWglGetProcAddress != NULL)
             return module;
     }

--- a/lib/gl_funcs.c
+++ b/lib/gl_funcs.c
@@ -151,7 +151,7 @@ ktxFindOpenGL() {
         // Need wglGetProcAddr for non-OpenGL-2 functions.
 #ifdef __clang__
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wcast-function-type-mismatche"
+    #pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
 #endif
         pfnWglGetProcAddress =
             (PFNGLGETPROCADDRESS)GetProcAddress(module,

--- a/lib/gl_funcs.c
+++ b/lib/gl_funcs.c
@@ -146,11 +146,18 @@ ktxFindOpenGL() {
         "opengl32.dll",
         &module
     );
+
     if (found) {
         // Need wglGetProcAddr for non-OpenGL-2 functions.
+#ifdef _MSVC_LANG
+    #pragma warning disable
+#endif
         pfnWglGetProcAddress =
-            (PFNGLGETPROCADDRESS)GetProcAddress(module,
-                                                 "wglGetProcAddress");
+            reinterpret_cast<PFNGLGETPROCADDRESS>(GetProcAddress(module,
+                                                 "wglGetProcAddress"));
+#ifdef _MSVC_LANG
+    #pragma warning restore
+#endif
         if (pfnWglGetProcAddress != NULL)
             return module;
     }

--- a/lib/gl_funcs.c
+++ b/lib/gl_funcs.c
@@ -153,8 +153,8 @@ ktxFindOpenGL() {
     #pragma warning disable
 #endif
         pfnWglGetProcAddress =
-            reinterpret_cast<PFNGLGETPROCADDRESS>(GetProcAddress(module,
-                                                 "wglGetProcAddress"));
+            (PFNGLGETPROCADDRESS)GetProcAddress(module,
+                                               "wglGetProcAddress");
 #ifdef _MSVC_LANG
     #pragma warning restore
 #endif

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -1616,10 +1616,8 @@ void CommandCreate::executeCreate() {
                 if (target.format().transfer() != KHR_DF_TRANSFER_UNSPECIFIED && target.format().transfer() != KHR_DF_TRANSFER_LINEAR) {
                     fatal(rc::INVALID_FILE,
                         "Input file \"{}\" The transfer function to be applied to the created texture is neither linear nor none. Normalize is only available for linear images. "
-                        "Use or modify {} or {} settings to assign the transfer function or convert the input image to linear, if required.",
-                        OptionsCreate::kAssignOetf, OptionsCreate::kConvertOetf);
-
-                        fmtInFile(inputFilepath));
+                        "Use or modify \"{}\" or \"{}\" settings to assign the transfer function or convert the input image to linear, if required.",
+                        fmtInFile(inputFilepath), OptionsCreate::kAssignOetf, OptionsCreate::kConvertOetf);
                     }
                 image->normalize();
             }

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -1591,6 +1591,9 @@ void CommandCreate::executeCreate() {
                 image->yflip();
             }
 
+            if (options.normalize)
+                image->normalize();
+
             if (options.swizzleInput)
                 image->swizzle(*options.swizzleInput);
 
@@ -2313,6 +2316,9 @@ void CommandCreate::generateMipLevels(KTXTexture2& texture, std::unique_ptr<Imag
         } catch (const std::exception& e) {
             fatal(rc::RUNTIME_ERROR, "Mipmap generation failed: {}", e.what());
         }
+
+        if (options.normalize)
+            image->normalize();
 
         const auto imageData = convert(image, options.vkFormat, inputFile);
 

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -148,11 +148,11 @@ struct OptionsCreate {
                 (kEncode, "Encode the created KTX file. Case insensitive."
                     "\nPossible options are: basis-lz | uastc", cxxopts::value<std::string>(), "<codec>")
                 (kNormalize, "Normalize input normals to have a unit length. Only valid for\n"
-                    "linear normal textures with 2 or more components. For 2-component inputs\n"
-                    "2D unit normals are calculated. Do not use these 2D unit normals\n"
-                    "to generate X+Y normals with --normal-mode. For 4-component inputs\n"
-                    "a 3D unit normal is calculated. 1.0 is used for the value of the\n"
-                    "4th component. Cannot be used with --raw.\n")
+                    "linear normal textures with 2 or more components. For 2-component\n"
+                    "inputs 2D unit normals are calculated. Do not use these 2D unit\n"
+                    "normals to generate X+Y normals with --normal-mode. For 4-component\n"
+                    "inputs a 3D unit normal is calculated. 1.0 is used for the value of\n"
+                    "the 4th component. Cannot be used with --raw.")
                 (kSwizzle, "KTX swizzle metadata.", cxxopts::value<std::string>(), "[rgba01]{4}")
                 (kInputSwizzle, "Pre-swizzle input channels.", cxxopts::value<std::string>(), "[rgba01]{4}")
                 (kAssignTf, "Force the created texture to have the specified transfer function, ignoring"
@@ -468,7 +468,7 @@ struct OptionsCreate {
 
         if (args[kNormalize].count()) {
             if (raw)
-                report.fatal_usage("Option --normalize can't be used with --raw.");
+                report.fatal_usage("Conflicting options: Option --normalize can't be used with --raw.");
             normalize = true;
         }
 
@@ -908,11 +908,11 @@ Create a KTX2 file from various input files.
         </dd>
         <dt>\--normalize</dt>
         <dd>Normalize input normals to have a unit length. Only valid for
-                linear normal textures with 2 or more components. For 2-component inputs
-                2D unit normals are calculated. Do not use these 2D unit normals
-                to generate X+Y normals with @b --normal-mode. For 4-component inputs
-                a 3D unit normal is calculated. 1.0 is used for the value of the
-                4th component. Cannot be used with @b \--raw.</dd>
+                linear normal textures with 2 or more components. For 2-component
+                inputs 2D unit normals are calculated. Do not use these 2D unit
+                normals to generate X+Y normals with @b --normal-mode. For 4-component
+                inputs a 3D unit normal is calculated. 1.0 is used for the value of
+                the 4th component. Cannot be used with @b \--raw.</dd>
         <dt>\--swizzle [rgba01]{4}</dt>
         <dd>KTX swizzle metadata.</dd>
         <dt>\--input-swizzle [rgba01]{4}</dt>
@@ -1613,10 +1613,10 @@ void CommandCreate::executeCreate() {
             }
 
             if (options.normalize) {
-                if (target.format().transfer() != KHR_DF_TRANSFER_LINEAR) {
+                if (colorSpaceInfo.usedInputTransferFunction != KHR_DF_TRANSFER_LINEAR) {
                     fatal(rc::INVALID_FILE,
-                        "Input file \"{}\" transfer functions is not linear. "
-                        "Use --assign-oetf=linear or --convert-oetf=linear to avoid this error.",
+                        "Input file \"{}\" transfer function is not linear. Normalize is only available for linear images. "
+                        "Use --assign-oetf=linear or --convert-oetf=linear to convert to linear if required.",
                         fmtInFile(inputFilepath));
                     }
                 image->normalize();

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -1619,8 +1619,8 @@ void CommandCreate::executeCreate() {
                     const auto convert_error_message = "Input file \"{}\" Modify \"{}\" settings to convert the input image to linear transfer function, if required.";
                     const auto inputTransfer =  inputImageFile->spec().format().transfer();
                     bool is_file_error = (inputTransfer != KHR_DF_TRANSFER_UNSPECIFIED && inputTransfer != KHR_DF_TRANSFER_LINEAR);
-                    bool is_assign_error =  !options.assignOETF.has_value();
-                    bool is_convert_error =  !options.convertOETF.has_value();
+                    bool is_assign_error =  !options.assignTF.has_value();
+                    bool is_convert_error =  !options.convertTF.has_value();
                     if (is_assign_error)
                         fatal(rc::INVALID_FILE, assign_error_message, fmtInFile(inputFilepath), OptionsCreate::kAssignOetf);
                     else if (is_convert_error)

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -1613,10 +1613,12 @@ void CommandCreate::executeCreate() {
             }
 
             if (options.normalize) {
-                if (target.format().transfer() != KHR_DF_TRANSFER_LINEAR) {
+                if (target.format().transfer() != KHR_DF_TRANSFER_UNSPECIFIED && target.format().transfer() != KHR_DF_TRANSFER_LINEAR) {
                     fatal(rc::INVALID_FILE,
-                        "Input file \"{}\" transfer function is not linear. Normalize is only available for linear images. "
-                        "Use --assign-oetf=linear or --convert-oetf=linear to convert to linear if required.",
+                        "Input file \"{}\" The transfer function to be applied to the created texture is neither linear nor none. Normalize is only available for linear images. "
+                        "Use or modify {} or {} settings to assign the transfer function or convert the input image to linear, if required.",
+                        OptionsCreate::kAssignOetf, OptionsCreate::kConvertOetf);
+
                         fmtInFile(inputFilepath));
                     }
                 image->normalize();

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -1626,7 +1626,7 @@ void CommandCreate::executeCreate() {
                     else if (is_convert_error)
                         fatal(rc::INVALID_FILE, convert_error_message, fmtInFile(inputFilepath), OptionsCreate::kConvertOetf);
                     else {
-                        assert(is_file_error && "In this branch it must be the input file that has the transfre function issue"); (void)is_file_error;
+                        assert(is_file_error && "In this branch it must be the input file that has the transfer function issue"); (void)is_file_error;
                         fatal(rc::INVALID_FILE, input_error_message, fmtInFile(inputFilepath));
                     }
                     }

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -150,7 +150,7 @@ struct OptionsCreate {
                 (kNormalize, "Normalize input normals to have a unit length. Only valid for\n"
                     "linear normal textures with 2 or more components. For 2-component inputs\n"
                     "2D unit normals are calculated. Do not use these 2D unit normals\n"
-                    "to generate X+Y normals for --normal-mode. For 4-component inputs\n"
+                    "to generate X+Y normals with --normal-mode. For 4-component inputs\n"
                     "a 3D unit normal is calculated. 1.0 is used for the value of the\n"
                     "4th component.\n")
                 (kSwizzle, "KTX swizzle metadata.", cxxopts::value<std::string>(), "[rgba01]{4}")
@@ -907,7 +907,7 @@ Create a KTX2 file from various input files.
         <dd>Normalize input normals to have a unit length. Only valid for
                 linear normal textures with 2 or more components. For 2-component inputs
                 2D unit normals are calculated. Do not use these 2D unit normals
-                to generate X+Y normals for --normal-mode. For 4-component inputs
+                to generate X+Y normals with @b --normal-mode. For 4-component inputs
                 a 3D unit normal is calculated. 1.0 is used for the value of the
                 4th component.</dd>
         <dt>\--swizzle [rgba01]{4}</dt>
@@ -1609,8 +1609,15 @@ void CommandCreate::executeCreate() {
                 image->yflip();
             }
 
-            if (options.normalize)
+            if (options.normalize) {
+                if (colorSpaceInfo.usedInputTransferFunction != KHR_DF_TRANSFER_LINEAR) {
+                    fatal(rc::INVALID_FILE,
+                        "Input file \"{}\" transfer functions is not linear. "
+                        "Use --assign-oetf=linear or --convert-oetf=linear to avoid this error.",
+                        fmtInFile(inputFilepath));
+                    }
                 image->normalize();
+            }
 
             if (options.swizzleInput)
                 image->swizzle(*options.swizzleInput);

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -1613,7 +1613,7 @@ void CommandCreate::executeCreate() {
             }
 
             if (options.normalize) {
-                if (colorSpaceInfo.usedInputTransferFunction != KHR_DF_TRANSFER_LINEAR) {
+                if (target.format().transfer() != KHR_DF_TRANSFER_LINEAR) {
                     fatal(rc::INVALID_FILE,
                         "Input file \"{}\" transfer function is not linear. Normalize is only available for linear images. "
                         "Use --assign-oetf=linear or --convert-oetf=linear to convert to linear if required.",

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -56,6 +56,7 @@ struct OptionsCreate {
     inline static const char* kRuntimeMipmap = "runtime-mipmap";
     inline static const char* kGenerateMipmap = "generate-mipmap";
     inline static const char* kEncode = "encode";
+    inline static const char* kNormalize = "normalize";
     inline static const char* kSwizzle = "swizzle";
     inline static const char* kInputSwizzle = "input-swizzle";
     inline static const char* kAssignOetf = "assign-oetf";
@@ -110,6 +111,7 @@ struct OptionsCreate {
     bool noWarnOnColorConversions = false;
     bool failOnOriginChanges = false;
     bool warnOnOriginChanges = false;
+    bool normalize = false;
 
     void init(cxxopts::Options& opts) {
         opts.add_options()
@@ -145,6 +147,12 @@ struct OptionsCreate {
                     " This option is mutually exclusive with --runtime-mipmap and cannot be used with UINT or 3D textures.")
                 (kEncode, "Encode the created KTX file. Case insensitive."
                     "\nPossible options are: basis-lz | uastc", cxxopts::value<std::string>(), "<codec>")
+                (kNormalize, "Normalize input normals to have a unit length. Only valid for\n"
+                    "linear textures with 2 or more components. For 2-component inputs\n"
+                    "2D unit normals are calculated. Do not use these 2D unit normals\n"
+                    "to generate X+Y normals for --normal-mode. For 4-component inputs\n"
+                    "a 3D unit normal is calculated. 1.0 is used for the value of the\n"
+                    "4th component.\n")
                 (kSwizzle, "KTX swizzle metadata.", cxxopts::value<std::string>(), "[rgba01]{4}")
                 (kInputSwizzle, "Pre-swizzle input channels.", cxxopts::value<std::string>(), "[rgba01]{4}")
                 (kAssignTf, "Force the created texture to have the specified transfer function, ignoring"
@@ -457,6 +465,9 @@ struct OptionsCreate {
             else
                 mipmapWrap = it->second;
         }
+
+        if (args[kNormalize].count())
+            normalize = true;
 
         if (args[kSwizzle].count()) {
             swizzle = to_lower_copy(args[kSwizzle].as<std::string>());

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -148,7 +148,7 @@ struct OptionsCreate {
                 (kEncode, "Encode the created KTX file. Case insensitive."
                     "\nPossible options are: basis-lz | uastc", cxxopts::value<std::string>(), "<codec>")
                 (kNormalize, "Normalize input normals to have a unit length. Only valid for\n"
-                    "linear textures with 2 or more components. For 2-component inputs\n"
+                    "linear normal textures with 2 or more components. For 2-component inputs\n"
                     "2D unit normals are calculated. Do not use these 2D unit normals\n"
                     "to generate X+Y normals for --normal-mode. For 4-component inputs\n"
                     "a 3D unit normal is calculated. 1.0 is used for the value of the\n"
@@ -903,6 +903,13 @@ Create a KTX2 file from various input files.
         Avoid mipmap generation if the Output TF (see @ref ktx\_create\_tf\_handling
         below) is non-linear and is not sRGB.
         </dd>
+        <dt>\--normalize</dt>
+        <dd>Normalize input normals to have a unit length. Only valid for
+                linear normal textures with 2 or more components. For 2-component inputs
+                2D unit normals are calculated. Do not use these 2D unit normals
+                to generate X+Y normals for --normal-mode. For 4-component inputs
+                a 3D unit normal is calculated. 1.0 is used for the value of the
+                4th component.</dd>
         <dt>\--swizzle [rgba01]{4}</dt>
         <dd>KTX swizzle metadata.</dd>
         <dt>\--input-swizzle [rgba01]{4}</dt>

--- a/tools/ktx/encode_utils_common.h
+++ b/tools/ktx/encode_utils_common.h
@@ -57,11 +57,13 @@ namespace ktx {
 */
 struct OptionsEncodeCommon {
     inline static const char* kNormalMode = "normal-mode";
+    inline static const char* kNormalize = "normalize";
     inline static const char* kThreads = "threads";
     inline static const char* kNoSse = "no-sse";
 
     std::string commonOptions{};
     bool normalMap{false};
+    bool normalize{false};
     ktx_uint32_t threadCount{1};
     ktx_bool_t noSSE;
 
@@ -83,6 +85,12 @@ struct OptionsEncodeCommon {
                 "    nml.xy = nml.xy * 2.0 - 1.0;           // Unpack to [-1,1]\n"
                 "    nml.z = sqrt(1 - dot(nml.xy, nml.xy)); // Compute Z\n"
                 "ETC1S / BasisLZ encoding, RDO is disabled (no selector RDO, no endpoint RDO) to provide better quality.")
+            (kNormalize, "Normalize input normals to have a unit length. Only valid for\n"
+                "linear textures with 2 or more components. For 2-component inputs\n"
+                "2D unit normals are calculated. Do not use these 2D unit normals\n"
+                "to generate X+Y normals for --normal-mode. For 4-component inputs\n"
+                "a 3D unit normal is calculated. 1.0 is used for the value of the\n"
+                "4th component.\n")
             (kThreads, "Sets the number of threads to use during encoding. By default, encoding "
                 "will use the number of threads reported by thread::hardware_concurrency or 1 if "
                 "value returned is 0.", cxxopts::value<uint32_t>(), "<count>")
@@ -108,6 +116,11 @@ struct OptionsEncodeCommon {
             normalMap = true;
         }
 
+        if (args[kNormalize].count()) {
+            captureCommonOption(kNormalize);
+            normalize = true;
+        }
+
         if (args[kThreads].count()) {
             threadCount = captureCodecOption<uint32_t>(args, kThreads);
         }
@@ -123,6 +136,7 @@ template <typename Options, typename Codec>
 constexpr void fillOptionsCodec(Options &options) {
     options.Codec::threadCount = options.OptionsEncodeCommon::threadCount;
     options.Codec::normalMap = options.OptionsEncodeCommon::normalMap;
+    // options.Codec::normalize = options.OptionsEncodeCommon::normalize;
 }
 
 template <typename Options>

--- a/tools/ktx/encode_utils_common.h
+++ b/tools/ktx/encode_utils_common.h
@@ -57,13 +57,11 @@ namespace ktx {
 */
 struct OptionsEncodeCommon {
     inline static const char* kNormalMode = "normal-mode";
-    inline static const char* kNormalize = "normalize";
     inline static const char* kThreads = "threads";
     inline static const char* kNoSse = "no-sse";
 
     std::string commonOptions{};
     bool normalMap{false};
-    bool normalize{false};
     ktx_uint32_t threadCount{1};
     ktx_bool_t noSSE;
 
@@ -85,12 +83,6 @@ struct OptionsEncodeCommon {
                 "    nml.xy = nml.xy * 2.0 - 1.0;           // Unpack to [-1,1]\n"
                 "    nml.z = sqrt(1 - dot(nml.xy, nml.xy)); // Compute Z\n"
                 "ETC1S / BasisLZ encoding, RDO is disabled (no selector RDO, no endpoint RDO) to provide better quality.")
-            (kNormalize, "Normalize input normals to have a unit length. Only valid for\n"
-                "linear textures with 2 or more components. For 2-component inputs\n"
-                "2D unit normals are calculated. Do not use these 2D unit normals\n"
-                "to generate X+Y normals for --normal-mode. For 4-component inputs\n"
-                "a 3D unit normal is calculated. 1.0 is used for the value of the\n"
-                "4th component.\n")
             (kThreads, "Sets the number of threads to use during encoding. By default, encoding "
                 "will use the number of threads reported by thread::hardware_concurrency or 1 if "
                 "value returned is 0.", cxxopts::value<uint32_t>(), "<count>")
@@ -116,11 +108,6 @@ struct OptionsEncodeCommon {
             normalMap = true;
         }
 
-        if (args[kNormalize].count()) {
-            captureCommonOption(kNormalize);
-            normalize = true;
-        }
-
         if (args[kThreads].count()) {
             threadCount = captureCodecOption<uint32_t>(args, kThreads);
         }
@@ -136,7 +123,6 @@ template <typename Options, typename Codec>
 constexpr void fillOptionsCodec(Options &options) {
     options.Codec::threadCount = options.OptionsEncodeCommon::threadCount;
     options.Codec::normalMap = options.OptionsEncodeCommon::normalMap;
-    // options.Codec::normalize = options.OptionsEncodeCommon::normalize;
 }
 
 template <typename Options>


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/KTX-Software/issues/812 partially. At the moment only adds support to create. 

NOTE: I can't seem to work out how to add support to encode because its not using `Image` from `./tools/imageio/image.hpp` its using streams to load this.

I have also tried to add this normalize option to `./tools/ktx/encode_utils_common.h` first. You can see this in the first commit  https://github.com/KhronosGroup/KTX-Software/commit/53f728f9aa549a255d28aee3b5f0de747e351242. I am not sure if thats the way to go to see this option in both `encode` and `create` but it felt like its not an encoder (basisu, ASTC) specific option so feels misplaced. 

The other option is to add another "general_util.h" which stores other commonly used options amongst the tools because it doesn't fit in all of the following categories either.

`ktx create [OPTION...] <input-file...> <output-file>`
`Encode ASTC options:`
`Encode BasisLZ options:`
`Encode UASTC options:`
`Encode common options:`
`Generate Mipmap options:`


