### PR TITLE
Update for Vulkan SDK 1.4.313.

### DIFF
--- a/.github/workflows/check-reuse.yml
+++ b/.github/workflows/check-reuse.yml
@@ -24,6 +24,8 @@ on:
 jobs:
   check-reuse:
     runs-on: ubuntu-latest
+    env:
+      GIT_LFS_SKIP_SMUDGE: 1
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+env:
+ GIT_LFS_SKIP_SMUDGE: 1
+
 jobs:
   build-docs:
     name: Build KTX-Software reference pages and documentation
@@ -64,7 +67,6 @@ jobs:
 
     env:
       BUILD_DIR: build
-      GIT_LFS_SKIP_SMUDGE: 1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_LFS_SKIP_SMUDGE: 1
+
 jobs:
   clang-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -189,8 +189,6 @@ jobs:
         run: |
           echo -n "Running on the following GitHub Actions CI runner: " && uname -a
           echo -n "CMake version on the runner is " && cmake --version
-          echo -e "machine github.com\n  login $GITHUB_TOKEN" >> ~/.netrc # Prevent rate limiting on Git LFS.
-          cat ~/.netrc
           sudo apt-get update
 
       - name: install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,7 +52,7 @@ jobs:
           generator: Ninja
           arch: x86_64
           compiler: gcc
