### PR TITLE
Shut up warnings clang with libstdc++ emits about non-virtual destructors

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,6 +58,28 @@ jobs:
             doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: ON,
             sse: ON, opencl: OFF
           }
+        - name: Clang Debug
+          os: ubuntu-22.04
+          generator: Ninja
+          arch: x86_64
+          compiler: clang
+          vk_sdk_ver: '1.3.290'
+          options: {
+            config: Debug,
+            doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: OFF,
+            sse: ON, opencl: OFF
+          }
+        - name: Clang Release
+          os: ubuntu-22.04
+          generator: Ninja
+          arch: x86_64
+          compiler: clang
+          vk_sdk_ver: '1.3.290'
+          options: {
+            config: Release,
+            doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: OFF,
+            sse: ON, opencl: OFF
+          }
         - name: Package (x86_64)
           os: ubuntu-22.04
           generator: Ninja

--- a/tools/ktx/command_compare.cpp
+++ b/tools/ktx/command_compare.cpp
@@ -1846,6 +1846,10 @@ struct KVEntry {
     char* value;
     ktx_uint32_t valueLen;
 
+    // shut up clang's complaints about derived classes
+    // that have virtual functions but non-virtual destructor
+    virtual ~KVEntry() {}
+
     template <typename T>
     static std::optional<T> load(ktxHashListEntry* entry) {
         if (entry) {


### PR DESCRIPTION
It complains a lot about non-final classes (structs) derived from KVEntry having virtual functions but no virtual destructor, which in std::optional code (that explicitly calls the destructor somewhere) could theoretically lead to the wrong destructor being called (that of the struct directly derived from KVEntry instead of the one of a hypothetical class derived from that struct that might actually need its destructor called).
This doesn't matter in practice because
1. those classes don't have any implemented constructors that need to do anything
2. no further classes are derived from those that are derived from KVEntry 

So (I think!) these warnings are only hypothetical, but still annoying.

Apparently this does not happen if Clang uses libc++ or MSVCs C++ stdlib (in the ClangCL case), but only with libstdc++, maybe even only with libstdc++ from GCC14, but that's the only version I have on my machine.

Fixes #1011 