### PR TITLE
GCC14/C++23 compatibility fix

### DIFF
--- a/external/basisu/encoder/cppspmd_sse.h
+++ b/external/basisu/encoder/cppspmd_sse.h
@@ -493,7 +493,7 @@ struct spmd_kernel
 	CPPSPMD_FORCE_INLINE vfloat& store(vfloat&& dst, const vfloat& src)
 	{
 		dst.m_value = blendv_mask_ps(dst.m_value, src.m_value, _mm_castsi128_ps(m_exec.m_mask));
-		return dst;
+		return { dst };
 	}
 	
 	CPPSPMD_FORCE_INLINE vfloat& store_all(vfloat& dst, const vfloat& src)
@@ -505,7 +505,7 @@ struct spmd_kernel
 	CPPSPMD_FORCE_INLINE vfloat& store_all(vfloat&& dst, const vfloat& src)
 	{
 		dst.m_value = src.m_value;
-		return dst;
+		return { dst };
 	}
 
 	// Linear ref to floats


### PR DESCRIPTION
Fixes the following error, when compiling with GCC 14, using `-std=c++23`:

```
<>/basisu/encoder/basisu_kernels_sse.cpp:41:
<>/basisu/encoder/cppspmd_sse.h: In member function ‘cppspmd_sse41::spmd_kernel::vfloat& cppspmd_sse41::spmd_kernel::store(vfloat&&, const vfloat&)’:
<>/basisu/encoder/cppspmd_sse.h:496:24: error: cannot bind non-const lvalue reference of type ‘cppspmd_sse41::spmd_kernel::vfloat&’ to an rvalue of type ‘cppspmd_sse41::spmd_kernel::vfloat’
  496 |                 return dst;
      |                        ^~~
<>/basisu/encoder/cppspmd_sse.h: In member function ‘cppspmd_sse41::spmd_kernel::vfloat& cppspmd_sse41::spmd_kernel::store_all(vfloat&&, const vfloat&)’:
<>/basisu/encoder/cppspmd_sse.h:508:24: error: cannot bind non-const lvalue reference of type ‘cppspmd_sse41::spmd_kernel::vfloat&’ to an rvalue of type ‘cppspmd_sse41::spmd_kernel::vfloat’
  508 |                 return dst;
      |                        ^~~

```