### PR TITLE
Fix handling of multiple files with spaces in names.

### DIFF
--- a/tests/loadtests/glloadtests/GLLoadTests.h
+++ b/tests/loadtests/glloadtests/GLLoadTests.h
@@ -54,7 +54,7 @@ class GLLoadTests : public GLAppSDL {
         eBack
     };
     void invokeSample(Direction dir);
-    LoadTestSample* showFile(std::string& filename);
+    LoadTestSample* showFile(const std::string& filename);
     LoadTestSample* pCurSample;
 
     bool quit = false;

--- a/tests/loadtests/glloadtests/gles1/ES1LoadTests.cpp
+++ b/tests/loadtests/glloadtests/gles1/ES1LoadTests.cpp
@@ -22,7 +22,7 @@
 #include "TexturedCube.h"
 
 LoadTestSample*
-GLLoadTests::showFile(std::string& filename)
+GLLoadTests::showFile(const std::string& filename)
 {
     KTX_error_code ktxresult;
     ktxTexture* kTexture;

--- a/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
+++ b/tests/loadtests/glloadtests/shader-based/GL3LoadTests.cpp
@@ -32,7 +32,7 @@
 #endif
 
 LoadTestSample*
-GLLoadTests::showFile(std::string& filename)
+GLLoadTests::showFile(const std::string& filename)
 {
     KTX_error_code ktxresult;
     ktxTexture* kTexture;
@@ -76,8 +76,7 @@ GLLoadTests::showFile(std::string& filename)
     ktxTexture_Destroy(kTexture);
 
     // Escape any spaces in filename.
-    filename = std::regex_replace( filename, std::regex(" "), "\\ " );
-    std::string args = "--external " + filename;
+    std::string args = "--external " + std::regex_replace( filename, std::regex(" "), "\\ " );
     pViewer = createViewer(w_width, w_height, args.c_str(), sBasePath);
     return pViewer;
 }

--- a/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
@@ -323,7 +323,7 @@ VulkanLoadTests::onFPSUpdate()
 }
 
 VulkanLoadTestSample*
-VulkanLoadTests::showFile(std::string& filename)
+VulkanLoadTests::showFile(const std::string& filename)
 {
     KTX_error_code ktxresult;
     ktxTexture* kTexture;
@@ -359,8 +359,7 @@ VulkanLoadTests::showFile(std::string& filename)
     ktxTexture_Destroy(kTexture);
 
     // Escape any spaces in filename.
-    filename = std::regex_replace( filename, std::regex(" "), "\\ " );
-    std::string args = "--external " + filename;
+    std::string args = "--external " + std::regex_replace( filename, std::regex(" "), "\\ " );
     pViewer = createViewer(vkctx, w_width, w_height, args.c_str(), sBasePath);
     return pViewer;
 }

--- a/tests/loadtests/vkloadtests/VulkanLoadTests.h
+++ b/tests/loadtests/vkloadtests/VulkanLoadTests.h
@@ -42,7 +42,7 @@ class VulkanLoadTests : public VulkanAppSDL {
         eBack
     };
     void invokeSample(Direction dir);
-    VulkanLoadTestSample* showFile(std::string& filename);
+    VulkanLoadTestSample* showFile(const std::string& filename);
     VulkanLoadTestSample* pCurSample;
 
     bool quit = false;


### PR DESCRIPTION
Space escaping was overwriting the original file name which did not need escaped spaces causing failure on subsequent opens of the file which happen when cycling through a list of files.