### PR TITLE
Fix vkloadtests build with cmake 3.29+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,12 +480,12 @@ if(KTX_FEATURE_GL_UPLOAD)
     )
 endif()
 
-if(APPLE_MAC_OS OR LINUX OR WIN32)
+if(APPLE OR LINUX OR WIN32)
     # By wrapping in generator expression we force multi configuration
     # generators (like Visual Studio, Xcode or Ninja multi-config) to
     # take the exact path and not change it.
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${KTX_BUILD_DIR}/$<CONFIG>>)
-    if(APPLE_MAC_OS OR LINUX)
+    if(APPLE OR LINUX)
         # Use a common RUNTIME_OUTPUT_DIR and LIBRARY_OUTPUT_DIR for all
         # targets so that INSTALL RPATH is functional in build directory
         # as well. BUILD_WITH_INSTALL_RPATH is necessary for working code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,9 +426,9 @@ set(KTX_MAIN_SRC
     )
 
 if (KTX_FEATURE_ETC_UNPACK)
-	list(APPEND KTX_MAIN_SRC 
-		external/etcdec/etcdec.cxx
-	)
+    list(APPEND KTX_MAIN_SRC 
+        external/etcdec/etcdec.cxx
+    )
 endif()
 
 set(BASISU_ENCODER_CXX_SRC

--- a/cmake/modules/FindVulkan.cmake
+++ b/cmake/modules/FindVulkan.cmake
@@ -274,7 +274,7 @@ if(APPLE)
         set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
     endif()
 else()
-    set(_Vulkan_SDK "$ENV{VULKAN_SDK}/bin")
+    set(_Vulkan_SDK "$ENV{VULKAN_SDK}")
 endif()
 
 # For backward compatibility as `FindVulkan` in previous CMake versions allow to retrieve `glslc`
@@ -314,31 +314,24 @@ if(WIN32)
 else()
     set(_Vulkan_library_name vulkan)
     set(_Vulkan_hint_include_search_paths
-            "${_Vulkan_SDK}/include"
+            ${_Vulkan_SDK}/include
     )
     set(_Vulkan_hint_executable_search_paths
-            "${_Vulkan_SDK}/bin"
+            ${_Vulkan_SDK}/bin
     )
     set(_Vulkan_hint_library_search_paths
-            "${_Vulkan_SDK}/lib"
+            ${_Vulkan_SDK}/lib
     )
 endif()
 if(APPLE AND IOS)
-    #list(APPEND _Vulkan_hint_include_search_paths
-    #        "${Vulkan_SDK_Base}/macOS/include"
-    #)
     if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
         list(APPEND _Vulkan_hint_library_search_paths
-                "${Vulkan_SDK_Base}/iOS/lib"
+                ${Vulkan_SDK_Base}/iOS/lib
         )
     elseif(CMAKE_SYSTEM_NAME STREQUAL "tvOS")
         list(APPEND _Vulkan_hint_library_search_paths
-                "${Vulkan_SDK_Base}/tvOS/lib"
+                ${Vulkan_SDK_Base}/tvOS/lib
         )
-#    else()
-#        list(APPEND _Vulkan_hint_library_search_paths
-#                "${Vulkan_SDK_Base}/lib"
-#        )
     endif()
 endif()
 

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -4,17 +4,16 @@
 # Find Vulkan package
 if(APPLE)
     # N.B. FindVulkan needs the VULKAN_SDK environment variable set to find
-    # the iOS frameworks and to set Vulkan_Target_SDK, used later in this
+    # the iOS frameworks and to set Vulkan_SDK_Base, used later in this
     # file. Therefore ensure to make that env. var. available to CMake and
     # Xcode. Special care is needed to ensure it is available to the CMake
     # and Xcode GUIs.
 #    set(CMAKE_FIND_DEBUG_MODE TRUE)
     find_package( Vulkan REQUIRED COMPONENTS MoltenVK )
 #    set(CMAKE_FIND_DEBUG_MODE FALSE)
-
     # Derive some other useful variables from those provided by find_package
     if(APPLE_LOCKED_OS)
-        set( Vulkan_SHARE_VULKAN ${Vulkan_Target_SDK}/${CMAKE_SYSTEM_NAME}/share/vulkan )
+        set( Vulkan_SHARE_VULKAN ${Vulkan_SDK_Base}/${CMAKE_SYSTEM_NAME}/share/vulkan )
     else()
         # Vulkan_LIBRARIES points to "libvulkan.dylib".
         # Find the name of the actual dylib which includes the version no.
@@ -310,7 +309,7 @@ if(APPLE)
             XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY		"YES"
             XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY	"YES"
             # Set RPATH to find frameworks
-            INSTALL_RPATH "@executable_path/Frameworks"
+            INSTALL_RPATH @executable_path/Frameworks
         )
     else()
         # Why is XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY not set here?
@@ -321,7 +320,7 @@ if(APPLE)
         set_target_properties( vkloadtests PROPERTIES
             XCODE_EMBED_FRAMEWORKS "${Vulkan_LIBRARY_REAL_PATH_NAME};${Vulkan_MoltenVK_LIBRARY};${Vulkan_Layer_VALIDATION}"
             # Set RPATH to find frameworks and dylibs
-            INSTALL_RPATH "@executable_path/../Frameworks"
+            INSTALL_RPATH @executable_path/../Frameworks
         )
         if(BUILD_SHARED_LIBS)
             # XCODE_EMBED_FRAMEWORKS does not appear to support generator


### PR DESCRIPTION
Fixes an issue with vkloadtests for iOS not running, caused by a change a little while ago.

Fixes a build issue with vkloadtests for  macOS with recent versions of CMake that recognize .xcframeworks.

@MathiasMagnus you may need to merge this into your GitHub actions PR in order to have successful builds, depending on what version of CMake is on the CI runners.