### PR TITLE
Add test builds on older environments.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,7 +75,7 @@ jobs:
             # version on macOS.
             config: 'Debug,Release', platform: macOS,
             doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
-            package: YES, sse: ON, opencl: OFF
+            package: OFF, sse: ON, opencl: OFF
           }
         - name: Build for iOS
           os: macos-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -280,7 +280,7 @@ jobs:
           compression-level: 0 # Installer already compressed.
 
       - name: Upload artifact pyktx
-        if: matrix.options.package == 'YES' && matrix.options.py == 'ON'
+        if:  matrix.options.py == 'ON' && matrix.options.package == 'YES' && matrix.options.config == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: pyktx-${{env.PACKAGE_NAME_SUFFIX}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
             package: YES, sse: OFF, opencl: OFF
           }
 
-    name: ${{ matrix.name && matrix.name || format('{0} SSE,OpenCL:{1},{2}', matrix.os, matrix.options.sse, matrix.options.opencl) }}
+    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:{1},{2},{3},{4}', matrix.os, matrix.options.package, matrix.options.loadtests, matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images
@@ -250,15 +250,17 @@ jobs:
           set +e
 
       # Re. packaging, note that the build script only creates packages for
-      # the Release configuration. If a change is desired, this workflow
-      # AND the script will have to be modified.
+      # the Release configuration. If this is changed work will be needed
+      # here to prevent failures from uploading same-named artifacts from both
+      # Release and Debug configs. Only uploading artifacts from macos-latest
+      # prevents the same failure with artifacts from builds on older OSes.
 
       # Notarization can only run if secrets were set (upstream repo)
       - name: Notarize
         env:
           ALTOOL_PASSWORD: ${{ secrets.ALTOOL_PASSWORD }}
           ALTOOL_PW_LABEL: ${{ secrets.ALTOOL_PW_LABEL }}
-        if: matrix.options.platform == 'macOS' && matrix.options.package == 'YES' && matrix.options.config == 'Release' && env.APPLE_ID
+        if: matrix.options.platform == 'macOS' && matrix.options.package == 'YES' && env.APPLE_ID
         run: ./scripts/notarize.sh $BUILD_DIR/KTX-Software-*.pkg $APPLE_ID $DEVELOPMENT_TEAM $ALTOOL_PASSWORD
 
       - name: Prepare KTX artifacts
@@ -272,7 +274,7 @@ jobs:
       # "package" job for each architecture produces artifacts. A second
       # job would attempt to upload a same-named artifact.
       - name: Upload artifact Install Package
-        if: matrix.options.package == 'YES' && matrix.options.config == 'Release'
+        if: matrix.options.package == 'YES'  matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
           name: KTX-Software-${{env.PACKAGE_NAME_SUFFIX}}
@@ -280,7 +282,7 @@ jobs:
           compression-level: 0 # Installer already compressed.
 
       - name: Upload artifact pyktx
-        if:  matrix.options.py == 'ON' && matrix.options.package == 'YES' && matrix.options.config == 'Release'
+        if:  matrix.options.py == 'ON' && matrix.options.package == 'YES' && matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
           name: pyktx-${{env.PACKAGE_NAME_SUFFIX}}
@@ -288,7 +290,7 @@ jobs:
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
-        if: github.ref_type == 'tag' && github.event_name == 'push' && matrix.options.package == 'YES' && matrix.options.config == 'Release'
+        if: github.ref_type == 'tag' && github.event_name == 'push' && matrix.options.package == 'YES' && matrix.options.config == 'Release' && matrix.os == 'macos-latest'
         with:
           draft: true
           prerelease: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,10 @@ jobs:
             package: YES, sse: OFF, opencl: OFF
           }
 
-    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:\ {1},{2},{3},{4}', matrix.os, matrix.options.package, (matrix.options.loadtests && matrix.options.loadtests || 'NO'), matrix.options.sse, matrix.options.opencl) }}
+    # ': ' within the format string causes a "mapping values are not
+    # allowed in this context" YAMl syntax error. Replacement {1} is
+    # a workaround.
+    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:{1}{2},{3},{4},{5}', matrix.os, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.loadtests, matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,9 +48,9 @@ jobs:
     #needs: formatting
     strategy:
       matrix:
-        os: [ macos-14 ]
+        os: [ macos-latest, macos-14 ]
         generator: [ Xcode ]
