### PR TITLE
4.4.1 release prep

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,6 +45,9 @@ jobs:
   linux:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     env:
       GIT_LFS_SKIP_SMUDGE: 1
       WERROR: ON
@@ -129,7 +132,7 @@ jobs:
         sha1sum $zip_basename.zip > $zip_basename.zip.sha1
 
     - name: Upload To Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: github.event_name == 'push' && github.ref_type == 'tag'
       with:
         draft: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,6 +44,7 @@ jobs:
   linux:
     permissions:
       packages: write
+      contents: write
     # Shortcircuit and don't burn CI time when formatting will reject
     #needs: formatting
     strategy:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,7 @@ jobs:
   macos:
     permissions:
       packages: write
+      contents: write
     # Shortcircuit and don't burn CI time when formatting will reject
     #needs: formatting
     strategy:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -42,6 +42,8 @@ jobs:
   #formatting:
   #  uses: ./.github/workflows/formatting.yml
   web:
+    permissions:
+      contents: write
     # Shortcircuit and don't burn CI time when formatting will reject
     #needs: formatting
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,6 +42,7 @@ jobs:
   windows:
     permissions:
       packages: write
+      contents: write
     # Shortcircuit and don't burn CI time when formatting will reject
     #needs: formatting
     strategy:
@@ -375,7 +376,7 @@ jobs:
         path: ${{env.BUILD_DIR}}/${{env.PYTHON_DIST_DIR}}
 
     - name: Upload to Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: matrix.options.package == 'YES' && matrix.toolset == 'CLangCL' && github.event_name == 'push' && github.ref_type == 'tag'
       with:
         draft: true

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,102 +2,47 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 Release Notes
 =============
-## Version 4.4
+## Version 4.4.1
 ### Summary
 
-* Aligns with [KTX Specification](https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html) Revision 4 and [Khronos Data Format Specification](https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.html) version 1.4.
-* Adds new tools and features to the KTX suite. Of particular note is
-  `ktx compare`.
-* Has a largely rewritten Javascript binding which gives access to read _and_
-  write functionality of *libktx* and includes an expanded test suite.
-* Has a refactored and greatly improved Java binding thanks to @javagl.
+* `ktxTexture2_DecodeAstc` now exposed in _libktx\_read_ on all platforms and in
+  the JS bindings.
+* `ktx info` can now show info about KTX v1 files. It and the underlying _libktx_
+  function now display GL type and format token names instead of hex values.
+* Many bugs and robustness issues have been fixed. Many of these address changes
+  in CI runner images and the latest compilers.
+* ASTC encoder updated to 5.3.0.
+* LodePNG updated to 20250506.
+* Building with Visual Studio 2019 is no longer supported.
 
-With the new tools and features the KTX tool suite now provides a superset of the functionality found in the legacy tools with the exception of `ktx2ktx2`. __The legacy tools, except `ktx2ktx2`, will be removed in Release 4.5. Adjust your workflows accordingly.__
+__The legacy tools will be removed in Release 4.5. Adjust your workflows accordingly.__
 
-### New Features in 4.4
-#### Command Line Tools Suite
-
-Two tools have been added to the `ktx` suite in v4.4 and two tools have significant new functionality.
-
-| Tool | Description | Equivalent lgeacy tool |
-| :--- | ----------- | ------------------- |
-| `ktx compare` | Compare KTX2 files | - |
-| `ktx deflate` | Deflate a KTX2 file with Zlib or Zstd | `ktxsc` |
-| `ktx create`  | Added `--assign-texcoord-origin`, `--convert-texcoord-origin`, `--normalize`, `--scale` | `toktx` |
-| `ktx encode`  | Can now encode a KTX2 file to an ASTC format | `ktxsc` |
-
+### New Features in 4.4.1
 #### libktx functions
 
-* `ktxTexture2_DecodeAstc` decodes an ASTC format texture to an uncompressed format.
+* `ktxTexture2_DecodeAstc`, which decodes an ASTC format texture to an
+  uncompressed format, is now available in _libktx\_read_ on all platforms and in
+  both the _libktx_ and _libktx\_read_ JS bindings.
+* `ktxPrintKTX1InfoTextForStream`, which prints information about a KTX v1 file
+  and was previously internal, is now exposed.
 
