### PR TITLE
Use relative rpaths to find installed library on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,13 +493,27 @@ if(APPLE OR LINUX OR WIN32)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${KTX_BUILD_DIR}/$<CONFIG>>)
     if(APPLE OR LINUX)
         # Use a common RUNTIME_OUTPUT_DIR and LIBRARY_OUTPUT_DIR for all
-        # targets so that INSTALL RPATH is functional in build directory
-        # as well. BUILD_WITH_INSTALL_RPATH is necessary for working code
-        # signing. Signing happens at build time so the binary must not
-        # be altered during install. Although Linux code is not yet being
-        # signed, make it symmetrical with macOS.
+        # targets so that the INSTALL RPATH we need for installed binaries
+        # is functional in the build directory as well. INSTALL_RPATH cannot
+        # be altered during install because that would break code signing
+        # which happens after building. Therefore BUILD_WITH_INSTALL_RPATH
+        # is necessary for working code signing. Although Linux code is not
+        # yet being signed, make it symmetrical with macOS.
         set(CMAKE_LIBRARY_OUTPUT_DIRECTORY $<1:${KTX_BUILD_DIR}/$<CONFIG>>)
         set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+
+        # Notes about install names, rpaths and code signing
+        # --------------------------------------------------
+        # Changing the install name of a library by setting INSTALL_NAME_DIR
+        # on a library target will invalidate the signature as it causes
+        # cmake to run `install_name_tool` after building and signing. The
+        # default install name is the library target's name prefixed by
+        # `@rpath/`. With this, `dyld` will load the library provided it is
+        # in one of the directories specified by a program's INSTALL_RPATH
+        # or is in the directory part of a full-path name passed to `dlopen`.
+        #
+        # A bad signature in either executable or shared library is
+        # indicated by the executable exiting with "Killed: 9".
     endif()
 endif()
 

--- a/interface/java_binding/CMakeLists.txt
+++ b/interface/java_binding/CMakeLists.txt
@@ -43,12 +43,6 @@ set_target_properties(ktx-jni PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${KTX_BUILD_DIR}/$<CONFIG>
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    # N.B. On macOS setting INSTALL_NAME_DIR here will invalidate the
-    # signature as it causes `install_name_tool` to be run after signing.
-    # With a bad signature a program dlopening the library is "Killed: 9".
-    # Even with the default `@rpath` prefix on the library's install name
-    # it can still be loaded by giving the full path to dlopen. So there
-    # is no need to try to remove `@rpath`.
     XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME "YES"
 )
 # The location of libktx_jni must be set explicitly in java.library.path.