-        arch: [ x86_64 ]
+        arch: [ arm64, x86_64 ]
         vulkan_sdk_version: ['1.4.313.1']
         options: [
           {config: 'Debug,Release', platform: macOS,
@@ -67,47 +67,20 @@ jobs:
            sse: OFF, opencl: OFF}
         ]
         include:
-        - name: Package (arm64)
-          os: macos-latest
+        - name: Test macOS 13 build
+          os: macos-13
           generator: Xcode
-          arch: arm64
+          arch: [ arm64, x86_64 ]
           vulkan_sdk_version: '1.4.313.1'
           options: {
-            config: Release, platform: macOS,
-            doc: ON, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
+            # graphviz no longer supports macOS 13 so doc: OFF.
+            # ts-graphviz/setup-graphviz@v2 does not support specifying a
+            # version on macOS.
+            config: 'Debug,Release', platform: macOS,
+            doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
             package: YES, sse: ON, opencl: OFF
           }
-        - name: OpenCL,SSE
-          os: macos-latest
-          generator: Xcode
-          arch: arm64
-          vulkan_sdk_version: '1.4.313.1'
-          options: {
-            config: Release, platform: macOS,
-            doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,
-            sse: ON, opencl: ON
-          }
-        - name: OpenCL
-          os: macos-latest
-          generator: Xcode
-          arch: arm64
-          vulkan_sdk_version: '1.4.313.1'
-          options: {
-            config: Release, platform: macOS,
-            doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,
-            sse: OFF, opencl: ON
-          }
-        - name: All OFF
-          os: macos-latest
-          generator: Xcode
-          arch: arm64
-          vulkan_sdk_version: '1.4.313.1'
-          options: {
-            config: Release, platform: macOS,
-            doc: OFF, jni: OFF, loadtests: OFF, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,
-            sse: OFF, opencl: OFF
-          }
-        - name: iOS
+        - name: Build for iOS
           os: macos-latest
           generator: Xcode
           arch: arm64
@@ -280,12 +253,16 @@ jobs:
           fi
           set +e
 
+      # Re. packaging, note that the build script only creates packages for
+      # the Release configuration. If a change is desired, this workflow
+      # AND the script will have to be modified.
+
       # Notarization can only run if secrets were set (upstream repo)
       - name: Notarize
         env:
           ALTOOL_PASSWORD: ${{ secrets.ALTOOL_PASSWORD }}
           ALTOOL_PW_LABEL: ${{ secrets.ALTOOL_PW_LABEL }}
-        if: matrix.options.platform == 'macOS' && matrix.options.package == 'YES' && env.APPLE_ID
+        if: matrix.options.platform == 'macOS' && matrix.options.package == 'YES' && matrix.options.config = 'Release' && env.APPLE_ID
         run: ./scripts/notarize.sh $BUILD_DIR/KTX-Software-*.pkg $APPLE_ID $DEVELOPMENT_TEAM $ALTOOL_PASSWORD
 
       - name: Prepare KTX artifacts
@@ -299,7 +276,7 @@ jobs:
       # "package" job for each architecture produces artifacts. A second
       # job would attempt to upload a same-named artifact.
       - name: Upload artifact Install Package
-        if: matrix.options.package == 'YES'
+        if: matrix.options.package == 'YES' && matrix.options.config ='Release'
         uses: actions/upload-artifact@v4
         with:
           name: KTX-Software-${{env.PACKAGE_NAME_SUFFIX}}
@@ -315,7 +292,7 @@ jobs:
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
-        if: matrix.options.package == 'YES' && github.event_name == 'push' && github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && github.event_name == 'push' && matrix.options.package == 'YES' && matrix.options.config ='Release'
         with:
           draft: true
           prerelease: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,7 +90,7 @@ jobs:
     # ': ' within the format string causes a "mapping values are not
     # allowed in this context" YAMl syntax error. Replacement {1} is
     # a workaround.
