### PR TITLE
fix: Enabled Android x86 build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ include(GNUInstallDirs) # Must be after project.
 include(CTest)          #           "
 
 set_target_processor_type(CPU_ARCHITECTURE) # Must be after project.
-if (CPU_ARCHITECTURE STREQUAL x86)
+if (CPU_ARCHITECTURE STREQUAL x86 AND NOT ANDROID)
     message(FATAL_ERROR "This project cannot be built for x86 cpu.")
 endif()
 CMAKE_DEPENDENT_OPTION( BASISU_SUPPORT_SSE


### PR DESCRIPTION
After upgrading to 4.4.0 building Android x86 failed.

As far as I can x86 was removed in a545f005ff987aa5a4a3c7f938490954ca85c095 so that the load tests build succeeds (presumably some platform like Windows x86 failed). However, libktx itself still builds nicely on Android x86 (and maybe even more x86 platforms).

This PR is not driven by known user demand (heck, I don't know if anyone has use for this), but to maintain compatibility in my downstream product. Removing support for a platform is a breaking change and requires a major version bump, strictly speaking. That's something I want to avoid.

Let me know what you think. Thanks for considering.