-          vk_sdk_ver: '1.3.290'
+          vk_sdk_ver: '1.4.313'
           options: {
             config: Debug,
             doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: ON,
@@ -63,7 +63,7 @@ jobs:
           generator: Ninja Multi-Config
           arch: x86_64
           compiler: clang
-          vk_sdk_ver: '1.3.290'
+          vk_sdk_ver: '1.4.313'
           options: {
             config: 'Debug,Release',
             doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: OFF,
@@ -74,7 +74,7 @@ jobs:
           generator: Ninja
           arch: x86_64
           compiler: gcc
-          vk_sdk_ver: '1.3.290'
+          vk_sdk_ver: '1.4.313'
           options: {
             config: Release,
             doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: ON,
@@ -85,7 +85,7 @@ jobs:
           generator: Ninja
           arch: aarch64
           compiler: gcc
-          vk_sdk_ver: '1.3.290'
+          vk_sdk_ver: '1.4.313'
           #vcpkg_install_options: --debug
           options: {
             config: Release,
@@ -97,7 +97,7 @@ jobs:
           generator: Ninja
           arch: x86_64
           compiler: gcc
-          vk_sdk_ver: '1.3.290'
+          vk_sdk_ver: '1.4.313'
           options: {
             config: Release,
             doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tools: OFF, tools_cts: OFF,
@@ -108,7 +108,7 @@ jobs:
           generator: Ninja
           arch: x86_64
           compiler: gcc
-          vk_sdk_ver: '1.3.290'
+          vk_sdk_ver: '1.4.313'
           options: {
             config: Release,
             doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tools: OFF, tools_cts: OFF,
@@ -119,7 +119,7 @@ jobs:
           generator: Ninja
           arch: x86_64
           compiler: gcc
-          vk_sdk_ver: '1.3.290'
+          vk_sdk_ver: '1.4.313'
           options: {
             config: Release,
             doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tools: OFF, tools_cts: OFF,

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,8 +130,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images
-      # for loadtests and legacy tool tests. They will be pulled later as
-      # necessary
+      # for texturetests etc., loadtests and legacy tool tests. They will be
+      # pulled later as necessary
       GIT_LFS_SKIP_SMUDGE: 1
 
       BUILD_DIR: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -129,6 +129,9 @@ jobs:
     name: ${{ matrix.name && matrix.name || format('{0} SSE,OpenCL:{1},{2}', matrix.os, matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
+      # To avoid bandwidth charges skip downloading source and golden images
+      # for loadtests and legacy tool tests. They will be pulled later as
+      # necessary
       GIT_LFS_SKIP_SMUDGE: 1
 
       BUILD_DIR: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -225,6 +225,9 @@ jobs:
           if [ "$FEATURE_TOOLS_CTS" = "ON" ]; then
             git submodule update --init --recursive tests/cts
           fi
+          if [ "$FEATURE_TESTS" = "ON" ]; then
+            git lfs pull --include=tests/srcimages,tests/testimage
+          fi
           # Make sure embedded dates are correct.
           ./install-gitconfig.sh
           scripts/smudge_date.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
         os: [ macos-13 ]
         generator: [ Xcode ]
         arch: [ x86_64 ]
-        vk_sdk_ver: ['1.3.290.0']
+        vk_sdk_ver: ['1.4.313.1']
         options: [
           {config: 'Debug,Release', platform: macOS,
            doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: ON,
@@ -69,7 +69,7 @@ jobs:
           os: macos-latest
           generator: Xcode
           arch: arm64
-          vk_sdk_ver: '1.3.290.0'
+          vk_sdk_ver: '1.4.313.1'
           options: {
             config: Release, platform: macOS,
             doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
@@ -79,7 +79,7 @@ jobs:
           os: macos-latest
           generator: Xcode
           arch: arm64
-          vk_sdk_ver: '1.3.290.0'
+          vk_sdk_ver: '1.4.313.1'
           options: {
             config: Release, platform: macOS,
             doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,
@@ -89,7 +89,7 @@ jobs:
           os: macos-latest
           generator: Xcode
           arch: arm64
-          vk_sdk_ver: '1.3.290.0'
+          vk_sdk_ver: '1.4.313.1'
           options: {
             config: Release, platform: macOS,
             doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,
@@ -99,7 +99,7 @@ jobs:
           os: macos-latest
           generator: Xcode
           arch: arm64
-          vk_sdk_ver: '1.3.290.0'
+          vk_sdk_ver: '1.4.313.1'
           options: {
             config: Release, platform: macOS,
             doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,
@@ -109,7 +109,7 @@ jobs:
           os: macos-latest
           generator: Xcode
           arch: arm64
-          vk_sdk_ver: '1.3.290.0'
+          vk_sdk_ver: '1.4.313.1'
           options: {
             config: Release, platform: iOS,
             doc: OFF, jni: OFF, loadtests: OpenGL+Vulkan, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -119,6 +119,9 @@ jobs:
     name: ${{ matrix.name && matrix.name || format('{0} SSE,OpenCL:{1},{2}', matrix.os, matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
+      # To avoid bandwidth charges skip downloading source and golden images
+      # for loadtests and legacy tool tests. They will be pulled later as
+      # necessary
       GIT_LFS_SKIP_SMUDGE: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -256,6 +256,9 @@ jobs:
           if [ "$FEATURE_TOOLS_CTS" = "ON" ]; then
             git submodule update --init --recursive tests/cts
           fi
+          if [ "$FEATURE_TESTS" = "ON" ]; then
+            git lfs pull --include=tests/srcimages,tests/testimage
+          fi
           # Make sure embedded dates are correct.
           ./install-gitconfig.sh
           scripts/smudge_date.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -120,8 +120,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images
-      # for loadtests and legacy tool tests. They will be pulled later as
-      # necessary
+      # for texturetests etc., loadtests and legacy tool tests. They will be
+      # pulled later as necessary
       GIT_LFS_SKIP_SMUDGE: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -185,8 +185,6 @@ jobs:
         run: |
           echo -n "Running on the following GitHub Actions CI runner: " && uname -a
           echo -n "CMake version on the runner is " && cmake --version
-          echo -e "machine github.com\n  login $GITHUB_TOKEN" >> ~/.netrc # Prevent rate limiting on Git LFS.
-          cat ~/.netrc
 
       - name: Install Doxygen
         if: matrix.options.doc == 'ON'

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -47,6 +47,9 @@ jobs:
       run:
         shell: bash
     env:
+      # To avoid bandwidth charges skip downloading source and golden images
+      # for loadtests and legacy tool tests. They will be pulled later as
+      # necessary
       GIT_LFS_SKIP_SMUDGE: 1
       WERROR: ON
 

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -48,8 +48,8 @@ jobs:
         shell: bash
     env:
       # To avoid bandwidth charges skip downloading source and golden images
-      # for loadtests and legacy tool tests. They will be pulled later as
-      # necessary
+      # for texturetests etc., loadtests and legacy tool tests. They will be
+      # pulled later as necessary
       GIT_LFS_SKIP_SMUDGE: 1
       WERROR: ON
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -131,8 +131,6 @@ jobs:
         run: |
           echo -n "Running on the following GitHub Actions CI runner: " && uname -a
           echo -n "CMake version on the runner is " && cmake --version
-          echo -e "machine github.com\n  login $GITHUB_TOKEN" >> ~/.netrc # Prevent rate limiting on Git LFS.
-          cat ~/.netrc
           # Need to set uid/gid because, unlike when running docker locally,
           # /src ends up being owned by the uid/gid running this script and
           # the recent fix for CVE-2022-24765 in Git causes Git to error

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -74,8 +74,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images
-      # for loadtests and legacy tool tests. They will be pulled later as
-      # necessary
+      # for texturetests etc., loadtests and legacy tool tests. They will be
+      # pulled later as necessary
       GIT_LFS_SKIP_SMUDGE: 1
 
       BUILD_DIR: build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -149,6 +149,9 @@ jobs:
           if [ "$FEATURE_TOOLS_CTS" = "ON" ]; then
             git submodule update --init --recursive tests/cts
           fi
+          if [ "$FEATURE_TESTS" = "ON" ]; then
+            git lfs pull --include=tests/srcimages,tests/testimage
+          fi
           # Make sure embedded dates are correct.
           ./install-gitconfig.sh
           scripts/smudge_date.sh

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -73,6 +73,9 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:
+      # To avoid bandwidth charges skip downloading source and golden images
+      # for loadtests and legacy tool tests. They will be pulled later as
+      # necessary
       GIT_LFS_SKIP_SMUDGE: 1
 
       BUILD_DIR: build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,8 +88,8 @@ jobs:
             options: {
               config: 'Debug,Release',
               # Can't run arm64 tests on x86 runner.
-              doc: ON, jni: ON, loadtests: OpenGL, py: OFF, tests: OFF, tools: ON, tools_cts: OFF,
-              package: YES
+              doc: ON, jni: OFF, loadtests: OpenGL, py: OFF, tests: OFF, tools: ON, tools_cts: OFF,
+              package: NO
             }
           - os: windows-11-arm
             generator: 'Visual Studio 17 2022'
@@ -98,7 +98,7 @@ jobs:
             #vcpkg_install_options: --debug
             options: {
               config: 'Debug,Release',
-              doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: OFF, tests: ON, tools: ON, tools_cts: ON,
+              doc: ON, jni: OFF, loadtests: OpenGL+Vulkan, py: OFF, tests: ON, tools: ON, tools_cts: ON,
               package: YES
             }
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,8 @@ jobs:
             #vcpkg_install_options: --debug
             options: {
               config: 'Debug,Release',
-              doc: ON, jni: ON, loadtests: OpenGL, py: OFF, tests: ON, tools: ON, tools_cts: ON,
+              # Can't run arm64 tests on x86 runner.
+              doc: ON, jni: ON, loadtests: OpenGL, py: OFF, tests: OFF, tools: ON, tools_cts: OFF,
               package: YES
             }
           - os: windows-11-arm
@@ -319,7 +320,7 @@ jobs:
 
     - name: Test Windows build
       # Tests built for arm64 can't be run as the CI runners are all x64.
-      if: matrix.arch == 'x64' && matrix.options.tests == 'ON'
+      if: matrix.options.tests == 'ON'
       run: ctest --output-on-failure --test-dir $env:BUILD_DIR -C Release
 
 #    - name: Upload test log

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,8 +31,6 @@ on:
       - LICENSE.md
       - LICENSES
       - REUSE.toml
-      - vcpkg.json
-      - vcpkg-configuration.json
 
   # Allow manual trigger
   workflow_dispatch:
@@ -104,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       # Skip downloading necessities for the load tests and source and golden
-      # images for the other tests since we can't run arm64 tests on the x64
+      # images for the other tests. Pull them when only when FEATURE_TESTS is on.
       # build host.
       GIT_LFS_SKIP_SMUDGE: 1
 
@@ -186,6 +184,10 @@ jobs:
       # Work around https://github.com/actions/checkout/issues/290.
       if: github.ref_type == 'tag' && matrix.check_mkvk != 'ONLY'
       run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+
+    - name: Install Git LFS
+      if: matrix.os == 'windows-11-arm'
+      run: git lfs install
 
     - name: Install Doxygen
       uses: ssciwr/doxygen-install@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,6 +87,16 @@ jobs:
             #vcpkg_install_options: --debug
             options: {
               config: 'Debug,Release',
+              doc: ON, jni: ON, loadtests: OpenGL, py: OFF, tests: ON, tools: ON, tools_cts: ON,
+              package: YES
+            }
+          - os: windows-11-arm
+            generator: 'Visual Studio 17 2022'
+            toolset: CLangCL
+            arch: arm64
+            #vcpkg_install_options: --debug
+            options: {
+              config: 'Debug,Release',
               doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: OFF, tests: ON, tools: ON, tools_cts: ON,
               package: YES
             }
@@ -137,7 +147,7 @@ jobs:
       OPENGL_ES_EMULATOR_WIN: C:\Imagination\Windows_x86_64
       PVR_SDK_HOME: https://github.com/powervr-graphics/Native_SDK/raw/master/lib/Windows_x86_64/
       PYTHON_DIST_DIR: interface/python_binding/dist
-      VULKAN_SDK_VER: 1.3.290.0
+      VULKAN_SDK_VER: 1.4.313.2
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,8 @@ jobs:
             options: {
               config: 'Debug,Release',
               # Can't run arm64 tests on x86 runner. Can't cross-compile Vulkan apps.
-              doc: ON, jni: OFF, loadtests: OpenGL, py: OFF, tests: OFF, tools: ON, tools_cts: OFF,
+              # Vulkan is added to test the build script correctly forces OpenGL only.
+              doc: ON, jni: OFF, loadtests: OpenGL+Vulkan, py: OFF, tests: OFF, tools: ON, tools_cts: OFF,
               package: NO
             }
           - os: windows-11-arm

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,6 +48,7 @@ jobs:
         generator: [ 'Visual Studio 17 2022' ]
         toolset: [v143, CLangCL]
         arch: [ x64 ]
+        java_version: [ '17' ]
         check_mkvk: [ NO ]
         options: [
           {config: 'Debug,Release',
@@ -85,7 +86,7 @@ jobs:
             #vcpkg_install_options: --debug
             options: {
               config: 'Debug,Release',
-              # Can't run arm64 tests on x86 runner.
+              # Can't run arm64 tests on x86 runner. Can't cross-compile Vulkan apps.
               doc: ON, jni: OFF, loadtests: OpenGL, py: OFF, tests: OFF, tools: ON, tools_cts: OFF,
               package: NO
             }
@@ -93,17 +94,19 @@ jobs:
             generator: 'Visual Studio 17 2022'
             toolset: CLangCL
             arch: arm64
+            # Oldest version available on arm runner.
+            java_version: '21'
             #vcpkg_install_options: --debug
             options: {
               config: 'Debug,Release',
-              doc: ON, jni: OFF, loadtests: OpenGL+Vulkan, py: OFF, tests: ON, tools: ON, tools_cts: ON,
+              doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: ON, tools: ON, tools_cts: ON,
               package: YES
             }
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images
-      # for loadtests and legacy tool tests. They will be pulled later as
-      # necessary
+      # for texturetests etc., loadtests and legacy tool tests. They will be
+      # pulled later as necessary
       GIT_LFS_SKIP_SMUDGE: 1
 
       BUILD_DIR: "build"
@@ -245,12 +248,12 @@ jobs:
       # This script only installs what's needed by ON FEATUREs.
       run: scripts/install_win.ps1
 
-    - name: Set up JDK 17.
+    - name: Set up JDK.
       if: matrix.options.jni == 'ON' && matrix.check_mkvk != 'ONLY'
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: ${{ matrix.java_version }}
 
     # Pre-installed Python in Windows Server 2022 is 3.9. However
     # CMake finds the latest on the runner (3.13.5 now). Should a
@@ -285,6 +288,10 @@ jobs:
       if: matrix.options.tools_cts =='ON'
       run:
         git submodule update --init --recursive tests/cts
+
+    - name: Pull LFS files
+      if: matrix.options.tests == 'ON'
+      run: git lfs pull --include=tests/srcimages,tests/testimages
 
     - name: Smudge embedded dates
       if: matrix.options.doc == 'ON'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,9 +101,9 @@ jobs:
             }
     runs-on: ${{ matrix.os }}
     env:
-      # Skip downloading necessities for the load tests and source and golden
-      # images for the other tests. Pull them when only when FEATURE_TESTS is on.
-      # build host.
+      # To avoid bandwidth charges skip downloading source and golden images
+      # for loadtests and legacy tool tests. They will be pulled later as
+      # necessary
       GIT_LFS_SKIP_SMUDGE: 1
 
       BUILD_DIR: "build"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,7 @@ jobs:
         generator: [ 'Visual Studio 17 2022' ]
         toolset: [v143, CLangCL]
         arch: [ x64 ]
-        java_version: [ '17' ]
+        java-version: [ '17' ]
         check_mkvk: [ NO ]
         options: [
           {config: 'Debug,Release',
@@ -73,6 +73,7 @@ jobs:
             generator: 'Visual Studio 16 2019'
             toolset: v142
             arch: x64
+            java-version: '17'
             options: {
               config: 'Debug,Release',
               doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: ON, tools: ON, tools_cts: ON,
@@ -95,7 +96,7 @@ jobs:
             toolset: CLangCL
             arch: arm64
             # Oldest version available on arm runner.
-            java_version: '21'
+            java-version: '21'
             #vcpkg_install_options: --debug
             options: {
               config: 'Debug,Release',
@@ -253,7 +254,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.java_version }}
+        java-version: ${{ matrix.java-version }}
 
     # Pre-installed Python in Windows Server 2022 is 3.9. However
     # CMake finds the latest on the runner (3.13.5 now). Should a

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -53,7 +53,7 @@ if ($ARCH -eq $defaultArch) {
 if ($FEATURE_LOADTESTS -match "Vulkan" -and $ARCH -ne  $defaultArch) {
   echo "The Vulkan SDK does not support cross-compilation of Vulkan apps."
   echo "Removing `"Vulkan`" from FEATURE_LOADTESTS."
-  $FEATURE_LOADTESTS -replace "\+?Vulkan"
+  $FEATURE_LOADTESTS = $FEATURE_LOADTESTS -replace "\+?Vulkan"
   if (-not $FEATURE_LOADTESTS) {
     $FEATURE_LOADTESTS = "OFF"
   }

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -25,7 +25,7 @@ function Set-ConfigVariable {
 }
 
 # Build for the local machine by default.
-# NOTE: See comment in ./install_win.ps1.
+# NOTE: See comment around line 64 in ./install_win.ps1.
 $systype = (Get-ComputerInfo).CsSystemType -match "(?<arch>.*)-based PC"
 $defaultArch = $matches['arch'].toLower()
 
@@ -34,7 +34,7 @@ $defaultArch = $matches['arch'].toLower()
 # environment. Some cases have been observed where setting env. var's
 # here sets them for the parent as well.
 $ARCH = Set-ConfigVariable ARCH $defaultArch
-if ($$ARCH -ne "x64" -and $ARCH -ne "arm64") {
+if ($ARCH -ne "x64" -and $ARCH -ne "arm64") {
   echo "KTX build for Windows does not support $ARCH architecture."
   echo "Only amd64 and arm64 are supported."
   exit 1

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -56,6 +56,7 @@ if ($FEATURE_LOADTESTS -match "Vulkan" -and $ARCH -ne  $defaultArch) {
   $FEATURE_LOADTESTS -replace "\+?Vulkan"
   if (-not $FEATURE_LOADTESTS) {
     $FEATURE_LOADTESTS = "OFF"
+  }
 }
 $FEATURE_PY = Set-ConfigVariable FEATURE_PY "OFF"
 $FEATURE_TESTS = Set-ConfigVariable FEATURE_TESTS "ON"

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -26,7 +26,7 @@ function Set-ConfigVariable {
 
 # Build for the local machine by default.
 # NOTE: See comment around line 64 in ./install_win.ps1.
-$systype = (Get-ComputerInfo).CsSystemType -match "(?<arch>.*)-based PC"
+$found = (Get-ComputerInfo).CsSystemType -match "(?<arch>.*)-based PC"
 $defaultArch = $matches['arch'].toLower()
 
 # These defaults are here to permit easy running of the script locally

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -22,7 +22,7 @@ else
   # No Vulkan SDK yet for Linux/arm64.
   FEATURE_LOADTESTS=${FEATURE_LOADTESTS:-OpenGL}
 fi
-VULKAN_SDK_VER=${VULKAN_SDK_VER:-1.3.290}
+VULKAN_SDK_VER=${VULKAN_SDK_VER:-1.4.313}
 
 sudo apt-get -qq update
 

--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -35,7 +35,7 @@ if [[ -n "$FEATURE_LOADTESTS" && "$FEATURE_LOADTESTS" != "OFF" ]]; then
     VULKAN_SDK_NAME=vulkansdk-macos-$VULKAN_SDK_VER
     curl -s -S -o $VULKAN_SDK_NAME.zip https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/mac/$VULKAN_SDK_NAME.zip?Human=true
     unzip  $VULKAN_SDK_NAME
-    sudo open $VULKAN_SDK_NAME.app --root "$VULKAN_INSTALL_DIR" --accept-licenses --default-answer --confirm-command install $IOS_COMPONENT
+    sudo open $VULKAN_SDK_NAME.app --args --root "$VULKAN_INSTALL_DIR" --accept-licenses --default-answer --confirm-command install $IOS_COMPONENT
     rm $VULKAN_SDK_NAME.zip
     unset VULKAN_SDK_NAME IOS_COMPONENT
     popd

--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -14,7 +14,7 @@ done
 
 FEATURE_LOADTESTS=${FEATURE_LOADTESTS:-OpenGL+Vulkan}
 PLATFORM=${PLATFORM:-macOS}
-VULKAN_SDK_VER=${VULKAN_SDK_VER:-1.3.243.0}
+VULKAN_SDK_VER=${VULKAN_SDK_VER:-1.4.313.1}
 
 git lfs install
 git lfs version
@@ -33,16 +33,10 @@ if [[ -n "$FEATURE_LOADTESTS" && "$FEATURE_LOADTESTS" != "OFF" ]]; then
     # Current dir. is .../build/{KhronosGroup,msc-}/KTX-Software. cd to 'build'.
     pushd ../..
     VULKAN_SDK_NAME=vulkansdk-macos-$VULKAN_SDK_VER
-    curl -s -S -o $VULKAN_SDK_NAME.dmg https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/mac/$VULKAN_SDK_NAME.dmg?Human=true
-    hdiutil attach $VULKAN_SDK_NAME.dmg
-    sudo /Volumes/$VULKAN_SDK_NAME/InstallVulkan.app/Contents/MacOS/InstallVulkan --root "$VULKAN_INSTALL_DIR" --accept-licenses --default-answer --confirm-command install $IOS_COMPONENT
-    #hdiutil detach /Volumes/VulkanSDK
-    set +e
-    while hdiutil detach /Volumes/$VULKAN_SDK_NAME; es=$?; [[ $ss -eq 16 ]]; do
-        lsof /Volumes/$VULKAN_SDK_NAME
-        sleep 10
-    done
-    rm $VULKAN_SDK_NAME.dmg
+    curl -s -S -o $VULKAN_SDK_NAME.zip https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/mac/$VULKAN_SDK_NAME.zip?Human=true
+    unzip  $VULKAN_SDK_NAME
+    sudo open $VULKAN_SDK_NAME.app --root "$VULKAN_INSTALL_DIR" --accept-licenses --default-answer --confirm-command install $IOS_COMPONENT
+    rm $VULKAN_SDK_NAME.zip
     unset VULKAN_SDK_NAME IOS_COMPONENT
     popd
   fi

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -67,7 +67,8 @@ if ($FEATURE_LOADTESTS -and $FEATURE_LOADTESTS -ne "OFF") {
     # $env:PROCESSOR_IDENTIFIER reports the correct information but in a
     # form, "ARMv8 (64-bit) ...", difficult to process into the arch. name
     # used in the SDK installers. Hence this though it takes time...
-    $ARCH = (Get-ComputerInfo).CsSystemType -match "(?<arch>.*)-based PC"
+    $found = (Get-ComputerInfo).CsSystemType -match "(?<arch>.*)-based PC"
+    $ARCH = $matches['arch']
     if ($ARCH -ne "ARM64" -and $ARCH -ne "X64") {
       echo "No VulkanSDK available for $ARCH."
       exit 1

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -73,9 +73,16 @@ if ($FEATURE_LOADTESTS -and $FEATURE_LOADTESTS -ne "OFF") {
       echo "No VulkanSDK available for $ARCH."
       exit 1
     }
+    # Grumble, grumble, grumble ...
+    if ($ARCH -eq "X64") {
+      $VSDK_PARENT = "windows"
+    } else {
+      $VSDK_PARENT = "warm"
+    }
     echo "Install VulkanSDK for $ARCH."
     pushd $env:TEMP
-    curl.exe -s -S -o VulkanSDK-Installer.exe "https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/windows/vulkansdk-windows-$ARCH-$VULKAN_SDK_VER.exe?Human=true"
+    echo "curl.exe -s -S -o VulkanSDK-Installer.exe `"https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/$VSDK_PARENT/vulkansdk-windows-$ARCH-$VULKAN_SDK_VER.exe?Human=true`""
+    curl.exe -s -S -o VulkanSDK-Installer.exe "https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/$VSDK_PARENT/vulkansdk-windows-$ARCH-$VULKAN_SDK_VER.exe?Human=true"
     Start-Process .\VulkanSDK-Installer.exe -ArgumentList "--accept-licenses --default-answer --confirm-command install" -NoNewWindow -Wait
     echo "Return to cloned repo."
     popd

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -68,7 +68,7 @@ if ($FEATURE_LOADTESTS -and $FEATURE_LOADTESTS -ne "OFF") {
     # form, "ARMv8 (64-bit) ...", difficult to process into the arch. name
     # used in the SDK installers. Hence this though it takes time...
     $ARCH = (Get-ComputerInfo).CsSystemType -match "(?<arch>.*)-based PC"
-    if ($ARCH -ne ARM64 -and $ARCH -ne "X64") {
+    if ($ARCH -ne "ARM64" -and $ARCH -ne "X64") {
       echo "No VulkanSDK available for $ARCH."
       exit 1
     }

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -68,7 +68,7 @@ if ($FEATURE_LOADTESTS -and $FEATURE_LOADTESTS -ne "OFF") {
     # form, "ARMv8 (64-bit) ...", difficult to process into the arch. name
     # used in the SDK installers. Hence this though it takes time...
     $found = (Get-ComputerInfo).CsSystemType -match "(?<arch>.*)-based PC"
-    $ARCH = $matches['arch']
+    $ARCH = $matches['arch'].toUpper()
     if ($ARCH -ne "ARM64" -and $ARCH -ne "X64") {
       echo "No VulkanSDK available for $ARCH."
       exit 1

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -81,7 +81,6 @@ if ($FEATURE_LOADTESTS -and $FEATURE_LOADTESTS -ne "OFF") {
     }
     echo "Install VulkanSDK for $ARCH."
     pushd $env:TEMP
-    echo "curl.exe -s -S -o VulkanSDK-Installer.exe `"https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/$VSDK_PARENT/vulkansdk-windows-$ARCH-$VULKAN_SDK_VER.exe?Human=true`""
     curl.exe -s -S -o VulkanSDK-Installer.exe "https://sdk.lunarg.com/sdk/download/$VULKAN_SDK_VER/$VSDK_PARENT/vulkansdk-windows-$ARCH-$VULKAN_SDK_VER.exe?Human=true"
     Start-Process .\VulkanSDK-Installer.exe -ArgumentList "--accept-licenses --default-answer --confirm-command install" -NoNewWindow -Wait
     echo "Return to cloned repo."

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/vulkantextoverlay.hpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/vulkantextoverlay.hpp
@@ -503,7 +503,9 @@ public:
             vkTools::initializers::pipelineInputAssemblyStateCreateInfo(
                 VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
                 0,
-                VK_FALSE);
+                // primmitiveRestartEnable not needed but disabling it results in a MoltenVK
+                // feature not present warning.
+                VK_TRUE);
 
         VkPipelineRasterizationStateCreateInfo rasterizationState =
             vkTools::initializers::pipelineRasterizationStateCreateInfo(

--- a/tests/loadtests/vkloadtests/Texture.cpp
+++ b/tests/loadtests/vkloadtests/Texture.cpp
@@ -587,7 +587,10 @@ Texture::preparePipelines()
 {
     vk::PipelineInputAssemblyStateCreateInfo inputAssemblyState(
             {},
-            vk::PrimitiveTopology::eTriangleStrip);
+            vk::PrimitiveTopology::eTriangleStrip,
+            // primmitiveRestartEnable not needed but disabling it results in a MoltenVK
+            // feature not present warning.
+            true);
 
     vk::PipelineRasterizationStateCreateInfo rasterizationState;
     // Must be false because we haven't enabled the depthClamp device feature.


### PR DESCRIPTION
* Update SDK version number in workflow.
* Change install_macos.sh to handle zip instead of dmg.
* Update loadtests to stop MoltenVK warning.
* Move ARM64 package build to windows-11-arm runner and run tests there while keeping a simpler cross-compile build as a check.
* Set GIT_LFS_SKIP_SMUDGE everywhere to save more bandwidth.
* Put `git lfs pull` commands in workflow files for clarity.
* Remove .netrc setup with GITHUB_TOKEN. Not needed on Actions runners.