-    name: ${{ matrix.name && matrix.name || format('{0} ({2}) Package,SSE,OpenCL:{1}{2},{3},{4}', matrix.os, matrix.arch, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.sse, matrix.options.opencl) }}
+    name: ${{ matrix.name && matrix.name || format('{0} ({1}) Package,SSE,OpenCL:{2}{3},{4},{5}', matrix.os, matrix.arch, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,7 +81,6 @@ jobs:
           os: macos-latest
           generator: Xcode
           arch: arm64
-          vulkan_sdk_version: '1.4.313.1'
           options: {
             config: Release, platform: iOS,
             doc: OFF, jni: OFF, loadtests: OpenGL+Vulkan, py: OFF, tests: OFF, tools: OFF, tools_cts: OFF,

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
             package: YES, sse: OFF, opencl: OFF
           }
 
-    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL: {1},{2},{3},{4}', matrix.os, matrix.options.package, matrix.options.loadtests && matrix.options.loadtests || 'OFF', matrix.options.sse, matrix.options.opencl) }}
+    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:{1},{2},{3},{4}', matrix.os, matrix.options.package, matrix.options.loadtests && matrix.options.loadtests || 'OFF', matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,16 +67,16 @@ jobs:
            sse: OFF, opencl: OFF}
         ]
         include:
-        - name: Test macOS 13 build
-          os: macos-13
-          options: {
-            # graphviz no longer supports macOS 13 so doc: OFF.
-            # ts-graphviz/setup-graphviz@v2 does not support specifying a
-            # version on macOS.
-            config: 'Debug,Release', platform: macOS,
-            doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
-            package: YES, sse: ON, opencl: OFF
-          }
+#        - name: Test macOS 13 build
+#          os: macos-13
+#          options: {
+#            # graphviz no longer supports macOS 13 so doc: OFF.
+#            # ts-graphviz/setup-graphviz@v2 does not support specifying a
+#            # version on macOS.
+#            config: 'Debug,Release', platform: macOS,
+#            doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
+#            package: YES, sse: ON, opencl: OFF
+#          }
         - name: Build for iOS
           os: macos-latest
           generator: Xcode

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
             package: YES, sse: OFF, opencl: OFF
           }
 
-    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:{1},{2},{3},{4}', matrix.os, matrix.options.package, matrix.options.loadtests && matrix.options.loadtests || 'OFF', matrix.options.sse, matrix.options.opencl) }}
+    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:\ {1},{2},{3},{4}', matrix.os, matrix.options.package, (matrix.options.loadtests && matrix.options.loadtests || 'NO'), matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
             package: YES, sse: OFF, opencl: OFF
           }
 
-    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:{1},{2},{3},{4}', matrix.os, matrix.options.package, matrix.options.loadtests, matrix.options.sse, matrix.options.opencl) }}
+    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL: {1},{2},{3},{4}', matrix.os, matrix.options.package, matrix.options.loadtests && matrix.options.loadtests || 'OFF', matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,7 +90,7 @@ jobs:
     # ': ' within the format string causes a "mapping values are not
     # allowed in this context" YAMl syntax error. Replacement {1} is
     # a workaround.