-* `ktxLoadOpenGL` so an application can explicitly make the library load the GL function pointers, that it uses, using an application provided `GetProcAddress` function. Use of this is recommended on any platform but it is most helpful on platforms such as Fedora where generic function queries are unable to find OpenGL functions.
+### Notable Fixes in 4.4.1
 
-* `ktxTexture2_Write*` and `ktxTexture[12]_Destroy` functions are now part of the public API.
+* A bug in mipmap generation in `ktx create` that led to sRGB images being
+  resampled without first decoding to linear has been fixed. If you have affected
+  KTX files you should regenerate your textures from their source images.
+* _libktx\_read_ no longer includes the ASTC encode functions, only the decode
+  functions.
+* A bug that caused a hang in `ktx create`, when the source image is an RGB PNG
+  file with an sBIT chunk and an alpha component is being added to the texture
+  being created, has been fixed.
 
-### Notable Changes in 4.4
-
-#### Alignment with [KTX Specification](https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html) Revision 4
-
-* Transfer function handling in `ktx create` has been revamped to support the flexibility of using almost any transfer function with non-sRGB formats that was introduced in Revision 1 of the [KTX Specification](https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html).
-
-* `ktx create` now allows setting a primaries value of "none", `KTX_DF_PRIMARIES_UNSPECIFIED`, which is required for certain formats in Revision 4 of the [KTX Specification](https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html). 
-
-* *libktx* now retains the values of the `bytesPlane[0-7]` fields in the DFD when supercompressing files as required following alignment of [KTX Specification](https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html) Revision 4 with [Khronos Data Format Specification](https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.html) version 1.4.  It will load supercompressed files with either zero or non-zero `bytesPlane` values. `ktx validator` will report a warning on files with zero `bytesPlane` values.
-
-#### Command Line Tools Suite
-
-
-
-The following functionality has changed.
-
-| Tool | Changed |
-| :--- | ------- |
-| `ktx create` | `--assign-oetf` → `--assign-tf`\*, <br/> `--convert-oetf` → `--convert-tf`.\*<br/> `--compare-ssim` and `--compare-psnr` can be used when encoding to ASTC.<br/>Non-raw input images can be resized by specifying the desired size with `--width` or `--height`. |  |
-| `ktx encode` | `--compare-ssim` and `--compare-psnr` can be used when encoding to ASTC. |
-
-\* Options renamed due to revamped functionality.
-
-#### Javascript binding
-
-The Javascript binding has been almost completely rewritten to support the read *and* write functionality of *libktx*. A test suite has been added that also serves as an example of how to use the functions.
-
-* The name of the factory function for creating the ktx module has been changed from `LIBKTX` to `createKtxModule` (and `createKtxReadModule`). The old name is provided as an alias. Be aware that using the alias corresponds to `createKtxModule` so you will get the full functionality.
-* The `ktx` prefixes have been removed from the only existing class that had it, `ktxTexture`. None of the new classes have a prefix. `ktcTexture` is provided as an alias to `texture`. Recommended usage is to assign the module instance returned by the factory function to `window.ktx` or other `ktx` variable making the prefixes unnecessary.
-* Enumerator names are now the same as the *libktx* names minus the `ktx{,_}` prefixes and `_e` suffixes for consistency and to make it easier to recall what the JS name will be.
-* Similarly constant names are the *libktx* names minus all prefixes as an enum or class name must be used when referencing them in JS. For example `KTX_PACK_UASTC_LEVEL_FASTEST` is simply `LEVEL_FASTEST` and is referenced in JS as `pack_uastc_flag_bits.LEVEL_FASTEST`.
-
-#### Java binding
-
-The Java binding has been greatly improved by a large refactoring focussing on error handling, documentation, completeness, and usability improvements ( #886 ). This includes several breaking changes. Not all breaking changes can be listed here explicitly. But in all cases, it should be easy for clients to update their code to the new state. The most important changes for the Java Wrapper are listed below.
-
-* Made deflateZstd, deflateZLIB, and createFromMemory available in the KtxTexture2 class.
-* Fixed a bug where the KtxBasisParams#setInputSwizzle function caused data corruption.
-* Increased the consistency of the naming and handling of constants:
-    * all constant names are UPPER\_SNAKE\_CASE, omitting common prefixes;
-    * classes that define constants offer a stringFor function that returns the string representation of a constant;
-    * the `KtxCreateStorage` class was renamed to `KtxTextureCreateStorage`;
-    * the `KtxPackUASTCFlagBits` class was renamed to `KtxPackUastcFlagBits`.
-* Improved error handling:
-    * when functions receive a parameter that is null, then this will no longer crash the JVM, but will throw a NullPointerException;
-    * when setInputSwizzle receives invalid arguments, then an `IllegalArgumentException` will be thrown;
-    * when one of the create... family of functions causes an error, meaning that the respective KtxTexture2 object cannot be created, then a `KtxException` will be thrown.
-* Added JavaDocs, and enabled the generation of JavaDocs as part of the Maven build process.
-* Internal improvements (like JNI field caching, and avoiding calling JNI functions with pending exceptions).
-* Supercompression functions exposed in the binding.
-* `ktxTexture_GLUpload function exposed in the binding.
-
-Massive thanks to @javagl for this work.
-
-
-#### ASTC Encoder
-
-* Updated to 5.2.0.
 
 ### Known Issues
 
 * Files deflated with zlib using *libktx* compiled with GCC and run on x86\_64 may not be bit-identical with those using *libktx* compiled with GCC and run on arm64.
 
-* Users making Basis Universal encoded or GPU block compressed textures for WebGL must be aware of WebGL restrictions with regard to texture size and may need to resize input images appropriately before using the `ktx create` tool, or use the `--resize` feature of the old `toktx` tool to produce an appropriately sized texture. In general, the dimensions of block compressed textures must be a multiple of the block size in WebGL and for WebGL 1.0 textures must have power-of-two dimensions. Additional portability restrictions apply for glTF per the _KHR\_texture\_basisu_ extension which can be verified using the `--gltf-basisu` command-line option of the new `ktx validate` tool.
+* Users making Basis Universal encoded or GPU block compressed textures for WebGL must be aware of WebGL restrictions with regard to texture size and may need to resize input images appropriately before using the `ktx create` tool, or use the `--resize` feature to produce an appropriately sized texture. In general, the dimensions of block compressed textures must be a multiple of the block size in WebGL and for WebGL 1.0 textures must have power-of-two dimensions. Additional portability restrictions apply for glTF per the _KHR\_texture\_basisu_ extension which can be verified using the `--gltf-basisu` command-line option of `ktx validate`.
 
 * Basis Universal encoding results (both ETC1S/LZ and UASTC) are non-deterministic across platforms. Results are valid but level sizes and data will differ slightly.  See [issue #60](https://github.com/BinomialLLC/basis_universal/issues/60) in the basis_universal repository.
 
@@ -105,155 +50,149 @@ Massive thanks to @javagl for this work.
 
 * Neither the Vulkan nor GL loaders support depth/stencil textures.
 
-### Changes since v4.3.2 (by part)
+### Changes since v4.4.0 (by part)
 ### libktx
 
-* Fix memory leaks. (#1003) (0f0e06519) (@MarkCallow)
+* Add v1 support to ktx info (#1060) (3cd9e3447) (@MarkCallow)
 
-* Fix issues with ktxLoadOpenGL documentation. (0c1922d89) (@MarkCallow)
+* Remove mentions of retired edgewise-consulting.com. (#1058) (0306d6a61) (@MarkCallow)
 
-* Fix incorrect data types in libktx\_mainpage.md examples (#992) (b35a47811) (@Lephar)
+* Export ktxTexture2\_DecodeAstc in JS bindings (#1034) (64a69009b) (@MarkCallow)
 
-* Set bytes planes to non-zero for supercompressed formats. (#988) (d4cad5f85) (@MarkCallow)
+* Restore rotted bits: update vcpkg caching and pyktx to latest Python (#1033) (f753fcabe) (@MarkCallow)
 
-* Fix memory leak. (#991) (e0cf193d4) (@MarkCallow)
+* Fix for Emscripten 4.0.9 (#1026) (1a983763c) (@MarkCallow)
 
-* Add normalise option to command create (#977) (2f691839a) (@wasimabbas-arm)
-
-* Make ktxTexture2\_Write functions public. (#985) (b330a2ee9) (@MarkCallow)
-
-* ktx create: Update transfer function handling (#982) (7356c0d74) (@MarkCallow)
-
-* Add vkformat checks to ktxTexture2\_DecodeAstc (#967) (aa6af91c6) (@wasimabbas-arm)
-
-* Fix ktxTexture2\_DecodeAstc error returns and document them. (#961) (b6190046b) (@MarkCallow)
-
-* Fix ktxTexture2\_DecodeAstc documentation. (c16537c89) (@MarkCallow)
-
-* Encode astc support (#952) (d1ad5cdc4) (@wasimabbas-arm)
-
-* Expose ktxTexture2\_GetImageOffset. (#954) (99c324fff) (@MarkCallow)
-
-* JNI improvements (#886) (2ee4332a1) (@javagl)
-
-* Add clang-format support (#913) (110f049fd) (@MathiasMagnus)
-
-* Fix issues newly flagged by Doxygen 1.11.0 (#925) (19c2f75ab) (@MarkCallow)
-
-* docs: clarify pointer lifetimes for ktxTexture\_SetImageFromMemory (#917) (b2cad1ad4) (@mjrister)
-
-* Update R16G16\_S10\_5\_NV format to R16G16\_SFIXED5\_NV (#921) (7f3adf1b5) (@MarkCallow)
-
-* Add JS bindings for full libktx (#874) (562509c7f) (@aqnuep)
-
-* Fixes for strnlen and unicode string literals (#916) (759f49d95) (@rGovers)
-
-* INVALID\_OPERATION if generateMipmaps set when block compressing. (e5585e34f) (@MarkCallow)
-
-* Expose ktxTexture[12]\_Destroy. (7132048c1) (@MarkCallow)
-
-* Move self-hosted dependencies to `external` folder (#909) (5fc739c8f) (@MathiasMagnus)
-
-* Fix various issues surfaced by fuzzer (#900) (6063e470f) (@florczyk-fb)
-
-* Expose supercompression functions via JNI (#879) (7abffbdbe) (@javagl)
-
-* Add function for app to explicitly make libktx load its GL function pointers. (#894) (0bca55aa7) (@MarkCallow)
-
-* Miscellaneous fixes (#893) (e31b3e5b8) (@MarkCallow)
-
-* Minor documentation fixes (#890) (e7d2d7194) (@javagl)
-
-* Merge ktx compare to main (#868) (6fcd95a7f) (@aqnuep)
+* Fix memory leaks. (#1007) (504b96247) (@MarkCallow)
 
 ### Tools
 
-* Add resize and scale support to create #999 (75d8d04bb) (@MarkCallow)
+* Add v1 support to ktx info (#1060) (3cd9e3447) (@MarkCallow)
 
-* Update for new commands and features. (350a63199) (@MarkCallow)
+* Remove mentions of retired edgewise-consulting.com. (#1058) (0306d6a61) (@MarkCallow)
 
-* Set bytes planes to non-zero for supercompressed formats. (#988) (d4cad5f85) (@MarkCallow)
+* Document that --generated-mipmap can't be used with --raw. (#1057) (1d7d44465) (@MarkCallow)
 
-* Add normalise option to command create (#977) (2f691839a) (@wasimabbas-arm)
+* Update fmt to latest release (v11.2) (#1056) (f5654c2b0) (@MarkCallow)
 
-* ktx create: Update transfer function handling (#982) (7356c0d74) (@MarkCallow)
+* Fix hang when adding alpha and PNG input has sBIT chunk. (#1054) (d9a0c2bd5) (@MarkCallow)
 
-* Add --{assign.convert}-texcoord-origin option to ktx create (#976) (91e61d6fa) (@MarkCallow)
+* Set color space in input image prior to resample. (#1051) (1daca0cdc) (@MarkCallow)
 
-* fix: INSTALL\_RPATH for linux using lib64 (#975) (ba9783356) (@MinGyuJung1996)
+* Use relative rpaths to find installed library on macOS (#1046) (d47320c24) (@MarkCallow)
 
-* Add vkformat checks to ktxTexture2\_DecodeAstc (#967) (aa6af91c6) (@wasimabbas-arm)
+* Shut up warnings clang with libstdc++ emits about non-virtual destructors (#1012) (fbb5412f5) (@DanielGibson)
 
-* Fix crash on loading EXR 2.0 input (#973) (7a8cd47de) (@MathiasMagnus)
+* Fix CLI error handling for --normalize. (#1016) (17d206239) (@MarkCallow)
 
-* Encode astc support (#952) (d1ad5cdc4) (@wasimabbas-arm)
-
-* Always use same method to set language version. (#947) (3439dafa7) (@MarkCallow)
-
-* Fix: ensure ktxdiff runs on macOS and enable CTS in Linux arm64 CI. (#946) (ffb915299) (@MarkCallow)
-
-* Fixing build on Ubuntu 24.04 w/ Clang 20 (#936) (33813d72a) (@Honeybunch)
-
-* Fix issues newly flagged by Doxygen 1.11.0 (#925) (19c2f75ab) (@MarkCallow)
-
-* Update R16G16\_S10\_5\_NV format to R16G16\_SFIXED5\_NV (#921) (7f3adf1b5) (@MarkCallow)
-
-* Update astc-encoder to 4.8.0 (subrepo pull). (#918) (7fb646cd3) (@MarkCallow)
-
-* Move self-hosted dependencies to `external` folder (#909) (5fc739c8f) (@MathiasMagnus)
-
-* Fix man page issues introduced by PR #817 (#903) (0d1ebc1d0) (@MarkCallow)
-
-* Refactor common options (#817) (0a16df82e) (@wasimabbas-arm)
-
-* Add `ktx deflate` command (#896) (da97911f9) (@MarkCallow)
-
-* Fixes to CLI error messages (#891) (eac4b9878) (@aqnuep)
-
-* Minor documentation fixes (#890) (e7d2d7194) (@javagl)
-
-* Merge ktx compare to main (#868) (6fcd95a7f) (@aqnuep)
-
-* Clarify description of --format argument for create when used with --encode (#873) (5414bd0eb) (@aqnuep)
-
-
+* Update LodePNG to version 20241228, (#1015) (6d1fc82ca) (@MarkCallow)
 
 ### JS Bindings
 
-* Align naming (#938) (a3cf1d506) (@MarkCallow)
+* Export ktxTexture2\_DecodeAstc in JS bindings (#1034) (64a69009b) (@MarkCallow)
 
-* Remove long ago deprecated items. (#926) (b1a115f3a) (@MarkCallow)
+* Fix for Emscripten 4.0.9 (#1026) (1a983763c) (@MarkCallow)
 
-* Update R16G16\_S10\_5\_NV format to R16G16\_SFIXED5\_NV (#921) (7f3adf1b5) (@MarkCallow)
+### Java Bindings
 
-* Add JS bindings for full libktx (#874) (562509c7f) (@aqnuep)
+* Use relative rpaths to find installed library on macOS (#1046) (d47320c24) (@MarkCallow)
 
-* Move self-hosted dependencies to `external` folder (#909) (5fc739c8f) (@MathiasMagnus)
+### Python Bindings
 
-### Java Binding
+* Restore rotted bits: update vcpkg caching and pyktx to latest Python (#1033) (f753fcabe) (@MarkCallow)
 
-* Java swizzle and constant fixes (#972) (3038f7cae) (@javagl)
+* Add option to use virtual environment for Python. (#1029) (b167e968c) (@MarkCallow)
 
-* Add GL upload function to Java interface (#959) (bd8ae318f) (@javagl)
+* Bump setuptools from 70.0.0 to 78.1.1 in /interface/python\_binding (#1025) (94d0c3a81) (@dependabot[bot])
 
-* Fix JNI function name for `getDataSizeUncompressed` (#957) (f3902db35) (@javagl)
+* Fix python deprecation warning. (#1018) (dac48df00) (@MarkCallow)
 
-* JNI improvements (#886) (2ee4332a1) (@javagl)
+### External Package Dependencies
 
-* Update R16G16\_S10\_5\_NV format to R16G16\_SFIXED5\_NV (#921) (7f3adf1b5) (@MarkCallow)
+* Remove mentions of retired edgewise-consulting.com. (#1058) (0306d6a61) (@MarkCallow)
 
-* Expose supercompression functions via JNI (#879) (7abffbdbe) (@javagl)
+* Update fmt to latest release (v11.2) (#1056) (f5654c2b0) (@MarkCallow)
 
-* Properly convert Java char to C char in inputSwizzle (#876) (cc5648532) (@javagl)
+* Migrate loadtest apps to SDL3 (#1055) (443e12238) (@MarkCallow)
 
-### Python Binding
+* Update ASTC encoder to 5.3.0 (#1036) (f6f0b9a1d) (@MarkCallow)
 
-* Set up workflow to build just the documentation. (#989) (a45ffed4d) (@MarkCallow)
+* Update lodepng to version 20250506 (#1035) (f9c73388a) (@MarkCallow)
 
-* Workaround removal of Python virtualenv in Actions runner 20240929.1. (#950) (e30405729) (@MarkCallow)
+* GCC14/C++23 compatibility fix (#1014) (f3f6b3b69) (@alexge50)
 
-* Bump setuptools from 69.0.2 to 70.0.0 in /interface/python\_binding (#930) (f389108ff) (@dependabot[bot])
+* Update LodePNG to version 20241228, (#1015) (6d1fc82ca) (@MarkCallow)
 
-* Update R16G16\_S10\_5\_NV format to R16G16\_SFIXED5\_NV (#921) (7f3adf1b5) (@MarkCallow)
+### Tests
+
+* Add v1 support to ktx info (#1060) (3cd9e3447) (@MarkCallow)
+
+* Remove mentions of retired edgewise-consulting.com. (#1058) (0306d6a61) (@MarkCallow)
+
+* Update CTS ref to merged tests. (65b0031d7) (@MarkCallow)
+
+* Document that --generated-mipmap can't be used with --raw. (#1057) (1d7d44465) (@MarkCallow)
+
+* Update fmt to latest release (v11.2) (#1056) (f5654c2b0) (@MarkCallow)
+
+* Migrate loadtest apps to SDL3 (#1055) (443e12238) (@MarkCallow)
+
+* Fix hang when adding alpha and PNG input has sBIT chunk. (#1054) (d9a0c2bd5) (@MarkCallow)
+
+* Set color space in input image prior to resample. (#1051) (1daca0cdc) (@MarkCallow)
+
+* Use relative rpaths to find installed library on macOS (#1046) (d47320c24) (@MarkCallow)
+
+* Clarify platforms where unit tests not supported. (#1040) (f9f36940b) (@MarkCallow)
+
+* Minor build fixes (#1039) (8dfb89507) (@MarkCallow)
+
+* Update for Vulkan SDK 1.4.313. (#1037) (d72218c6a) (@MarkCallow)
+
+* Export ktxTexture2\_DecodeAstc in JS bindings (#1034) (64a69009b) (@MarkCallow)
+
+* Restore rotted bits: update vcpkg caching and pyktx to latest Python (#1033) (f753fcabe) (@MarkCallow)
+
+* Fix handling of multiple files with spaces in names. (#1030) (b2f4da2aa) (@MarkCallow)
+
+* Update CTS ref for merged test updates. (b9218bc50) (@MarkCallow)
+
+* Fix CLI error handling for --normalize. (#1016) (17d206239) (@MarkCallow)
+
+* Linux and MacOS workflows (#1004) (520dc8f89) (@MathiasMagnus)
 
 
+
+### Build Scripts and CMake files
+
+* Add v1 support to ktx info (#1060) (3cd9e3447) (@MarkCallow)
+
+* Migrate loadtest apps to SDL3 (#1055) (443e12238) (@MarkCallow)
+
+* Fix hang when adding alpha and PNG input has sBIT chunk. (#1054) (d9a0c2bd5) (@MarkCallow)
+
+* Use relative rpaths to find installed library on macOS (#1046) (d47320c24) (@MarkCallow)
+
+* Clarify platforms where unit tests not supported. (#1040) (f9f36940b) (@MarkCallow)
+
+* Minor build fixes (#1039) (8dfb89507) (@MarkCallow)
+
+* Update for Vulkan SDK 1.4.313. (#1037) (d72218c6a) (@MarkCallow)
+
+* Export ktxTexture2\_DecodeAstc in JS bindings (#1034) (64a69009b) (@MarkCallow)
+
+* Restore rotted bits: update vcpkg caching and pyktx to latest Python (#1033) (f753fcabe) (@MarkCallow)
+
+* Add option to use virtual environment for Python. (#1029) (b167e968c) (@MarkCallow)
+
+* Fix: Install graphviz if FEATURE\_DOCS ON (#1028) (e69101917) (@MarkCallow)
+
+* Fix for Emscripten 4.0.9 (#1026) (1a983763c) (@MarkCallow)
+
+* Enable use of Ninja Multi-Config generator for Linux builds (#1017) (161878025) (@MarkCallow)
+
+* Update LodePNG to version 20241228, (#1015) (6d1fc82ca) (@MarkCallow)
+
+* Fix issues in CMakeLists.txt (see #996) (#998) (c033ac8fa) (@DanielGibson)
+
+* Linux and MacOS workflows (#1004) (520dc8f89) (@MathiasMagnus)

--- a/cmake/License.rtf
+++ b/cmake/License.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2513
+{\rtf1\ansi\ansicpg1252\cocoartf2822
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 HelveticaNeue;}
 {\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
 {\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
@@ -16,4 +16,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 \pard\pardeftab720\sa140\partightenfactor0
 \cf2 \
 \pard\pardeftab720\sa280\partightenfactor0
-\cf2 libktx is the work of Mark Callow based on work by Georg Kolling and Jacob Str\'f6m with contributions borrowed from Troy Hanson, Johannes van Waveren, Lode Vandevenne and Rich Geldreich. The tools are the work of Mark Callow. The CMake-based build setup used to produce this installer is the work of Andreas Atteneder.}
+\cf2 libktx is the work of Mark Callow based on work by Georg Kolling and Jacob Str\'f6m with contributions borrowed from Troy Hanson, Johannes van Waveren, Lode Vandevenne and Rich Geldreich. The KTX tool suite is the work of RasterGrid Kft. The legacy tools are the work of Mark Callow. The CMake-based build setup used to produce this installer is the work of Andreas Atteneder.}

--- a/cmake/ReadMe.rtf
+++ b/cmake/ReadMe.rtf
@@ -1,31 +1,39 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2513
+{\rtf1\ansi\ansicpg1252\cocoartf2822
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 HelveticaNeue;\f1\fnil\fcharset0 LucidaGrande;\f2\fnil\fcharset0 HelveticaNeue-Italic;
 \f3\fnil\fcharset0 HelveticaNeue-Bold;}
 {\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
 {\*\expandedcolortbl;;\cssrgb\c0\c0\c0\cname textColor;}
-{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{square\}}{\leveltext\leveltemplateid1\'01\uc0\u9642 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
-{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
+{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{hyphen\}}{\leveltext\leveltemplateid1\'01\uc0\u8259 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{hyphen\}}{\leveltext\leveltemplateid2\'01\uc0\u8259 ;}{\levelnumbers;}\fi-360\li1440\lin1440 }{\listname ;}\listid1}
+{\list\listtemplateid2\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{square\}}{\leveltext\leveltemplateid101\'01\uc0\u9642 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{hyphen\}}{\leveltext\leveltemplateid102\'01\uc0\u8259 ;}{\levelnumbers;}\fi-360\li1440\lin1440 }{\listname ;}\listid2}}
+{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}}
 \paperw11900\paperh16840\margl1440\margr1440\vieww19120\viewh13180\viewkind0
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
 
-\f0\fs26 \cf2 This will install the following KTX tools:\
+\f0\fs26 \cf2 This will install the following:\
 \
 \pard\tx220\tx720\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li720\fi-720\pardirnatural\partightenfactor0
-\ls1\ilvl0\cf2 {\listtext	
-\f1 \uc0\u9642 
-\f0 	}ktx2check - Check KTX v2 files for validity.\
-{\listtext	
-\f1 \uc0\u9642 
-\f0 	}ktxinfo - Print info about a KTX file in human-readable form.\
-{\listtext	
-\f1 \uc0\u9642 
-\f0 	}ktx2ktx2 - Convert a KTX v1 file to a KTX v2 file.\
-{\listtext	
-\f1 \uc0\u9642 
-\f0 	}ktxsc - Supercompress a KTX v2 file.\
-{\listtext	
-\f1 \uc0\u9642 
-\f0 	}toktx - Create a KTX v1 or v2 file from .jpg, .png or Netpbm images.\
+
+\f1 \cf2    \uc0\u9642 
+\f0 	ktx - Unified front end for the KTX tool suite:\
+\pard\tx940\tx1440\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li1440\fi-1440\pardirnatural\partightenfactor0
+\ls1\ilvl1\cf2 {\listtext	\uc0\u8259 	}create - Create KTX v2 files.\
+{\listtext	\uc0\u8259 	}compare - Compare KTX v2 files.\
+{\listtext	\uc0\u8259 	}deflate - Apply Zstd or ZLIB compression to a KTX v2 file.\
+{\listtext	\uc0\u8259 	}encode - Encode a KTX v2 file to Basis Universal or ASTC.\
+{\listtext	\uc0\u8259 	}extract - Extract an image from a KTX v2 file.\
+{\listtext	\uc0\u8259 	}info - Display info about a KTX file.\
+{\listtext	\uc0\u8259 	}transcode - Transcode a KTX v2 file.\
+{\listtext	\uc0\u8259 	}validate - Validate a KTX v2 file.\
+\pard\tx220\tx720\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li720\fi-720\pardirnatural\partightenfactor0
+
+\f1 \cf2    \uc0\u9642 
+\f0 	Legacy tools which will be removed in the next release:\
+\pard\tx940\tx1440\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\li1440\fi-1440\pardirnatural\partightenfactor0
+\ls2\ilvl1\cf2 {\listtext	\uc0\u8259 	}ktx2check - Check KTX v2 files for validity.\
+{\listtext	\uc0\u8259 	}ktxinfo - Print info about a KTX file in human-readable form.\
+{\listtext	\uc0\u8259 	}ktx2ktx2 - Convert a KTX v1 file to a KTX v2 file.\
+{\listtext	\uc0\u8259 	}ktxsc - Supercompress a KTX v2 file.\
+{\listtext	\uc0\u8259 	}toktx - Create a KTX v1 or v2 file from .jpg, .png or Netpbm images.\
 \pard\tx566\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
 \cf2 \
 By clicking the 

--- a/lib/libktx_mainpage.md
+++ b/lib/libktx_mainpage.md
@@ -19,7 +19,7 @@ For information about the KTX format see the
 formal specification.</a>
 
 @authors
-<a href="http://github.com/MarkCallow">Mark Callow/a>,
+<a href="http://github.com/MarkCallow">Mark Callow</a>,
 formerly at <a href="http://www.hicorp.co.jp">HI Corporation</a>\n
 Mátyás Császár and Daniel Rákos, <a href="https://www.rastergrid.com/">RasterGrid</a>\n
 Wasim Abbas, <a href="https://www.arm.com/">Arm</a>\n


### PR DESCRIPTION
* Update release notes.
* Update installers' ReadMe and License files.
* Add `contents: write` permission so workflows can write to Release.
* Fix HTML error in libktx_mainpage.md.