@@ -57,7 +51,7 @@ set_target_properties(ktx-jni PROPERTIES
 if(APPLE)
     set_target_properties(ktx-jni PROPERTIES
         # @executable_path does not work as the executable here is the JVM.
-        INSTALL_RPATH "@loader_path;/usr/local/lib"
+        INSTALL_RPATH "@loader_path;${CMAKE_INSTALL_LIBDIR}"
     )
 elseif(LINUX)
     set_target_properties(ktx-jni PROPERTIES
@@ -65,7 +59,7 @@ elseif(LINUX)
         # searches first in the directory of the .so then in the directory
         # of the application that is loading the first .so. See
         # https://stackoverflow.com/questions/23006930/the-shared-library-rpath-and-the-binary-rpath-priority/52647116#52647116
-        INSTALL_RPATH "$ORIGIN;/usr/local/lib"
+        INSTALL_RPATH "$ORIGIN;${CMAKE_INSTALL_LIBDIR}"
     )
 endif()
 set_code_sign(ktx-jni)

--- a/interface/java_binding/CMakeLists.txt
+++ b/interface/java_binding/CMakeLists.txt
@@ -43,6 +43,12 @@ set_target_properties(ktx-jni PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${KTX_BUILD_DIR}/$<CONFIG>
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
+    # N.B. On macOS setting INSTALL_NAME_DIR here will invalidate the
+    # signature as it causes `install_name_tool` to be run after signing.
+    # With a bad signature a program dlopening the library is "Killed: 9".
+    # Even with the default `@rpath` prefix on the library's install name
+    # it can still be loaded by giving the full path to dlopen. So there
+    # is no need to try to remove `@rpath`.
     XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME "YES"
 )
 # The location of libktx_jni must be set explicitly in java.library.path.

--- a/interface/java_binding/CMakeLists.txt
+++ b/interface/java_binding/CMakeLists.txt
@@ -51,7 +51,7 @@ set_target_properties(ktx-jni PROPERTIES
 if(APPLE)
     set_target_properties(ktx-jni PROPERTIES
         # @executable_path does not work as the executable here is the JVM.
-        INSTALL_RPATH "@loader_path;${CMAKE_INSTALL_LIBDIR}"
+        INSTALL_RPATH "@loader_path;/usr/local/${CMAKE_INSTALL_LIBDIR}"
     )
 elseif(LINUX)
     set_target_properties(ktx-jni PROPERTIES
@@ -59,7 +59,7 @@ elseif(LINUX)
         # searches first in the directory of the .so then in the directory
         # of the application that is loading the first .so. See
         # https://stackoverflow.com/questions/23006930/the-shared-library-rpath-and-the-binary-rpath-priority/52647116#52647116
-        INSTALL_RPATH "$ORIGIN;${CMAKE_INSTALL_LIBDIR}"
+        INSTALL_RPATH "$ORIGIN;/usr/local/${CMAKE_INSTALL_LIBDIR}"
     )
 endif()
 set_code_sign(ktx-jni)

--- a/interface/java_binding/CMakeLists.txt
+++ b/interface/java_binding/CMakeLists.txt
@@ -44,13 +44,24 @@ set_target_properties(ktx-jni PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
     XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME "YES"
-    # The location of libktx_jni must be set explicitly in java.library.path.
-    # This sets places to search for libktx. The second is needed to
-    # successfully run the tests during build. Setting "./" here, to say look
-    # in the same directory, does not work. @executable_path does not
-    # work as the executable here is the JVM.
-    INSTALL_RPATH "/usr/local/lib;${KTX_BUILD_DIR}/$<CONFIG>"
 )
+# The location of libktx_jni must be set explicitly in java.library.path.
+# This sets places to search for libktx when loading libktx_jni. Setting
+# "./" here, to say look in the same directory, does not work.
+if(APPLE)
+    set_target_properties(ktx-jni PROPERTIES
+        # @executable_path does not work as the executable here is the JVM.
+        INSTALL_RPATH "@loader_path;/usr/local/lib"
+    )
+elseif(LINUX)
+    set_target_properties(ktx-jni PROPERTIES
+        # Reportedly ld.so when loading a .so with a DT_RUNPATH of $ORIGIN
+        # searches first in the directory of the .so then in the directory
+        # of the application that is loading the first .so. See
+        # https://stackoverflow.com/questions/23006930/the-shared-library-rpath-and-the-binary-rpath-priority/52647116#52647116
+        INSTALL_RPATH "$ORIGIN;/usr/local/lib"
+    )
+endif()
 set_code_sign(ktx-jni)
 
 if(APPLE AND KTX_EMBED_BITCODE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,11 +5,11 @@ function(set_test_properties test_target)
     # See comments in set_tools_properties() in ../tools/CMakeLists.txt.
     if(APPLE)
         set_target_properties(${test_target} PROPERTIES
-            INSTALL_RPATH "@executable_path;/usr/local/lib"
+            INSTALL_RPATH "@executable_path;@executable_path/../${CMAKE_INSTALL_LIBDIR}"
         )
     elseif(LINUX)
         set_target_properties(${test_target} PROPERTIES
-            INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../lib"
+            INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
         )
     endif()
 endfunction()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -26,9 +26,7 @@ function(set_tool_properties tool_target)
             #
             # Check the LC_RPATH entries with
             # - otool -l <file> | grep -A 3 LC_RPATH
-            #
-            # TODO: Consider adding @executable_path/../lib.
-            INSTALL_RPATH "@executable_path;/usr/local/lib"
+            INSTALL_RPATH "@executable_path;/usr/local/${CMAKE_INSTALL_LIBDIR}"
             CXX_VISIBILITY_PRESET ${STATIC_APP_LIB_SYMBOL_VISIBILITY}
         )
     elseif(LINUX)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -26,7 +26,7 @@ function(set_tool_properties tool_target)
             #
             # Check the LC_RPATH entries with
             # - otool -l <file> | grep -A 3 LC_RPATH
-            INSTALL_RPATH "@executable_path;/usr/local/${CMAKE_INSTALL_LIBDIR}"
+            INSTALL_RPATH "@executable_path;@executable_path/../${CMAKE_INSTALL_LIBDIR}"
             CXX_VISIBILITY_PRESET ${STATIC_APP_LIB_SYMBOL_VISIBILITY}
         )
     elseif(LINUX)


### PR DESCRIPTION
This will make it easier to install the software in an alternate location.

Consistently use `${CMAKE_INSTALL_LIBDIR}` instead of `lib` when setting rpath.

In rpath of libktx-jni for finding libktx on Linux and macOS use attribute for same directory instead of hardcoding the build directory. 

Add comment re install names. rpath and code signing.