### PR TITLE
Fix vcpkg caching for PR builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,6 +42,8 @@ jobs:
   #formatting:
   #  uses: ./.github/workflows/formatting.yml
   linux:
+    permissions:
+      packages: write
     # Shortcircuit and don't burn CI time when formatting will reject
     #needs: formatting
     strategy:
@@ -75,6 +77,7 @@ jobs:
           arch: x86_64
           compiler: gcc
           vk_sdk_ver: '1.4.313'
+          #vcpkg_install_options: --debug
           options: {
             config: Release,
             doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tools: ON, tools_cts: ON,
@@ -260,8 +263,6 @@ jobs:
         if: matrix.options.loadtests != 'OFF'
         env:
           USERNAME: KhronosGroup
-          API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         # `vcpkg fetch nuget` fetches nuget and outputs the location of
         # the fetched command. It is a .exe that runs in the mono VM.
@@ -272,9 +273,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${{ env.USERNAME }}" \
-            -Password "${API_KEY:-$GITHUB_TOKEN}"
+            -Password "${{ secrets.GITHUB_TOKEN }}"
           mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${API_KEY:-$GITHUB_TOKEN}" \
+            setapikey "${{ secrets.GITHUB_TOKEN }}" \
             -Source "${{ env.NUGET_FEED_URL }}"
 
       - name: script

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -260,6 +260,7 @@ jobs:
         if: matrix.options.loadtests != 'OFF'
         env:
           USERNAME: KhronosGroup
+          API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
         shell: bash
         # `vcpkg fetch nuget` fetches nuget and outputs the location of
         # the fetched command. It is a .exe that runs in the mono VM.
@@ -270,9 +271,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${{ env.USERNAME }}" \
-            -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
+            -Password "${API_KEY:-$GITHUB_TOKEN}"
           mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" \
+            setapikey "${API_KEY:-$GITHUB_TOKEN}" \
             -Source "${{ env.NUGET_FEED_URL }}"
 
       - name: script

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -261,6 +261,7 @@ jobs:
         env:
           USERNAME: KhronosGroup
           API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         # `vcpkg fetch nuget` fetches nuget and outputs the location of
         # the fetched command. It is a .exe that runs in the mono VM.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -237,6 +237,7 @@ jobs:
         env:
           USERNAME: KhronosGroup
           API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         # `vcpkg fetch nuget` fetches nuget and outputs the location of
         # the fetched command. It is a .exe that runs in the mono VM.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -236,6 +236,7 @@ jobs:
         if: matrix.options.loadtests != 'OFF'
         env:
           USERNAME: KhronosGroup
+          API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
         shell: bash
         # `vcpkg fetch nuget` fetches nuget and outputs the location of
         # the fetched command. It is a .exe that runs in the mono VM.
@@ -246,9 +247,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${{ env.USERNAME }}" \
-            -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
+            -Password "${API_KEY:-$GITHUB_TOKEN}"
           mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" \
+            setapikey "${API_KEY:-$GITHUB_TOKEN}" \
             -Source "${{ env.NUGET_FEED_URL }}"
 
       - name: before_script

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,6 +42,8 @@ jobs:
   #formatting:
   #  uses: ./.github/workflows/formatting.yml
   macos:
+    permissions:
+      packages: write
     # Shortcircuit and don't burn CI time when formatting will reject
     #needs: formatting
     strategy:
@@ -236,8 +238,6 @@ jobs:
         if: matrix.options.loadtests != 'OFF'
         env:
           USERNAME: KhronosGroup
-          API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         # `vcpkg fetch nuget` fetches nuget and outputs the location of
         # the fetched command. It is a .exe that runs in the mono VM.
@@ -248,9 +248,9 @@ jobs:
             -StorePasswordInClearText \
             -Name GitHubPackages \
             -UserName "${{ env.USERNAME }}" \
-            -Password "${API_KEY:-$GITHUB_TOKEN}"
+            -Password "${{ secrets.GITHUB_TOKEN }}"
           mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${API_KEY:-$GITHUB_TOKEN}" \
+            setapikey "${{ secrets.GITHUB_TOKEN }}" \
             -Source "${{ env.NUGET_FEED_URL }}"
 
       - name: before_script

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -225,7 +225,9 @@ jobs:
       # the fetched command.
       run: |
         # ??= is PowerShell 7+ only.
+        $PSVersionTable
         $env:API_KEY ??= $env:GITHUB_TOKEN
+        echo $env:API_KEY
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
           sources add `
           -Source "${{ env.NUGET_FEED_URL }}" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,6 +40,8 @@ jobs:
   #formatting:
   #  uses: ./.github/workflows/formatting.yml
   windows:
+    permissions:
+      packages: write
     # Shortcircuit and don't burn CI time when formatting will reject
     #needs: formatting
     strategy:
@@ -219,29 +221,19 @@ jobs:
       if: matrix.options.loadtests != 'OFF'
       env:
         USERNAME: KhronosGroup
-        API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
       shell: pwsh
       # `vcpkg fetch nuget` fetches nuget and outputs the location of
       # the fetched command.
       run: |
-        # ??= is PowerShell 7+ only.
-        $PSVersionTable
-        $env:API_KEY ??= "${{ secrets.GITHUB_TOKEN }}"
-        echo "API_KEY = $env:API_KEY"
-        if ($env:API_KEY -eq "${{ secrets.GH_PACKAGES_TOKEN }}") {
-            echo "API_KEY matches secret"
-        } else {
-            echo "API_KEY does not match secret"
-        }
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
           sources add `
           -Source "${{ env.NUGET_FEED_URL }}" `
           -StorePasswordInClearText `
           -Name GitHubPackages `
           -UserName "${{ env.USERNAME }}" `
-          -Password "$env:API_KEY"
+          -Password "${{ secrets.GITHUB_TOKEN }}"
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
-          setapikey "$env:API_KEY" `
+          setapikey "${{ secrets.GITHUB_TOKEN }}" `
           -Source "${{ env.NUGET_FEED_URL }}"
 
     - name: Install Dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -220,6 +220,7 @@ jobs:
       env:
         USERNAME: KhronosGroup
         API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
       # `vcpkg fetch nuget` fetches nuget and outputs the location of
       # the fetched command.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -219,19 +219,22 @@ jobs:
       if: matrix.options.loadtests != 'OFF'
       env:
         USERNAME: KhronosGroup
+        API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
       shell: pwsh
       # `vcpkg fetch nuget` fetches nuget and outputs the location of
       # the fetched command.
       run: |
+        # ??= is PowerShell 7+ only.
+        $env:API_KEY ??= $env:GITHUB_TOKEN
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
           sources add `
           -Source "${{ env.NUGET_FEED_URL }}" `
           -StorePasswordInClearText `
           -Name GitHubPackages `
           -UserName "${{ env.USERNAME }}" `
-          -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
+          -Password "$env.API_KEY"
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
-          setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" `
+          setapikey "$env:API_KEY"
           -Source "${{ env.NUGET_FEED_URL }}"
 
     - name: Install Dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -227,7 +227,12 @@ jobs:
         # ??= is PowerShell 7+ only.
         $PSVersionTable
         $env:API_KEY ??= $env:GITHUB_TOKEN
-        echo $env:API_KEY
+        echo "API_KEY = $env:API_KEY"
+        if ($env:API_KEY -eq ${{ secrets.GH_PACKAGES_TOKEN }}) {
+            echo "API_KEY matches secret"
+        } else {
+            echo "API_KEY does not match secret"
+        }
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
           sources add `
           -Source "${{ env.NUGET_FEED_URL }}" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -239,9 +239,9 @@ jobs:
           -StorePasswordInClearText `
           -Name GitHubPackages `
           -UserName "${{ env.USERNAME }}" `
-          -Password "$env.API_KEY"
+          -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
-          setapikey "$env:API_KEY" `
+          setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" `
           -Source "${{ env.NUGET_FEED_URL }}"
 
     - name: Install Dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -239,9 +239,9 @@ jobs:
           -StorePasswordInClearText `
           -Name GitHubPackages `
           -UserName "${{ env.USERNAME }}" `
-          -Password "${{ secrets.GH_PACKAGES_TOKEN }}"
+          -Password "$env:API_KEY"
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
-          setapikey "${{ secrets.GH_PACKAGES_TOKEN }}" `
+          setapikey "$env:API_KEY" `
           -Source "${{ env.NUGET_FEED_URL }}"
 
     - name: Install Dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -220,14 +220,13 @@ jobs:
       env:
         USERNAME: KhronosGroup
         API_KEY: ${{ secrets.GH_PACKAGES_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
       # `vcpkg fetch nuget` fetches nuget and outputs the location of
       # the fetched command.
       run: |
         # ??= is PowerShell 7+ only.
         $PSVersionTable
-        $env:API_KEY ??= $env:GITHUB_TOKEN
+        $env:API_KEY ??= "${{ secrets.GITHUB_TOKEN }}"
         echo "API_KEY = $env:API_KEY"
         if ($env:API_KEY -eq "${{ secrets.GH_PACKAGES_TOKEN }}") {
             echo "API_KEY matches secret"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -234,7 +234,7 @@ jobs:
           -UserName "${{ env.USERNAME }}" `
           -Password "$env.API_KEY"
         .$(${{ env.VCPKG_EXE }} fetch nuget) `
-          setapikey "$env:API_KEY"
+          setapikey "$env:API_KEY" `
           -Source "${{ env.NUGET_FEED_URL }}"
 
     - name: Install Dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -228,7 +228,7 @@ jobs:
         $PSVersionTable
         $env:API_KEY ??= $env:GITHUB_TOKEN
         echo "API_KEY = $env:API_KEY"
-        if ($env:API_KEY -eq ${{ secrets.GH_PACKAGES_TOKEN }}) {
+        if ($env:API_KEY -eq "${{ secrets.GH_PACKAGES_TOKEN }}") {
             echo "API_KEY matches secret"
         } else {
             echo "API_KEY does not match secret"


### PR DESCRIPTION
Use GITHUB_TOKEN so no need for a repo secret. Add `packages: write` permission for GITHUB_TOKEN so can write to the cache. Despite the request, permission will not be elevated for forks (PRs).