### PR TITLE
Export ktxTexture2_DecodeAstc in JS bindings

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -76,7 +76,7 @@ jobs:
       run: cmake --build build --config Release
     - name: Test Mingw build
       run: ctest --output-on-failure --test-dir build -C Release
-    - name: Upload test log
-      shell: pwsh
-      if: ${{ failure() }}
-      run: scripts/on_failure.ps1
+#    - name: Upload test log
+#      shell: pwsh
+#      if: ${{ failure() }}
+#      run: scripts/on_failure.ps1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ set(KTX_BUILD_DIR "${CMAKE_BINARY_DIR}")
 set(KTX_MAIN_SRC
     include/KHR/khr_df.h
     include/ktx.h
+    lib/astc_codec.cpp
     lib/basis_sgd.h
     lib/basis_transcode.cpp
     lib/miniz_wrapper.cpp
@@ -763,7 +764,6 @@ macro(common_libktx_settings target enable_write library_type)
             ${target}
         PRIVATE
             lib/basis_encode.cpp
-            lib/astc_codec.cpp
             ${BASISU_ENCODER_CXX_SRC}
             lib/writer1.c
             lib/writer2.c
@@ -1267,21 +1267,25 @@ PRIVATE
     $<$<AND:${is_clangcl},$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,17.0.3>>:_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR>
 )
 
-if(NOT BUILD_SHARED_LIBS AND APPLE)
-    # Make a single static library to simplify linking.
-    add_dependencies(ktx ${ASTCENC_LIB_TARGET})
-    add_custom_command( TARGET ktx
-        POST_BUILD
-        COMMAND libtool -static -o $<TARGET_FILE:ktx> $<TARGET_FILE:ktx> $<TARGET_FILE:${ASTCENC_LIB_TARGET}>
-    )
+macro(set_astc_dependencies target)
+    if(NOT BUILD_SHARED_LIBS AND APPLE)
+        # Make a single static library to simplify linking.
+        add_dependencies(${target} ${ASTCENC_LIB_TARGET})
+        add_custom_command( TARGET ${target}
+            POST_BUILD
+            COMMAND libtool -static -o $<TARGET_FILE:${target}> $<TARGET_FILE:ktx> $<TARGET_FILE:${ASTCENC_LIB_TARGET}>
+        )
 
-    # Don't know libtool equivalent on Windows or Emscripten. Applications
-    # will have to link with  both ktx and ${ASTCENC_LIB_TARGET}. Static libs
-    # are unlikely to be used on Windows so not a problem there. For Emscripten
-    # everything is built into the JS module so not an issue there either.
-else()
-    target_link_libraries(ktx PRIVATE ${ASTCENC_LIB_TARGET})
-endif()
+        # Don't know libtool equivalent on Windows or Emscripten. Applications
+        # will have to link with  both ktx and ${ASTCENC_LIB_TARGET}. Static libs
+        # are unlikely to be used on Windows so not a problem there. For Emscripten
+        # everything is built into the JS module so not an issue there either.
+    else()
+        target_link_libraries(${target} PRIVATE ${ASTCENC_LIB_TARGET})
+    endif()
+endmacro(set_astc_dependencies)
+set_astc_dependencies(ktx)
+set_astc_dependencies(ktx_read)
 
 # Other external projects
 # `NOT TARGET`s here are a precaution. They would only be exercised if

--- a/interface/js_binding/ktx_wrapper.cpp
+++ b/interface/js_binding/ktx_wrapper.cpp
@@ -101,7 +101,7 @@ namespace ktx
         }
 
         // This is needed because embind cannot do constructor overloads
-        // where the only the parameter type(s) differ. See
+        // where only the parameter type(s) differ. See
         // class_<ktx::texture> in EMSCRIPTEN_BINDINGS below for more
         // details.
         texture createCopy()
@@ -256,6 +256,16 @@ namespace ktx
             return result;
         }
 
+        ktx_error_code_e decodeAstc()
+        {
+            ktx_error_code_e result;
+            result = ktxTexture2_DecodeAstc(*this);
+            if (result != KTX_SUCCESS) {
+                std::cout << "ERROR: Failed to decodeAstc: " << ktxErrorString(result) << std::endl;
+            }
+            return result;
+        }
+
         // NOTE: WebGLTexture objects are completely opaque so the option of passing in the texture
         // to use is not viable.
         val glUpload()
@@ -363,7 +373,7 @@ namespace ktx
 
             result = ktxTexture2_CompressAstcEx(*this, &params);
             if (result != KTX_SUCCESS) {
-                std::cout << "ERROR: failed to compressAstc: " << ktxErrorString(result) << std::endl;
+                std::cout << "ERROR: Failed to compressAstc: " << ktxErrorString(result) << std::endl;
             }
             return result;
         }
@@ -426,7 +436,7 @@ namespace ktx
 
             result = ktxTexture2_DeflateZstd(*this, compression_level);
             if (result != KTX_SUCCESS) {
-                std::cout << "ERROR: failed to deflateZstd: " << ktxErrorString(result) << std::endl;
+                std::cout << "ERROR: Failed to deflateZstd: " << ktxErrorString(result) << std::endl;
             }
             return result;
         }
@@ -443,7 +453,7 @@ namespace ktx
 
             result = ktxTexture2_DeflateZLIB(*this, compression_level);
             if (result != KTX_SUCCESS) {
-                std::cout << "ERROR: failed to deflateZLIB: " << ktxErrorString(result) << std::endl;
+                std::cout << "ERROR: Failed to deflateZLIB: " << ktxErrorString(result) << std::endl;
             }
             return result;
         }
@@ -457,7 +467,7 @@ namespace ktx
                                            value.c_str());
 
             if (result != KTX_SUCCESS) {
-                std::cout << "ERROR: failed to addKVPair (string): " << ktxErrorString(result) << std::endl;
+                std::cout << "ERROR: Failed to addKVPair (string): " << ktxErrorString(result) << std::endl;
             }
             return result;
         }
@@ -479,7 +489,7 @@ namespace ktx
                                            value.data());
 
             if (result != KTX_SUCCESS) {
-                std::cout << "ERROR: failed to addKVPair (vector): " << ktxErrorString(result) << std::endl;
+                std::cout << "ERROR: Failed to addKVPair (vector): " << ktxErrorString(result) << std::endl;
             }
             return result;
         }
@@ -491,7 +501,7 @@ namespace ktx
             result = ktxHashList_DeleteKVPair(ht, key.c_str());
 
             if (result != KTX_SUCCESS) {
-                std::cout << "ERROR: failed to deleteKVPair: " << ktxErrorString(result) << std::endl;
+                std::cout << "ERROR: Failed to deleteKVPair: " << ktxErrorString(result) << std::endl;
             }
             return result;
         }
@@ -526,11 +536,11 @@ namespace ktx
             if (result == KTX_SUCCESS) {
                 return val(emscripten::typed_memory_view(ktx_data_size, ktx_data));
             } else {
-                std::cout << "ERROR: failed to writeToMemory: " << ktxErrorString(result) << std::endl;
+                std::cout << "ERROR: Failed to writeToMemory: " << ktxErrorString(result) << std::endl;
                 return val::null();
             }
         }
-#endif
+#endif /* KTX_FEATURE_WRITE */
     };
 }
 
@@ -633,6 +643,7 @@ interface texture {
                 CreateStorageEnum? storage);
 
     error_code compressAstc(ktxAstcParams params); // **
+    error_code decodeAstc(ktxAstcParams params);
     error_code compressBasis(ktxBasisParams params); // **
     texture createCopy();  // **
     error_code defateZLIB();   // **
@@ -1286,6 +1297,7 @@ EMSCRIPTEN_BINDINGS(ktx)
         .function("findKeyValue", &ktx::texture::findKeyValue)
         .function("getImage", &ktx::texture::getImage)
         .function("glUpload", &ktx::texture::glUpload)
