### PR TITLE
Restore use of emsdk-latest

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -146,10 +146,7 @@ jobs:
           # Also with the Linux version of the Docker engine, all products of
           # the build in $BUILD_DIR are owned by root unless uid/gid is set.
           #
-          # In emsdk 4.0.13 all the executable files except emcc have mode 744
-          # so can only be run by root. Until emsdk is fixed, stick with 4.0.12.
-          #docker run -dit --name emscripten --user "$(id -u):$(id -g)" -v $(pwd):/src emscripten/emsdk bash
-          docker run -dit --name emscripten --user "$(id -u):$(id -g)" -v $(pwd):/src emscripten/emsdk:4.0.12 bash
+          docker run -dit --name emscripten --user "$(id -u):$(id -g)" -v $(pwd):/src emscripten/emsdk bash
 
       - name: before_script
         run: |


### PR DESCRIPTION
now that the permissions issue in 4.13 has been fixed.