-    name: ${{ matrix.name && matrix.name || format('{0} Package,SSE,OpenCL:{1}{2},{3},{4}', matrix.os, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.sse, matrix.options.opencl) }}
+    name: ${{ matrix.name && matrix.name || format('{0} ({2}) Package,SSE,OpenCL:{1}{2},{3},{4}', matrix.os, matrix.arch, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,7 +90,7 @@ jobs:
     # ': ' within the format string causes a "mapping values are not
     # allowed in this context" YAMl syntax error. Replacement {1} is
     # a workaround.
-    name: ${{ matrix.name && matrix.name || format('{0} Package,Loadtest Apps,SSE,OpenCL:{1}{2},{3},{4},{5}', matrix.os, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.loadtests, matrix.options.sse, matrix.options.opencl) }}
+    name: ${{ matrix.name && matrix.name || format('{0} Package,SSE,OpenCL:{1}{2},{3},{4}', matrix.os, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}
     env:
       # To avoid bandwidth charges skip downloading source and golden images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,7 +88,7 @@ jobs:
           }
 
     # ': ' within the format string causes a "mapping values are not
-    # allowed in this context" YAMl syntax error. Replacement {1} is
+    # allowed in this context" YAML syntax error. Replacement {1} is
     # a workaround.
     name: ${{ matrix.name && matrix.name || format('{0} ({1}) Package,SSE,OpenCL:{2}{3},{4},{5}', matrix.os, matrix.arch, ' ', matrix.options.package && matrix.options.package || 'NO', matrix.options.sse, matrix.options.opencl) }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,6 @@
 # Copyright 2025 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
-name: KTX-Software MacOS & iOS CI
+name: KTX-Software macOS & iOS CI
 
 # Seems no way to avoid duplicating this on logic in each .yml file.
 # See https://github.com/actions/starter-workflows/issues/245.

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -274,7 +274,7 @@ jobs:
       # "package" job for each architecture produces artifacts. A second
       # job would attempt to upload a same-named artifact.
       - name: Upload artifact Install Package
-        if: matrix.options.package == 'YES'  matrix.os == 'macos-latest'
+        if: matrix.options.package == 'YES'  && matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
           name: KTX-Software-${{env.PACKAGE_NAME_SUFFIX}}
@@ -290,7 +290,7 @@ jobs:
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
-        if: github.ref_type == 'tag' && github.event_name == 'push' && matrix.options.package == 'YES' && matrix.options.config == 'Release' && matrix.os == 'macos-latest'
+        if: github.ref_type == 'tag' && github.event_name == 'push' && matrix.options.package == 'YES' && matrix.os == 'macos-latest'
         with:
           draft: true
           prerelease: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -262,7 +262,7 @@ jobs:
         env:
           ALTOOL_PASSWORD: ${{ secrets.ALTOOL_PASSWORD }}
           ALTOOL_PW_LABEL: ${{ secrets.ALTOOL_PW_LABEL }}
-        if: matrix.options.platform == 'macOS' && matrix.options.package == 'YES' && matrix.options.config = 'Release' && env.APPLE_ID
+        if: matrix.options.platform == 'macOS' && matrix.options.package == 'YES' && matrix.options.config == 'Release' && env.APPLE_ID
         run: ./scripts/notarize.sh $BUILD_DIR/KTX-Software-*.pkg $APPLE_ID $DEVELOPMENT_TEAM $ALTOOL_PASSWORD
 
       - name: Prepare KTX artifacts
@@ -276,7 +276,7 @@ jobs:
       # "package" job for each architecture produces artifacts. A second
       # job would attempt to upload a same-named artifact.
       - name: Upload artifact Install Package
-        if: matrix.options.package == 'YES' && matrix.options.config ='Release'
+        if: matrix.options.package == 'YES' && matrix.options.config == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: KTX-Software-${{env.PACKAGE_NAME_SUFFIX}}
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
-        if: github.ref_type == 'tag' && github.event_name == 'push' && matrix.options.package == 'YES' && matrix.options.config ='Release'
+        if: github.ref_type == 'tag' && github.event_name == 'push' && matrix.options.package == 'YES' && matrix.options.config == 'Release'
         with:
           draft: true
           prerelease: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,16 +67,16 @@ jobs:
            sse: OFF, opencl: OFF}
         ]
         include:
-#        - name: Test macOS 13 build
-#          os: macos-13
-#          options: {
-#            # graphviz no longer supports macOS 13 so doc: OFF.
-#            # ts-graphviz/setup-graphviz@v2 does not support specifying a
-#            # version on macOS.
-#            config: 'Debug,Release', platform: macOS,
-#            doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
-#            package: YES, sse: ON, opencl: OFF
-#          }
+        - name: Test macOS 13 build
+          os: macos-13
+          options: {
+            # graphviz no longer supports macOS 13 so doc: OFF.
+            # ts-graphviz/setup-graphviz@v2 does not support specifying a
+            # version on macOS.
+            config: 'Debug,Release', platform: macOS,
+            doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: OFF, tools: ON, tools_cts: OFF,
+            package: YES, sse: ON, opencl: OFF
+          }
         - name: Build for iOS
           os: macos-latest
           generator: Xcode

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -69,9 +69,6 @@ jobs:
         include:
         - name: Test macOS 13 build
           os: macos-13
-          generator: Xcode
-          arch: [ arm64, x86_64 ]
-          vulkan_sdk_version: '1.4.313.1'
           options: {
             # graphviz no longer supports macOS 13 so doc: OFF.
             # ts-graphviz/setup-graphviz@v2 does not support specifying a

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,7 @@ jobs:
         include:
           - os: windows-2022
             generator: 'Visual Studio 17 2022'
-            toolset: v144
+            toolset: v143
             arch: x64
             java-version: '17'
             options: {

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,6 +71,17 @@ jobs:
            sse: ON, opencl: ON}
         ]
         include:
+          - os: windows-2022
+            generator: 'Visual Studio 17 2022'
+            toolset: v144
+            arch: x64
+            java-version: '17'
+            options: {
+              config: 'Debug,Release',
+              doc: OFF, jni: ON, loadtests: OpenGL+Vulkan, py: ON, tests: ON, tools: ON, tools_cts: ON,
+              package: NO,
+              sse: ON, opencl: OFF
+            }
           - os: windows-latest
             generator: 'Visual Studio 17 2022'
             toolset: CLangCL


### PR DESCRIPTION
* Test builds on macos 13 and windows-2022.

* Simplify matrix specification in macOS build.