+        .function("decodeAstc", &ktx::texture::decodeAstc)
         .function("transcodeBasis", &ktx::texture::transcodeBasis)
 #if KTX_FEATURE_WRITE
         .constructor<const ktxTextureCreateInfo&, ktxTextureCreateStorageEnum>()

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -777,11 +777,11 @@ astcSwizzle(const ktxAstcParams &params) {
     astcenc_swizzle swizzle{ASTCENC_SWZ_R, ASTCENC_SWZ_G, ASTCENC_SWZ_B, ASTCENC_SWZ_A};
 
     std::vector<astcenc_swz*> swizzle_array{&swizzle.r, &swizzle.g, &swizzle.b, &swizzle.a};
-    std::string inputSwizzle(params.inputSwizzle, sizeof(params.inputSwizzle));
-
-    if (inputSwizzle.size() > 0) {
-        assert(inputSwizzle.size() == 4 && "InputSwizzle is invalid.");
-
+    // For historical reasons params.inputSwizzle[0] == '\0' is interpreted to mean no
+    // swizzle. The docs says it must match the regular expression /^[rgba01]{4}$/.
+    if (params.inputSwizzle[0] != '\0') {
+        std::string inputSwizzle(params.inputSwizzle, sizeof(params.inputSwizzle));
+        // TODO: Check for RE match.
         for (int i = 0; i < 4; i++) {
             if (inputSwizzle[i] == 'r')
                 *swizzle_array[i] = ASTCENC_SWZ_R;

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -11,7 +11,7 @@
  * @file
  * @~English
  *
- * @brief Functions for compressing a texture to ASTC format.
+ * @brief Functions for compressing a texture to ASTC format and decoding one in ASTC format..
  *
  * @author Wasim Abbas , www.arm.com
  */
@@ -33,6 +33,10 @@
 #include "vkformat_enum.h"
 
 #include "astc-encoder/Source/astcenc.h"
+
+//************************************************************************
+//*              Functions common to decoder and encoder                 *
+//************************************************************************
 
 #if !defined(_WIN32) || defined(WIN32_HAS_PTHREADS)
 #include <pthread.h>
@@ -70,6 +74,466 @@ pthread_join(pthread_t thread, void** value) {
 }
 #endif
 
+/**
+ * @internal
+ * @~English
+ * @brief Worker thread helper payload for launchThreads.
+ */
+struct LaunchDesc {
+    /** The native thread handle. */
+    pthread_t threadHandle;
+    /** The total number of threads in the thread pool. */
+    int threadCount;
+    /** The thread index in the thread pool. */
+    int threadId;
+    /** The user thread function to execute. */
+    void (*func)(int, int, void*);
+    /** The user thread payload. */
+    void* payload;
+};
+
+/**
+ * @internal
+ * @~English
+ * @brief Helper function to translate thread entry points.
+ *
+ * Convert a (void*) thread entry to an (int, void*) thread entry, where the
+ * integer contains the thread ID in the thread pool.
+ *
+ * @param p The thread launch helper payload.
+ */
+static void*
+launchThreadsHelper(void *p) {
+    LaunchDesc* ltd = (LaunchDesc*)p;
+    ltd->func(ltd->threadCount, ltd->threadId, ltd->payload);
+    return nullptr;
+}
+
+
+static void
+launchThreads(int threadCount, void (*func)(int, int, void*), void *payload) {
+    // Directly execute single threaded workloads on this thread
+    if (threadCount <= 1) {
+        func(1, 0, payload);
+        return;
+    }
+
+    // Otherwise spawn worker threads
+    LaunchDesc *threadDescs = new LaunchDesc[threadCount];
+    for (int i = 0; i < threadCount; i++) {
+        threadDescs[i].threadCount = threadCount;
+        threadDescs[i].threadId = i;
+        threadDescs[i].payload = payload;
+        threadDescs[i].func = func;
+
+        pthread_create(&(threadDescs[i].threadHandle), nullptr,
+                       launchThreadsHelper, (void*)&(threadDescs[i]));
+    }
+
+    // ... and then wait for them to complete
+    for (int i = 0; i < threadCount; i++) {
+        pthread_join(threadDescs[i].threadHandle, nullptr);
+    }
+
+    delete[] threadDescs;
+}
+
+/**
+ * @internal
+ * @~English
+ * @brief Map astcenc error code to KTX error code
+ *
+ * Asserts are fired on errors reflecting bad parameters passed by libktx
+ * or astcenc compilation settings that do not permit correct operation.
+ *
+ * @param astc_error The error code to be mapped.
+ * @return An equivalent KTX error code.
+ */
+static ktx_error_code_e
+mapAstcError(astcenc_error astc_error) {
+    switch (astc_error) {
+    case ASTCENC_SUCCESS:
+        return KTX_SUCCESS;
+    case ASTCENC_ERR_OUT_OF_MEM:
+        return KTX_OUT_OF_MEMORY;
+    case ASTCENC_ERR_BAD_BLOCK_SIZE: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_DECODE_MODE: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_FLAGS: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_PARAM: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_PROFILE: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_QUALITY: //[[fallthrough]];
+    case ASTCENC_ERR_BAD_SWIZZLE:
+        assert(false && "libktx passing bad parameter to astcenc");
+        return KTX_INVALID_VALUE;
+    case ASTCENC_ERR_BAD_CONTEXT:
+        assert(false && "libktx has set up astcenc context incorrectly");
+        return KTX_INVALID_OPERATION;
+    case ASTCENC_ERR_BAD_CPU_FLOAT:
+        assert(false && "Code compiled such that float operations do not meet codec's assumptions.");
+        // Most likely compiled with fast math enabled.
+        return KTX_INVALID_OPERATION;
+    case ASTCENC_ERR_NOT_IMPLEMENTED:
+        assert(false && "ASTCENC_BLOCK_MAX_TEXELS not enough for specified block size");
+        return KTX_UNSUPPORTED_FEATURE;
+    // gcc fails to detect that the switch handles all astcenc_error
+    // enumerators and raises a return-type error, "control reaches end of
+    // non-void function", hence this
+    default:
+        assert(false && "Unhandled astcenc error");
+        return KTX_INVALID_OPERATION;
+    }
+}
+
+/**
+ * @memberof ktxTexture
+ * @internal
+ * @ingroup reader writer
+ * @~English
+ * @brief       Creates valid ASTC decoder profile from VkFormat
+ *
+ * @return      Valid astc_profile from VkFormat
+ */
+static astcenc_profile
+astcProfile(bool sRGB, bool ldr) {
+
+    if (sRGB && ldr)
+        return ASTCENC_PRF_LDR_SRGB;
+    else if (!sRGB) {
+        if (ldr)
+            return ASTCENC_PRF_LDR;
+        else
+            return ASTCENC_PRF_HDR;
+    }
+    // TODO: Add support for the following
+    // KTX_PACK_ASTC_ENCODER_ACTION_COMP_HDR_RGB_LDR_ALPHA; currently not supported
+
+    assert(ldr && "HDR sRGB profile not supported");
+
+  return ASTCENC_PRF_LDR_SRGB;
+}
+
+//************************************************************************
+//*                          Decoder functions                           *
+//************************************************************************
+
+/**
+ * @memberof ktxTexture
+ * @internal
+ * @ingroup reader
+ * @~English
+ * @brief       Used to check if an ASTC encoded texture is LDR format or not.
+ *
+ * @return      true if the VkFormat is an ASTC LDR format.
+ */
+inline bool isFormatAstcLDR(ktxTexture2* This) noexcept {
+    return (KHR_DFDSVAL(This->pDfd + 1, 0, QUALIFIERS) & KHR_DF_SAMPLE_DATATYPE_FLOAT) == 0;
+}
+
+/**
+ * @memberof ktxTexture
+ * @internal
+ * @ingroup reader
+ * @~English
+ * @brief       Should be used to get uncompressed version of ASTC VkFormat
+ *
+ * The decompressed format is calculated from corresponding ASTC format. There are
+ * only 3 possible options currently supported. RGBA8, SRGBA8 and RGBA32.
+ *
+ * @return      Uncompressed version of VKFormat for a specific ASTC VkFormat
+ */
+inline VkFormat getUncompressedFormat(ktxTexture2* This) noexcept {
+    uint32_t* BDB = This->pDfd + 1;
+
+    if (KHR_DFDSVAL(BDB, 0, QUALIFIERS) & KHR_DF_SAMPLE_DATATYPE_FLOAT) {
+        return VK_FORMAT_R32G32B32A32_SFLOAT;
+    } else {
+        if (khr_df_transfer_e(KHR_DFDVAL(BDB, TRANSFER) == KHR_DF_TRANSFER_SRGB))
+            return VK_FORMAT_R8G8B8A8_SRGB;
+        else
+            return VK_FORMAT_R8G8B8A8_UNORM;
+    }
+}
+
+struct decompression_workload
+{
+    astcenc_context* context;
+    uint8_t* data;
+    size_t data_len;
+    astcenc_image* image_out;
+    astcenc_swizzle swizzle;
+    astcenc_error error;
+};
+
+/**
+ * @internal
+ * @ingroup reader
+ * @brief Runner callback function for a decompression worker thread.
+ *
+ * @param thread_count   The number of threads in the worker pool.
+ * @param thread_id      The index of this thread in the worker pool.
+ * @param payload        The parameters for this thread.
+ */
+static void decompression_workload_runner(int thread_count, int thread_id, void* payload) {
+    (void)thread_count;
+
+    decompression_workload* work = static_cast<decompression_workload*>(payload);
+    astcenc_error error = astcenc_decompress_image(work->context, work->data, work->data_len,
+                                                   work->image_out, &work->swizzle, thread_id);
+    // This is a racy update, so which error gets returned is a random, but it
+    // will reliably report an error if an error occurs
+    if (error != ASTCENC_SUCCESS)
+    {
+        work->error = error;
+    }
+}
+
+/*
+ * Cannot use DECLARE_PRIVATE macro declared in texture.h because it calls the
+ * variable `private` which is obviously a no-no in c++. TODO: consider changing.
+ * Declare our own similar macros. Cognizant that the using functions handle both
+ * This and a prototype object, pass the object as a parameter.
+ */
+#define DECLARE_PRIVATE_EX(n,t2) ktxTexture2_private& n = *(t2->_private)
+#define DECLARE_PROTECTED_EX(n,t2) ktxTexture_protected& n = *(t2->_protected)
+
+/**
+ * @ingroup reader
+ * @brief Decodes a ktx2 texture object, if it is ASTC encoded.
+
+ * The decompressed format is calculated from corresponding ASTC format. There are
+ * only 3 possible options currently supported. RGBA8, SRGBA8 and RGBA32.
+ * @note 3d textures are decoded to a multi-slice 3d texture.
+ *
+ * Updates @p This with the decoded image.
+ *
+ * @param This     The texture to decode
+ *
+ * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
+ *
+ * @exception KTX_FILE_DATA_ERROR
+ *                              DFD is incorrect: supercompression scheme or
+ *                              sample's channelId do not match ASTC colorModel.
+ * @exception KTX_INVALID_OPERATION
+ *                              The texture's images are not in ASTC format.
+ * @exception KTX_INVALID_OPERATION
+ *                              The texture object does not contain any data.
+ * @exception KTX_INVALID_OPERATION
+ *                              ASTC decoder failed to decompress image.
+ *                              Possibly due to incorrect floating point
+ *                              compilation settings. Should not happen
+ *                              in release package.
+ * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out decoding.
+ * @exception KTX_UNSUPPORTED_FEATURE
+ *                              The texture's images are supercompressed with an
+ *                              unsupported scheme.
+ * @exception KTX_UNSUPPORTED_FEATURE
+ *                              ASTC encoder not compiled with enough
+ *                              capacity for requested block size. Should
+ *                              not happen in release package.
+ */
+KTX_error_code
+ktxTexture2_DecodeAstc(ktxTexture2 *This) {
+    // Decompress This using astc-decoder
+    uint32_t* BDB = This->pDfd + 1;
+    khr_df_model_e colorModel = (khr_df_model_e)KHR_DFDVAL(BDB, MODEL);
+    if (colorModel != KHR_DF_MODEL_ASTC) {
+        return KTX_INVALID_OPERATION; // Not in astc decodable format
+    }
+    if (This->supercompressionScheme == KTX_SS_BASIS_LZ) {
+        return KTX_FILE_DATA_ERROR; // Not a valid file.
+    }
+    // Safety check.
+    if (This->supercompressionScheme > KTX_SS_END_RANGE) {
+        return KTX_UNSUPPORTED_FEATURE; // Unsupported scheme.
+    }
+    // Other schemes are decoded in ktxTexture2_LoadImageData.
+
+    DECLARE_PRIVATE_EX(priv, This);
+
+    uint32_t channelId = KHR_DFDSVAL(BDB, 0, CHANNELID);
+    if (channelId != KHR_DF_CHANNEL_ASTC_DATA) {
+        return KTX_FILE_DATA_ERROR;
+    }
+
+    ktx_uint32_t vkformat = (ktx_uint32_t)getUncompressedFormat(This);
+
+    // Create a prototype texture to use for calculating sizes in the target
+    // format and, as useful side effects, provide us with a properly sized
+    // data allocation and the DFD for the target format.
+    ktxTextureCreateInfo createInfo;
+    createInfo.glInternalformat = 0;
+    createInfo.vkFormat = vkformat;
+    createInfo.baseWidth = This->baseWidth;
+    createInfo.baseHeight = This->baseHeight;
+    createInfo.baseDepth = This->baseDepth;
+    createInfo.generateMipmaps = This->generateMipmaps;
+    createInfo.isArray = This->isArray;
+    createInfo.numDimensions = This->numDimensions;
+    createInfo.numFaces = This->numFaces;
+    createInfo.numLayers = This->numLayers;
+    createInfo.numLevels = This->numLevels;
+    createInfo.pDfd = nullptr;
+
+    KTX_error_code result;
+    ktxTexture2* prototype;
+    result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_ALLOC_STORAGE, &prototype);
+
+    if (result != KTX_SUCCESS) {
+        assert(result == KTX_OUT_OF_MEMORY); // The only run time error
+        return result;
+    }
+
+    if (!This->pData) {
+        if (ktxTexture_isActiveStream((ktxTexture*)This)) {
+             // Load pending. Complete it.
+            result = ktxTexture2_LoadImageData(This, NULL, 0);
+            if (result != KTX_SUCCESS)
+            {
+                ktxTexture2_Destroy(prototype);
+                return result;
+            }
+        } else {
+            // No data to decode.
+            ktxTexture2_Destroy(prototype);
+            return KTX_INVALID_OPERATION;
+        }
+    }
+
+    // This is where I do the decompression from "This" to prototype target
+    astcenc_swizzle swizzle{ASTCENC_SWZ_R, ASTCENC_SWZ_G, ASTCENC_SWZ_B, ASTCENC_SWZ_A};
+    float           quality{ASTCENC_PRE_MEDIUM};
+    uint32_t        flags{0}; // TODO: Use normals mode to reconstruct normals params->normalMap ? ASTCENC_FLG_MAP_NORMAL : 0};
+
+    uint32_t        block_size_x = KHR_DFDVAL(BDB, TEXELBLOCKDIMENSION0) + 1;
+    uint32_t        block_size_y = KHR_DFDVAL(BDB, TEXELBLOCKDIMENSION1) + 1;
+    uint32_t        block_size_z = KHR_DFDVAL(BDB, TEXELBLOCKDIMENSION2) + 1;
+
+    // quality = astcQuality(params->qualityLevel);
+    // swizzle = astcSwizzle(*params);
+
+    // if(params->perceptual) flags |= ASTCENC_FLG_USE_PERCEPTUAL;
+
+    ktx_uint32_t transfer = KHR_DFDVAL(BDB, TRANSFER);
+    bool ldr = isFormatAstcLDR(This);
+    astcenc_profile profile = astcProfile(transfer == KHR_DF_TRANSFER_SRGB, ldr);
+
+    uint32_t threadCount{1}; // Decompression isn't the bottleneck and only used when checking for psnr and ssim
+    astcenc_config   astc_config;
+    astcenc_context *astc_context;
+    astcenc_error astc_error = astcenc_config_init(profile,
+                                                   block_size_x, block_size_y, block_size_z,
+                                                   quality, flags,
+                                                   &astc_config);
+
+    if (astc_error != ASTCENC_SUCCESS)
+        return mapAstcError(astc_error);
+
+    astc_error  = astcenc_context_alloc(&astc_config, threadCount, &astc_context);
+
+    if (astc_error != ASTCENC_SUCCESS)
+        return mapAstcError(astc_error);
+
+    decompression_workload work;
+    work.context = astc_context;
+    work.swizzle = swizzle;
+    work.error = ASTCENC_SUCCESS;
+
+    for (uint32_t levelIndex = 0; levelIndex < This->numLevels; ++levelIndex) {
+        const uint32_t imageWidth = std::max(This->baseWidth >> levelIndex, 1u);
+        const uint32_t imageHeight = std::max(This->baseHeight >> levelIndex, 1u);
+        const uint32_t imageDepths = std::max(This->baseDepth >> levelIndex, 1u);
+
+        for (uint32_t layerIndex = 0; layerIndex < This->numLayers; ++layerIndex) {
+            for (uint32_t faceIndex = 0; faceIndex < This->numFaces; ++faceIndex) {
+                for (uint32_t depthSliceIndex = 0; depthSliceIndex < imageDepths; ++depthSliceIndex) {
+
+                    ktx_size_t levelImageSizeIn = ktxTexture_calcImageSize(ktxTexture(This), levelIndex, KTX_FORMAT_VERSION_TWO);
+
+                    ktx_size_t imageOffsetIn;
+                    ktx_size_t imageOffsetOut;
+
+                    ktxTexture2_GetImageOffset(This, levelIndex, layerIndex, faceIndex + depthSliceIndex, &imageOffsetIn);
+                    ktxTexture2_GetImageOffset(prototype, levelIndex, layerIndex, faceIndex + depthSliceIndex, &imageOffsetOut);
+
+                    auto* imageDataIn = This->pData + imageOffsetIn;
+                    auto* imageDataOut = prototype->pData + imageOffsetOut;
+
+                    astcenc_image imageOut;
+                    imageOut.dim_x = imageWidth;
+                    imageOut.dim_y = imageHeight;
+                    imageOut.dim_z = imageDepths;
+                    imageOut.data_type = ASTCENC_TYPE_U8; // TODO: Fix for HDR types
+                    imageOut.data = (void**)&imageDataOut; // TODO: Fix for HDR types
+
+                    work.data = imageDataIn;
+                    work.data_len = levelImageSizeIn;
+                    work.image_out = &imageOut;
+
+                    // Only launch worker threads for multi-threaded use - it makes basic
+                    // single-threaded profiling and debugging a little less convoluted
+                    if (threadCount > 1) {
+                        launchThreads(threadCount, decompression_workload_runner, &work);
+                    } else {
+                        work.error = astcenc_decompress_image(work.context, work.data, work.data_len,
+                                                              work.image_out, &work.swizzle, 0);
+                    }
+
+                    // Reset ASTC context for next image
+                    astcenc_decompress_reset(astc_context);
+
+                    if (work.error != ASTCENC_SUCCESS) {
+                        //std::cout << "ASTC decompressor failed\n" << astcenc_get_error_string(work.error) << std::endl;
+
+                        astcenc_context_free(astc_context);
+                        return mapAstcError(work.error);
+                    }
+                }
+            }
+        }
+    }
+
+    // We are done with astcdecoder
+    astcenc_context_free(astc_context);
+
+    if (result == KTX_SUCCESS) {
+        // Fix up the current texture
+        DECLARE_PROTECTED_EX(thisPrtctd, This);
+        DECLARE_PRIVATE_EX(protoPriv, prototype);
+        DECLARE_PROTECTED_EX(protoPrtctd, prototype);
+        memcpy(&thisPrtctd._formatSize, &protoPrtctd._formatSize,
+               sizeof(ktxFormatSize));
+        This->vkFormat = vkformat;
+        This->isCompressed = prototype->isCompressed;
+        This->supercompressionScheme = KTX_SS_NONE;
+        priv._requiredLevelAlignment = protoPriv._requiredLevelAlignment;
+        // Copy the levelIndex from the prototype to This.
+        memcpy(priv._levelIndex, protoPriv._levelIndex,
+               This->numLevels * sizeof(ktxLevelIndexEntry));
+        // Move the DFD and data from the prototype to This.
+        free(This->pDfd);
+        This->pDfd = prototype->pDfd;
+        prototype->pDfd = 0;
+        free(This->pData);
+        This->pData = prototype->pData;
+        This->dataSize = prototype->dataSize;
+        prototype->pData = 0;
+        prototype->dataSize = 0;
+        // Free SGD data
+        This->_private->_sgdByteLength = 0;
+        if (This->_private->_supercompressionGlobalData) {
+            free(This->_private->_supercompressionGlobalData);
+            This->_private->_supercompressionGlobalData = NULL;
+        }
+    }
+    ktxTexture2_Destroy(prototype);
+    return result;
+}
+
+//************************************************************************
+//*                          Encoder functions                           *
+//************************************************************************
+
+#if KTX_FEATURE_WRITE
 static astcenc_image*
 imageAllocate(uint32_t bitness,
               uint32_t dim_x, uint32_t dim_y, uint32_t dim_z) {
@@ -301,72 +765,6 @@ astcVkFormat(ktx_uint32_t block_size, bool sRGB) {
 /**
  * @memberof ktxTexture
  * @internal
- * @ingroup reader
- * @~English
- * @brief       Should be used to get uncompressed version of ASTC VkFormat
- *
- * The decompressed format is calculated from corresponding ASTC format. There are
- * only 3 possible options currently supported. RGBA8, SRGBA8 and RGBA32.
- *
- * @return      Uncompressed version of VKFormat for a specific ASTC VkFormat
- */
-inline VkFormat getUncompressedFormat(ktxTexture2* This) noexcept {
-    uint32_t* BDB = This->pDfd + 1;
-
-    if (KHR_DFDSVAL(BDB, 0, QUALIFIERS) & KHR_DF_SAMPLE_DATATYPE_FLOAT) {
-        return VK_FORMAT_R32G32B32A32_SFLOAT;
-    } else {
-        if (khr_df_transfer_e(KHR_DFDVAL(BDB, TRANSFER) == KHR_DF_TRANSFER_SRGB))
-            return VK_FORMAT_R8G8B8A8_SRGB;
-        else
-            return VK_FORMAT_R8G8B8A8_UNORM;
-    }
-}
-
-/**
- * @memberof ktxTexture
- * @internal
- * @ingroup reader
- * @~English
- * @brief       Should be used to check if an ASTC VkFormat is LDR format or not.
- *
- * @return      true if the VkFormat is an ASTC LDR format.
- */
-inline bool isFormatAstcLDR(ktxTexture2* This) noexcept {
-    return (KHR_DFDSVAL(This->pDfd + 1, 0, QUALIFIERS) & KHR_DF_SAMPLE_DATATYPE_FLOAT) == 0;
-}
-
-/**
- * @memberof ktxTexture
- * @internal
- * @ingroup reader writer
- * @~English
- * @brief       Creates valid ASTC decoder profile from VkFormat
- *
- * @return      Valid astc_profile from VkFormat
- */
-static astcenc_profile
-astcProfile(bool sRGB, bool ldr) {
-
-    if (sRGB && ldr)
-        return ASTCENC_PRF_LDR_SRGB;
-    else if (!sRGB) {
-        if (ldr)
-            return ASTCENC_PRF_LDR;
-        else
-            return ASTCENC_PRF_HDR;
-    }
-    // TODO: Add support for the following
-    // KTX_PACK_ASTC_ENCODER_ACTION_COMP_HDR_RGB_LDR_ALPHA; currently not supported
-
-    assert(ldr && "HDR sRGB profile not supported");
-
-  return ASTCENC_PRF_LDR_SRGB;
-}
-
-/**
- * @memberof ktxTexture
- * @internal
  * @ingroup writer
  * @~English
  * @brief       Creates valid ASTC encoder swizzle from string.
@@ -473,115 +871,6 @@ compressionWorkloadRunner(int threadCount, int threadId, void* payload) {
     // will reliably report an error if an error occurs
     if (error != ASTCENC_SUCCESS) {
         work->error = error;
-    }
-}
-
-/**
- * @internal
- * @brief Worker thread helper payload for launchThreads.
- */
-struct LaunchDesc {
-    /** The native thread handle. */
-    pthread_t threadHandle;
-    /** The total number of threads in the thread pool. */
-    int threadCount;
-    /** The thread index in the thread pool. */
-    int threadId;
-    /** The user thread function to execute. */
-    void (*func)(int, int, void*);
-    /** The user thread payload. */
-    void* payload;
-};
-
-/**
- * @internal
- * @~English
- * @brief Helper function to translate thread entry points.
- *
- * Convert a (void*) thread entry to an (int, void*) thread entry, where the
- * integer contains the thread ID in the thread pool.
- *
- * @param p The thread launch helper payload.
- */
-static void*
-launchThreadsHelper(void *p) {
-    LaunchDesc* ltd = (LaunchDesc*)p;
-    ltd->func(ltd->threadCount, ltd->threadId, ltd->payload);
-    return nullptr;
-}
-
-/* Public function, see header file for detailed documentation */
-static void
-launchThreads(int threadCount, void (*func)(int, int, void*), void *payload) {
-    // Directly execute single threaded workloads on this thread
-    if (threadCount <= 1) {
-        func(1, 0, payload);
-        return;
-    }
-
-    // Otherwise spawn worker threads
-    LaunchDesc *threadDescs = new LaunchDesc[threadCount];
-    for (int i = 0; i < threadCount; i++) {
-        threadDescs[i].threadCount = threadCount;
-        threadDescs[i].threadId = i;
-        threadDescs[i].payload = payload;
-        threadDescs[i].func = func;
-
-        pthread_create(&(threadDescs[i].threadHandle), nullptr,
-                       launchThreadsHelper, (void*)&(threadDescs[i]));
-    }
-
-    // ... and then wait for them to complete
-    for (int i = 0; i < threadCount; i++) {
-        pthread_join(threadDescs[i].threadHandle, nullptr);
-    }
-
-    delete[] threadDescs;
-}
-
-/**
- * @internal
- * @~English
- * @brief Map astcenc error code to KTX error code
- *
- * Asserts are fired on errors reflecting bad parameters passed by libktx
- * or astcenc compilation settings that do not permit correct operation.
- *
- * @param astc_error The error code to be mapped.
- * @return An equivalent KTX error code.
- */
-static ktx_error_code_e
-mapAstcError(astcenc_error astc_error) {
-    switch (astc_error) {
-    case ASTCENC_SUCCESS:
-        return KTX_SUCCESS;
-    case ASTCENC_ERR_OUT_OF_MEM:
-        return KTX_OUT_OF_MEMORY;
-    case ASTCENC_ERR_BAD_BLOCK_SIZE: //[[fallthrough]];
-    case ASTCENC_ERR_BAD_DECODE_MODE: //[[fallthrough]];
-    case ASTCENC_ERR_BAD_FLAGS: //[[fallthrough]];
-    case ASTCENC_ERR_BAD_PARAM: //[[fallthrough]];
-    case ASTCENC_ERR_BAD_PROFILE: //[[fallthrough]];
-    case ASTCENC_ERR_BAD_QUALITY: //[[fallthrough]];
-    case ASTCENC_ERR_BAD_SWIZZLE:
-        assert(false && "libktx passing bad parameter to astcenc");
-        return KTX_INVALID_VALUE;
-    case ASTCENC_ERR_BAD_CONTEXT:
-        assert(false && "libktx has set up astcenc context incorrectly");
-        return KTX_INVALID_OPERATION;
-    case ASTCENC_ERR_BAD_CPU_FLOAT:
-        assert(false && "Code compiled such that float operations do not meet codec's assumptions.");
-        // Most likely compiled with fast math enabled.
-        return KTX_INVALID_OPERATION;
-    case ASTCENC_ERR_NOT_IMPLEMENTED:
-        assert(false && "ASTCENC_BLOCK_MAX_TEXELS not enough for specified block size");
-        return KTX_UNSUPPORTED_FEATURE;
-    // gcc fails to detect that the switch handles all astcenc_error
-    // enumerators and raises a return-type error, "control reaches end of
-    // non-void function", hence this
-    default:
-        assert(false && "Unhandled astcenc error");
-        return KTX_INVALID_OPERATION;
     }
 }
 
@@ -933,269 +1222,16 @@ ktxTexture2_CompressAstc(ktxTexture2* This, ktx_uint32_t quality) {
 
     return ktxTexture2_CompressAstcEx(This, &params);
 }
-
-struct decompression_workload
-{
-    astcenc_context* context;
-    uint8_t* data;
-    size_t data_len;
-    astcenc_image* image_out;
-    astcenc_swizzle swizzle;
-    astcenc_error error;
-};
-
-/**
- * @internal
- * @ingroup reader
- * @brief Runner callback function for a decompression worker thread.
- *
- * @param thread_count   The number of threads in the worker pool.
- * @param thread_id      The index of this thread in the worker pool.
- * @param payload        The parameters for this thread.
- */
-static void decompression_workload_runner(int thread_count, int thread_id, void* payload) {
-    (void)thread_count;
-
-    decompression_workload* work = static_cast<decompression_workload*>(payload);
-    astcenc_error error = astcenc_decompress_image(work->context, work->data, work->data_len,
-                                                   work->image_out, &work->swizzle, thread_id);
-    // This is a racy update, so which error gets returned is a random, but it
-    // will reliably report an error if an error occurs
-    if (error != ASTCENC_SUCCESS)
-    {
-        work->error = error;
-    }
+#else
+extern "C" KTX_error_code
+ktxTexture2_CompressAstcEx(ktxTexture2*, ktxAstcParams*) {
+    return KTX_INVALID_OPERATION;
 }
 
-/**
- * @ingroup reader
- * @brief Decodes a ktx2 texture object, if it is ASTC encoded.
-
- * The decompressed format is calculated from corresponding ASTC format. There are
- * only 3 possible options currently supported. RGBA8, SRGBA8 and RGBA32.
- * @note 3d textures are decoded to a multi-slice 3d texture.
- *
- * Updates @p This with the decoded image.
- *
- * @param This     The texture to decode
- *
- * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
- *
- * @exception KTX_FILE_DATA_ERROR
- *                              DFD is incorrect: supercompression scheme or
- *                              sample's channelId do not match ASTC colorModel.
- * @exception KTX_INVALID_OPERATION
- *                              The texture's images are not in ASTC format.
- * @exception KTX_INVALID_OPERATION
- *                              The texture object does not contain any data.
- * @exception KTX_INVALID_OPERATION
- *                              ASTC decoder failed to decompress image.
- *                              Possibly due to incorrect floating point
- *                              compilation settings. Should not happen
- *                              in release package.
- * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out decoding.
- * @exception KTX_UNSUPPORTED_FEATURE
- *                              The texture's images are supercompressed with an
- *                              unsupported scheme.
- * @exception KTX_UNSUPPORTED_FEATURE
- *                              ASTC encoder not compiled with enough
- *                              capacity for requested block size. Should
- *                              not happen in release package.
- */
-KTX_error_code
-ktxTexture2_DecodeAstc(ktxTexture2 *This) {
-    // Decompress This using astc-decoder
-    uint32_t* BDB = This->pDfd + 1;
-    khr_df_model_e colorModel = (khr_df_model_e)KHR_DFDVAL(BDB, MODEL);
-    if (colorModel != KHR_DF_MODEL_ASTC) {
-        return KTX_INVALID_OPERATION; // Not in astc decodable format
-    }
-    if (This->supercompressionScheme == KTX_SS_BASIS_LZ) {
-        return KTX_FILE_DATA_ERROR; // Not a valid file.
-    }
-    // Safety check.
-    if (This->supercompressionScheme > KTX_SS_END_RANGE) {
-        return KTX_UNSUPPORTED_FEATURE; // Unsupported scheme.
-    }
-    // Other schemes are decoded in ktxTexture2_LoadImageData.
-
-    DECLARE_PRIVATE(priv, This);
-
-    uint32_t channelId = KHR_DFDSVAL(BDB, 0, CHANNELID);
-    if (channelId != KHR_DF_CHANNEL_ASTC_DATA) {
-        return KTX_FILE_DATA_ERROR;
-    }
-
-    ktx_uint32_t vkformat = (ktx_uint32_t)getUncompressedFormat(This);
-
-    // Create a prototype texture to use for calculating sizes in the target
-    // format and, as useful side effects, provide us with a properly sized
-    // data allocation and the DFD for the target format.
-    ktxTextureCreateInfo createInfo;
-    createInfo.glInternalformat = 0;
-    createInfo.vkFormat = vkformat;
-    createInfo.baseWidth = This->baseWidth;
-    createInfo.baseHeight = This->baseHeight;
-    createInfo.baseDepth = This->baseDepth;
-    createInfo.generateMipmaps = This->generateMipmaps;
-    createInfo.isArray = This->isArray;
-    createInfo.numDimensions = This->numDimensions;
-    createInfo.numFaces = This->numFaces;
-    createInfo.numLayers = This->numLayers;
-    createInfo.numLevels = This->numLevels;
-    createInfo.pDfd = nullptr;
-
-    KTX_error_code result;
-    ktxTexture2* prototype;
-    result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_ALLOC_STORAGE, &prototype);
-
-    if (result != KTX_SUCCESS) {
-        assert(result == KTX_OUT_OF_MEMORY); // The only run time error
-        return result;
-    }
-
-    if (!This->pData) {
-        if (ktxTexture_isActiveStream((ktxTexture*)This)) {
-             // Load pending. Complete it.
-            result = ktxTexture2_LoadImageData(This, NULL, 0);
-            if (result != KTX_SUCCESS)
-            {
-                ktxTexture2_Destroy(prototype);
-                return result;
-            }
-        } else {
-            // No data to decode.
-            ktxTexture2_Destroy(prototype);
-            return KTX_INVALID_OPERATION;
-        }
-    }
-
-    // This is where I do the decompression from "This" to prototype target
-    astcenc_swizzle swizzle{ASTCENC_SWZ_R, ASTCENC_SWZ_G, ASTCENC_SWZ_B, ASTCENC_SWZ_A};
-    float           quality{ASTCENC_PRE_MEDIUM};
-    uint32_t        flags{0}; // TODO: Use normals mode to reconstruct normals params->normalMap ? ASTCENC_FLG_MAP_NORMAL : 0};
-
-    uint32_t        block_size_x = KHR_DFDVAL(BDB, TEXELBLOCKDIMENSION0) + 1;
-    uint32_t        block_size_y = KHR_DFDVAL(BDB, TEXELBLOCKDIMENSION1) + 1;
-    uint32_t        block_size_z = KHR_DFDVAL(BDB, TEXELBLOCKDIMENSION2) + 1;
-
-    // quality = astcQuality(params->qualityLevel);
-    // swizzle = astcSwizzle(*params);
-
-    // if(params->perceptual) flags |= ASTCENC_FLG_USE_PERCEPTUAL;
-
-    ktx_uint32_t transfer = KHR_DFDVAL(BDB, TRANSFER);
-    bool ldr = isFormatAstcLDR(This);
-    astcenc_profile profile = astcProfile(transfer == KHR_DF_TRANSFER_SRGB, ldr);
-
-    uint32_t threadCount{1}; // Decompression isn't the bottleneck and only used when checking for psnr and ssim
-    astcenc_config   astc_config;
-    astcenc_context *astc_context;
-    astcenc_error astc_error = astcenc_config_init(profile,
-                                                   block_size_x, block_size_y, block_size_z,
-                                                   quality, flags,
-                                                   &astc_config);
-
-    if (astc_error != ASTCENC_SUCCESS)
-        return mapAstcError(astc_error);
-
-    astc_error  = astcenc_context_alloc(&astc_config, threadCount, &astc_context);
-
-    if (astc_error != ASTCENC_SUCCESS)
-        return mapAstcError(astc_error);
-
-    decompression_workload work;
-    work.context = astc_context;
-    work.swizzle = swizzle;
-    work.error = ASTCENC_SUCCESS;
-
-    for (uint32_t levelIndex = 0; levelIndex < This->numLevels; ++levelIndex) {
-        const uint32_t imageWidth = std::max(This->baseWidth >> levelIndex, 1u);
-        const uint32_t imageHeight = std::max(This->baseHeight >> levelIndex, 1u);
-        const uint32_t imageDepths = std::max(This->baseDepth >> levelIndex, 1u);
-
-        for (uint32_t layerIndex = 0; layerIndex < This->numLayers; ++layerIndex) {
-            for (uint32_t faceIndex = 0; faceIndex < This->numFaces; ++faceIndex) {
-                for (uint32_t depthSliceIndex = 0; depthSliceIndex < imageDepths; ++depthSliceIndex) {
-
-                    ktx_size_t levelImageSizeIn = ktxTexture_calcImageSize(ktxTexture(This), levelIndex, KTX_FORMAT_VERSION_TWO);
-
-                    ktx_size_t imageOffsetIn;
-                    ktx_size_t imageOffsetOut;
-
-                    ktxTexture2_GetImageOffset(This, levelIndex, layerIndex, faceIndex + depthSliceIndex, &imageOffsetIn);
-                    ktxTexture2_GetImageOffset(prototype, levelIndex, layerIndex, faceIndex + depthSliceIndex, &imageOffsetOut);
-
-                    auto* imageDataIn = This->pData + imageOffsetIn;
-                    auto* imageDataOut = prototype->pData + imageOffsetOut;
-
-                    astcenc_image imageOut;
-                    imageOut.dim_x = imageWidth;
-                    imageOut.dim_y = imageHeight;
-                    imageOut.dim_z = imageDepths;
-                    imageOut.data_type = ASTCENC_TYPE_U8; // TODO: Fix for HDR types
-                    imageOut.data = (void**)&imageDataOut; // TODO: Fix for HDR types
-
-                    work.data = imageDataIn;
-                    work.data_len = levelImageSizeIn;
-                    work.image_out = &imageOut;
-
-                    // Only launch worker threads for multi-threaded use - it makes basic
-                    // single-threaded profiling and debugging a little less convoluted
-                    if (threadCount > 1) {
-                        launchThreads(threadCount, decompression_workload_runner, &work);
-                    } else {
-                        work.error = astcenc_decompress_image(work.context, work.data, work.data_len,
-                                                              work.image_out, &work.swizzle, 0);
-                    }
-
-                    // Reset ASTC context for next image
-                    astcenc_decompress_reset(astc_context);
-
-                    if (work.error != ASTCENC_SUCCESS) {
-                        //std::cout << "ASTC decompressor failed\n" << astcenc_get_error_string(work.error) << std::endl;
-
-                        astcenc_context_free(astc_context);
-                        return mapAstcError(work.error);
-                    }
-                }
-            }
-        }
-    }
-
-    // We are done with astcdecoder
-    astcenc_context_free(astc_context);
-
-    if (result == KTX_SUCCESS) {
-        // Fix up the current texture
-        DECLARE_PROTECTED(thisPrtctd, This);
-        DECLARE_PRIVATE(protoPriv, prototype);
-        DECLARE_PROTECTED(protoPrtctd, prototype);
-        memcpy(&thisPrtctd._formatSize, &protoPrtctd._formatSize,
-               sizeof(ktxFormatSize));
-        This->vkFormat = vkformat;
-        This->isCompressed = prototype->isCompressed;
-        This->supercompressionScheme = KTX_SS_NONE;
-        priv._requiredLevelAlignment = protoPriv._requiredLevelAlignment;
-        // Copy the levelIndex from the prototype to This.
-        memcpy(priv._levelIndex, protoPriv._levelIndex,
-               This->numLevels * sizeof(ktxLevelIndexEntry));
-        // Move the DFD and data from the prototype to This.
-        free(This->pDfd);
-        This->pDfd = prototype->pDfd;
-        prototype->pDfd = 0;
-        free(This->pData);
-        This->pData = prototype->pData;
-        This->dataSize = prototype->dataSize;
-        prototype->pData = 0;
-        prototype->dataSize = 0;
-        // Free SGD data
-        This->_private->_sgdByteLength = 0;
-        if (This->_private->_supercompressionGlobalData) {
-            free(This->_private->_supercompressionGlobalData);
-            This->_private->_supercompressionGlobalData = NULL;
-        }
-    }
-    ktxTexture2_Destroy(prototype);
-    return result;
+extern "C" KTX_error_code
+ktxTexture2_CompressAstc(ktxTexture2*, ktx_uint32_t) {
+    return KTX_INVALID_OPERATION;
 }
+#endif /* KTX_FEATURE_WRITE */
+
+

--- a/lib/astc_codec.cpp
+++ b/lib/astc_codec.cpp
@@ -777,7 +777,7 @@ astcSwizzle(const ktxAstcParams &params) {
     astcenc_swizzle swizzle{ASTCENC_SWZ_R, ASTCENC_SWZ_G, ASTCENC_SWZ_B, ASTCENC_SWZ_A};
 
     std::vector<astcenc_swz*> swizzle_array{&swizzle.r, &swizzle.g, &swizzle.b, &swizzle.a};
-    std::string inputSwizzle = params.inputSwizzle;
+    std::string inputSwizzle(params.inputSwizzle, sizeof(params.inputSwizzle));
 
     if (inputSwizzle.size() > 0) {
         assert(inputSwizzle.size() == 4 && "InputSwizzle is invalid.");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,12 @@ if(KTX_FEATURE_LOADTEST_APPS)
     add_subdirectory(loadtests)
 endif()
 
+if(KTX_FEATURE_TESTS OR KTX_FEATURE_TOOLS_CTS)
+    # Used by texturetests as well as CTS.
+    add_subdirectory(ktxdiff)
+    set(KTX_DIFF_PATH $<TARGET_FILE:ktxdiff>)
+endif()
+
 # gtest based unit-tests
 if(KTX_FEATURE_TESTS AND NOT APPLE_LOCKED_OS AND NOT ANDROID AND NOT EMSCRIPTEN)
     include(tests.cmake)
@@ -33,7 +39,6 @@ if(KTX_FEATURE_TOOLS)
 
     # ktx cli tool tests
     if(KTX_FEATURE_TOOLS_CTS)
-        add_subdirectory(ktxdiff)
         set(KTX_TOOLS_PATH $<TARGET_FILE:ktxtools>)
         set(KTX_DIFF_PATH $<TARGET_FILE:ktxdiff>)
         add_subdirectory(cts/clitests)

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -117,7 +117,7 @@ add_library( appfwSDL STATIC
 target_compile_features(appfwSDL PUBLIC c_std_99 cxx_std_11)
 if(EMSCRIPTEN)
     target_compile_options( appfwSDL PUBLIC
-         "SHELL:-s USE_SDL=2"
+         "SHELL:--use-port=sdl2"
     )
 endif()
 

--- a/tests/streamtests/CMakeLists.txt
+++ b/tests/streamtests/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_executable( streamtests
     streamtests.cc
+    ../tests.cmake
 )
 set_test_properties(streamtests)
 set_code_sign(streamtests)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -74,6 +74,10 @@ target_link_libraries(
     ${CMAKE_THREAD_LIBS_INIT}
 )
 
+if(NOT DEFINED KTX_DIFF_PATH)
+    message(FATAL_ERROR "KTX_DIFF_PATH not defined. Needed by texturetests.")
+endif()
+
 add_executable( texturetests
     texturetests/texturetests.cc
     unittests/wthelper.h
@@ -109,8 +113,11 @@ gtest_discover_tests(unittests
     # With the 5s default we get periodic timeouts on Travis & GitHub CI.
     DISCOVERY_TIMEOUT 20
 )
+
+#cmake_policy(SET CMP0178 NEW)
+cmake_print_variables(CMAKE_CURRENT_BINARY_DIR)
 gtest_discover_tests(texturetests
     TEST_PREFIX texturetest.
     DISCOVERY_TIMEOUT 20
-    EXTRA_ARGS "${PROJECT_SOURCE_DIR}/tests/testimages/"
+    EXTRA_ARGS "${PROJECT_SOURCE_DIR}/tests/testimages/" ${KTX_DIFF_PATH}
 )

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -12,7 +12,7 @@ find_package(Threads)
 # Silicon Macs. By default (MODE POST_BUILD) test discovery
 # is done as a post build operation which runs the test
 # executable to discover the list of tests as soon as it is
-# built. This unsurprisngly fails when cross compiling as
+# built. This unsurprisingly fails when cross compiling as
 # tests built for the target won't run on the host. It fails
 # on Apple Silicon as all executables must be signed. Because
 # most generators (Xcode certainly) set up signing as a post
@@ -77,9 +77,16 @@ target_link_libraries(
 add_executable( texturetests
     texturetests/texturetests.cc
     unittests/wthelper.h
+    tests.cmake
 )
 set_test_properties(texturetests)
 set_code_sign(texturetests)
+
+target_compile_features(
+    texturetests
+PUBLIC
+    cxx_std_17
+)
 
 target_include_directories(
     texturetests

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -114,8 +114,6 @@ gtest_discover_tests(unittests
     DISCOVERY_TIMEOUT 20
 )
 
-#cmake_policy(SET CMP0178 NEW)
-cmake_print_variables(CMAKE_CURRENT_BINARY_DIR)
 gtest_discover_tests(texturetests
     TEST_PREFIX texturetest.
     DISCOVERY_TIMEOUT 20

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -3158,9 +3158,9 @@ DecodeUTF8Path(std::string path) {
 inline std::string DecodeUTF8Path(std::string path) { return path; }
 #endif
 
-//#if defined(WIN32)
-//  #define stat _stat64i32
-//#endif
+#if defined(WIN32)
+  #define stat _stat64i32
+#endif
 
 static int
 statUTF8(const char* path, struct stat* info) {

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -2850,7 +2850,7 @@ TEST(UnicodeFileNames, CreateFrom) {
 
         filePath.replace_filename(*it);
         result = ktxTexture_CreateFromNamedFile(
-            filePath.c_str(),
+            filePath.u8string().c_str(),
             KTX_TEXTURE_CREATE_NO_FLAGS,
             &texture);
         EXPECT_EQ(result, KTX_SUCCESS);
@@ -2862,12 +2862,12 @@ TEST(UnicodeFileNames, CreateFrom) {
 
         if (filePath.extension() == ".ktx") {
             result = ktxTexture1_CreateFromNamedFile(
-                filePath.c_str(),
+                filePath.u8string().c_str(),
                 KTX_TEXTURE_CREATE_NO_FLAGS,
                 (ktxTexture1**)&texture);
         } else {
             result = ktxTexture2_CreateFromNamedFile(
-                filePath.c_str(),
+                filePath.u8string().c_str(),
                 KTX_TEXTURE_CREATE_NO_FLAGS,
                 (ktxTexture2**)&texture);
         }
@@ -2906,7 +2906,7 @@ TEST_F(ktxTexture2_AstcLdrEncodeDecodeTest, CompressToAstcLdrThenDecode) {
                                      << ktxErrorString(result);
         ASSERT_TRUE(texture->pData != NULL) << "Image data not loaded";
 
-        result = ktxTexture2_WriteToNamedFile(texture, original.c_str());
+        result = ktxTexture2_WriteToNamedFile(texture, original.u8string().c_str());
         ASSERT_TRUE(result == KTX_SUCCESS);
 
         auto depth = texture->baseDepth;
@@ -2961,7 +2961,7 @@ TEST_F(ktxTexture2_AstcLdrEncodeDecodeTest, CompressToAstcLdrThenDecode) {
         model = static_cast<khr_df_model_e>(KHR_DFDVAL(texture->pDfd+1, MODEL));
         EXPECT_EQ(model, KHR_DF_MODEL_RGBSDA);
         EXPECT_EQ(depth, texture->baseDepth);
-        result = ktxTexture2_WriteToNamedFile(texture, decoded.c_str());
+        result = ktxTexture2_WriteToNamedFile(texture, decoded.u8string().c_str());
         std::string command = ktxdiffPath;
         command += " " + original.string() + " " + decoded.string() + " 0.01 > " + ktxdiffOut.string();
         int status = std::system(command.c_str());
@@ -2969,7 +2969,7 @@ TEST_F(ktxTexture2_AstcLdrEncodeDecodeTest, CompressToAstcLdrThenDecode) {
         EXPECT_EQ(texture->baseHeight, height);
         EXPECT_EQ(texture->baseWidth, width);
         if (status != 0) {
-            std::cout << std::ifstream(ktxdiffOut.string()).rdbuf();
+            std::cout << std::ifstream(ktxdiffOut).rdbuf();
         }
         if (texture) {
             ktxTexture_Destroy(ktxTexture(texture));

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -2976,7 +2976,7 @@ class ktxTexture2AstcLdrEncodeDecodeTestBase
             EXPECT_EQ(depth, texture->baseDepth);
             result = ktxTexture2_WriteToNamedFile(texture, decoded.u8string().c_str());
             int status;
-            if (internalformat != GL_RGB8 && internalformat != GL_SRGB8) {
+            if constexpr (internalformat != (GLenum)GL_RGB8 && internalformat != (GLenum)GL_SRGB8) {
                 std::string command = ktxdiffPath.u8string();
                 command += " " + original.string() + " " + decoded.string() + " 0.01 > " + ktxdiffOut.string();
                 status = std::system(command.c_str());

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -3174,10 +3174,6 @@ statUTF8(const char* path, struct stat* info) {
 GTEST_API_ int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
 
-    std::cerr << "argc = " << argc << std::endl;
-    for (int i = 0; i < argc; i++) {
-        std::cerr << "argv[" << i << "] = " << argv[i] << std::endl;
-    }
     if (!::testing::FLAGS_gtest_list_tests) {
         if (argc != 3) {
             std::cerr << "Usage: " << argv[0] << " <test images path> <ktxdiff path>\n";

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -3149,7 +3149,7 @@ GTEST_API_ int main(int argc, char** argv) {
 
         struct stat info;
 
-        if (stat(imagePath.c_str(), &info) != 0) {
+        if (stat(imagePath.u8string().c_str(), &info) != 0) {
             std::cerr << "Cannot access " << imagePath << std::endl;
             return -2;
         }

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -2943,7 +2943,8 @@ class ktxTexture2AstcLdrEncodeDecodeTestBase
 
             EXPECT_EQ(result, KTX_SUCCESS);
             VkFormat expectedFormat = blockDimensionToFormat(blockDimension);
-            EXPECT_TRUE(texture->vkFormat == expectedFormat);
+            // Oops! Maybe it was a mistake to define texture.vkFormat as unsigned.
+            EXPECT_TRUE(texture->vkFormat == (ktx_uint32_t)expectedFormat);
 
             uint32_t* pBdb = texture->pDfd+1;
             if (isFormatFloat()) {

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -3158,16 +3158,16 @@ DecodeUTF8Path(std::string path) {
 inline std::string DecodeUTF8Path(std::string path) { return path; }
 #endif
 
-#if defined(WIN32)
-  #define stat64 _stat64i32
-#endif
+//#if defined(WIN32)
+//  #define stat _stat64i32
+//#endif
 
 static int
-stat64UTF8(const char* path, struct stat64* info) {
+statUTF8(const char* path, struct stat* info) {
 #if defined(_WIN32)
     return _wstat(DecodeUTF8Path(path).c_str(), info);
 #else
-    return stat64(path, &info);
+    return stat(path, info);
 #endif
 }
 
@@ -3203,9 +3203,9 @@ GTEST_API_ int main(int argc, char* argv[]) {
         imagePath /= "";  // Ensure trailing / so path will be handled as a directory.
         ktxdiffPath = argv[2];
 
-        struct stat64 info;
+        struct stat info;
 
-        if (stat64UTF8(imagePath.u8string().c_str(), &info) != 0) {
+        if (statUTF8(imagePath.u8string().c_str(), &info) != 0) {
             std::cerr << "Cannot access " << imagePath << std::endl;
             return -2;
         }  else if (!(info.st_mode & S_IFDIR)) {

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -2976,7 +2976,7 @@ class ktxTexture2AstcLdrEncodeDecodeTestBase
             result = ktxTexture2_WriteToNamedFile(texture, decoded.u8string().c_str());
             int status;
             if (internalformat != GL_RGB8 && internalformat != GL_SRGB8) {
-                std::string command = ktxdiffPath;
+                std::string command = ktxdiffPath.u8string();
                 command += " " + original.string() + " " + decoded.string() + " 0.01 > " + ktxdiffOut.string();
                 status = std::system(command.c_str());
             } else {

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -3174,6 +3174,10 @@ statUTF8(const char* path, struct stat* info) {
 GTEST_API_ int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
 
+    std::cerr << "argc = " << argc << std::endl;
+    for (int i = 0; i < argc; i++) {
+        std::cerr << "argv[" << i << "] = " << argv[i] << std::endl;
+    }
     if (!::testing::FLAGS_gtest_list_tests) {
         if (argc != 3) {
             std::cerr << "Usage: " << argv[0] << " <test images path> <ktxdiff path>\n";
@@ -3183,12 +3187,13 @@ GTEST_API_ int main(int argc, char* argv[]) {
 #if defined(_WIN32)
         // Manually acquire the wide char command line in case a unicode
         // filename has been specified.
-        static std::vector<std::unique_ptr<char[]>> utf8Argv(argc);
+        int allargc;
         LPWSTR commandLine = GetCommandLineW();
-        LPWSTR* wideArgv = CommandLineToArgvW(commandLine, &argc);
-
-        imagePath = wideArgv[1];
-        ktxdiffPath = wideArgv[2];
+        LPWSTR* wideArgv = CommandLineToArgvW(commandLine, &allargc);
+        // commandLine still has all the arguments including those removed
+        // by InitGoogleTest, hence the arg index calculation.
+        imagePath = wideArgv[allargc - argc + 1];
+        ktxdiffPath = wideArgv[allargc - argc + 2];
 #else
         imagePath = argv[1];
         ktxdiffPath = argv[2];

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -51,6 +51,8 @@ extern ktx_bool_t __disableWriterMetadata__;
 
 namespace {
 
+namespace fs = std::filesystem;
+
 // Recursive function to return the greatest common divisor of a and b.
 static uint32_t
 gcd(uint32_t a, uint32_t b) {
@@ -2831,22 +2833,8 @@ TEST_F(ktxTexture2_MetadataTest, LibVersionUpdatedCorrectly) {
 #define OS_SEP '/'
 #endif
 
-std::string imagePath;
-std::string ktxdiffPath;
-
-std::string combinePaths(std::string const a, std::string const b) {
-    if (a.back() == OS_SEP) {
-        return a + b;
-#if defined(_WIN32)
-    }
-    else if (a.back() == UNIX_SEP) {
-        return a + b;
-#endif
-    }
-    else {
-        return a + OS_SEP + b;
-    }
-}
+fs::path imagePath;
+fs::path ktxdiffPath;
 
 TEST(UnicodeFileNames, CreateFrom) {
     std::vector<std::string> fileSet = {
@@ -2868,7 +2856,7 @@ TEST(UnicodeFileNames, CreateFrom) {
         ktx_error_code_e result;
         ktxTexture* texture;
 
-        std::string path = combinePaths(imagePath, *it);
+        fs::path path = imagePath / *it;
         result = ktxTexture_CreateFromNamedFile(
             path.c_str(),
             KTX_TEXTURE_CREATE_NO_FLAGS,
@@ -2877,8 +2865,7 @@ TEST(UnicodeFileNames, CreateFrom) {
         EXPECT_NE(texture, (ktxTexture*)0);
         ktxTexture_Destroy(texture);
 
-        size_t dotIndex = path.find_last_of('.');
-        if (path.substr(dotIndex + 1).compare("ktx") == 0) {
+        if (path.extension() == ".ktx") {
             result = ktxTexture1_CreateFromNamedFile(
                 path.c_str(),
                 KTX_TEXTURE_CREATE_NO_FLAGS,
@@ -2906,12 +2893,12 @@ GTEST_API_ int main(int argc, char** argv) {
             return -1;
         }
 
-        imagePath = std::string(argv[1]);
-        ktxdiffPath = std::string(argv[2]);
+        imagePath = argv[1];
+        ktxdiffPath = argv[2];
 
         struct stat info;
 
-        if (stat(imagePath.data(), &info) != 0) {
+        if (stat(imagePath.c_str(), &info) != 0) {
             std::cerr << "Cannot access " << imagePath << std::endl;
             return -2;
         }

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -2825,16 +2825,7 @@ TEST_F(ktxTexture2_MetadataTest, LibVersionUpdatedCorrectly) {
 // Unicode file name tests
 ///////////////////////////////////////////
 
-#if defined(_WIN32)
-#define _CRT_SECURE_NO_WARNINGS
-#define OS_SEP '\\'
-#define UNIX_SEP '/'
-#else
-#define OS_SEP '/'
-#endif
-
 fs::path imagePath;
-fs::path ktxdiffPath;
 
 TEST(UnicodeFileNames, CreateFrom) {
     std::vector<std::string> fileSet = {
@@ -2882,35 +2873,6 @@ TEST(UnicodeFileNames, CreateFrom) {
     }
 }
 
-}  // namespace
-
-GTEST_API_ int main(int argc, char** argv) {
-    testing::InitGoogleTest(&argc, argv);
-
-    if (!::testing::FLAGS_gtest_list_tests) {
-        if (argc != 3) {
-            std::cerr << "Usage: " << argv[0] << " <test images path> <ktxdiff path>\n";
-            return -1;
-        }
-
-        imagePath = argv[1];
-        ktxdiffPath = argv[2];
-
-        struct stat info;
-
-        if (stat(imagePath.c_str(), &info) != 0) {
-            std::cerr << "Cannot access " << imagePath << std::endl;
-            return -2;
-        }
-        else if (!(info.st_mode & S_IFDIR)) {
-            std::cerr << imagePath << " is not a valid directory\n";
-            return -3;
-        }
-    }
-
-    return RUN_ALL_TESTS();
-}
-
 ////////////////////////////////////////////
 // ASTC encode & decode tests
 ///////////////////////////////////////////
@@ -2920,16 +2882,15 @@ GTEST_API_ int main(int argc, char** argv) {
 
 class ktxTexture2_AstcLdrEncodeDecodeTest: public ktxTexture2TestBase<GLubyte, 4, GL_RGBA8> { };
 
+fs::path ktxdiffPath;
+
 TEST_F(ktxTexture2_AstcLdrEncodeDecodeTest, CompressToAstcLdrThenDecode) {
     ktxTexture2* texture;
     KTX_error_code result;
-    auto tmpDir = std::filesystem::temp_directory_path();
-    std::filesystem::path original = tmpDir;
-    original /= "CompressToAstcLdrThenDecode_original.ktx2";
-    std::filesystem::path decoded = tmpDir;
-    decoded /= "CompressToAstcLdrThenDecode_decoded.ktx2";
-    std::filesystem::path ktxdiffOut = tmpDir;
-    ktxdiffOut /= "ktxdiffOut.txt";
+    auto tmpDir = fs::temp_directory_path();
+    fs::path original = tmpDir / "CompressToAstcLdrThenDecode_original.ktx2";
+    fs::path decoded = tmpDir / "CompressToAstcLdrThenDecode_decoded.ktx2";
+    fs::path ktxdiffOut = tmpDir / "ktxdiffOut.txt";
 
     if (ktxMemFile != NULL) {
         result = ktxTexture2_CreateFromMemory(ktxMemFile, ktxMemFileLen,
@@ -3007,9 +2968,38 @@ TEST_F(ktxTexture2_AstcLdrEncodeDecodeTest, CompressToAstcLdrThenDecode) {
         }
         if (texture) {
             ktxTexture_Destroy(ktxTexture(texture));
-            std::filesystem::remove(original);
-            std::filesystem::remove(decoded);
-            std::filesystem::remove(ktxdiffOut);
+            fs::remove(original);
+            fs::remove(decoded);
+            fs::remove(ktxdiffOut);
         }
     }
+}
+
+}  // namespace
+
+GTEST_API_ int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+
+    if (!::testing::FLAGS_gtest_list_tests) {
+        if (argc != 3) {
+            std::cerr << "Usage: " << argv[0] << " <test images path> <ktxdiff path>\n";
+            return -1;
+        }
+
+        imagePath = argv[1];
+        ktxdiffPath = argv[2];
+
+        struct stat info;
+
+        if (stat(imagePath.c_str(), &info) != 0) {
+            std::cerr << "Cannot access " << imagePath << std::endl;
+            return -2;
+        }
+        else if (!(info.st_mode & S_IFDIR)) {
+            std::cerr << imagePath << " is not a valid directory\n";
+            return -3;
+        }
+    }
+
+    return RUN_ALL_TESTS();
 }

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -3050,6 +3050,7 @@ class ktxTexture2AstcLdrEncodeDecodeTestBase
             case KTX_PACK_ASTC_BLOCK_DIMENSION_6x5x5: return VK_FORMAT_ASTC_6x5x5_SRGB_BLOCK_EXT;
             case KTX_PACK_ASTC_BLOCK_DIMENSION_6x6x5: return VK_FORMAT_ASTC_6x6x5_SRGB_BLOCK_EXT;
             case KTX_PACK_ASTC_BLOCK_DIMENSION_6x6x6: return VK_FORMAT_ASTC_6x6x6_SRGB_BLOCK_EXT;
+            default: return VK_FORMAT_UNDEFINED;
         };
     }
 
@@ -3080,6 +3081,7 @@ class ktxTexture2AstcLdrEncodeDecodeTestBase
             case KTX_PACK_ASTC_BLOCK_DIMENSION_6x5x5: return VK_FORMAT_ASTC_6x5x5_UNORM_BLOCK_EXT;
             case KTX_PACK_ASTC_BLOCK_DIMENSION_6x6x5: return VK_FORMAT_ASTC_6x6x5_UNORM_BLOCK_EXT;
             case KTX_PACK_ASTC_BLOCK_DIMENSION_6x6x6: return VK_FORMAT_ASTC_6x6x6_UNORM_BLOCK_EXT;
+            default: return VK_FORMAT_UNDEFINED;
         };
     }
 };

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -2843,33 +2843,37 @@ TEST(UnicodeFileNames, CreateFrom) {
 
     std::vector<std::string>::const_iterator it;
 
+    fs::path filePath = imagePath;
     for (it = fileSet.begin(); it < fileSet.end(); it++) {
         ktx_error_code_e result;
-        ktxTexture* texture;
+        ktxTexture* texture = nullptr;
 
-        fs::path path = imagePath / *it;
+        filePath.replace_filename(*it);
         result = ktxTexture_CreateFromNamedFile(
-            path.c_str(),
+            filePath.c_str(),
             KTX_TEXTURE_CREATE_NO_FLAGS,
             &texture);
         EXPECT_EQ(result, KTX_SUCCESS);
         EXPECT_NE(texture, (ktxTexture*)0);
-        ktxTexture_Destroy(texture);
+        if (texture) {
+            ktxTexture_Destroy(texture);
+            texture = nullptr;
+        }
 
-        if (path.extension() == ".ktx") {
+        if (filePath.extension() == ".ktx") {
             result = ktxTexture1_CreateFromNamedFile(
-                path.c_str(),
+                filePath.c_str(),
                 KTX_TEXTURE_CREATE_NO_FLAGS,
                 (ktxTexture1**)&texture);
         } else {
             result = ktxTexture2_CreateFromNamedFile(
-                path.c_str(),
+                filePath.c_str(),
                 KTX_TEXTURE_CREATE_NO_FLAGS,
                 (ktxTexture2**)&texture);
         }
         EXPECT_EQ(result, KTX_SUCCESS);
         EXPECT_NE(texture, (ktxTexture*)0);
-        ktxTexture_Destroy(texture);
+        if (texture) ktxTexture_Destroy(texture);
     }
 }
 
@@ -2888,6 +2892,7 @@ TEST_F(ktxTexture2_AstcLdrEncodeDecodeTest, CompressToAstcLdrThenDecode) {
     ktxTexture2* texture;
     KTX_error_code result;
     auto tmpDir = fs::temp_directory_path();
+
     fs::path original = tmpDir / "CompressToAstcLdrThenDecode_original.ktx2";
     fs::path decoded = tmpDir / "CompressToAstcLdrThenDecode_decoded.ktx2";
     fs::path ktxdiffOut = tmpDir / "ktxdiffOut.txt";
@@ -2987,6 +2992,7 @@ GTEST_API_ int main(int argc, char** argv) {
         }
 
         imagePath = argv[1];
+        imagePath /= "";   // Ensure trailing / so path will be handled as a directory.
         ktxdiffPath = argv[2];
 
         struct stat info;

--- a/tests/transcodetests/CMakeLists.txt
+++ b/tests/transcodetests/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_executable( transcodetests
     transcodetests.cc
+    ../tests.cmake
 )
 set_test_properties(transcodetests)
 set_code_sign(transcodetests)

--- a/tests/webgl/libktx-webgl/libktx-test.js
+++ b/tests/webgl/libktx-webgl/libktx-test.js
@@ -992,15 +992,16 @@ async function runTests(filename) {
     await testWriteToMemoryAndRead(ktexture)
 
     await testEncodeAstc(ktextureCopy);
-    if (astcSupported) {
-      textureAstc = uploadTextureToGl(gl, ktextureCopy);
-      setUVMatrix(textureAstc, mat3.create(), ktextureCopy);
-      setTexParameters(texture, ktexture);
-      updateItem(items[astcCompTextureItem], textureAstc);
-    } else {
+    if (!astcSupported) {
+      var result = ktextureCopy.decodeAstc();
+      showTestResult('compress_astc_result', result == ktx.error_code.SUCCESS);
       items[astcCompTextureItem].label.textContent +=
-                 ". (Not displayed. This device does not support WEBGL_compressed_texture_astc)"
+                 ". (Software decoded. This device does not support WEBGL_compressed_texture_astc)"
     }
+    textureAstc = uploadTextureToGl(gl, ktextureCopy);
+    setUVMatrix(textureAstc, mat3.create(), ktextureCopy);
+    setTexParameters(texture, ktexture);
+    updateItem(items[astcCompTextureItem], textureAstc);
 
     elem('runtests').disabled = true;
 

--- a/tests/webgl/llt-three/KTX2Loader.js
+++ b/tests/webgl/llt-three/KTX2Loader.js
@@ -436,7 +436,7 @@ class KTX2Container {
 		if ( config.astcSupported ) {
 
 			targetFormat = TranscodeTarget.ASTC_4x4_RGBA;
-			thights.transcodedFormat = RGBA_ASTC_4x4_Format;
+			this.transcodedFormat = RGBA_ASTC_4x4_Format;
 
 		} else if ( config.dxtSupported ) {
 


### PR DESCRIPTION
Add ktxTexture2_DecodeAstc to `libktx_read`, a previous omission. Needed too so the function can be included in the read-only JS bindings.

Add tests of ASTC encode and decode functionality to `texturetest`. The change includes needing to pass the path to `ktxdiff` to `texturetests` as the new tests use it to compare the decoded result with the original image.

Change `texturetest` to use std::filesystem::path and c++17.

Fix issue in `astc_codec.cpp` where conversion of `params.inputSwizzle' could fail, asserting in a debug build.