### PR TITLE
Add KTX_FEATURE_JS option controlling whether `ktx_js[_read]` are built.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option( KTX_FEATURE_JNI "Create Java bindings for libktx." OFF )
 option( KTX_FEATURE_PY "Create Python source distribution." OFF )
 option( KTX_FEATURE_TESTS "Create unit tests." ON )
 option( KTX_FEATURE_TOOLS_CTS "Enable KTX CLI Tools CTS tests (requires CTS submodule)." OFF )
+option( KTX_FEATURE_JS "Enable JavaScript bindings in Emscripten builds." ON )
 
 if(KTX_FEATURE_TOOLS_CTS AND NOT KTX_FEATURE_TOOLS)
     message(WARNING "KTX_FEATURE_TOOLS is not set -> disabling KTX_FEATURE_TOOLS_CTS.")
@@ -243,7 +244,7 @@ endif()
 
 create_version_file()
 
-if(EMSCRIPTEN)
+if(EMSCRIPTEN AND KTX_FEATURE_JS)
     set(
         KTX_EM_COMMON_LINK_FLAGS
         --bind


### PR DESCRIPTION
(Reopening #1072, now targeting `main`)

Adds a new CMake option called `KTX_FEATURE_JS`. It defaults to ON, but when set to OFF, `ktx_js` and `ktx_js_read` are not built, even under Emscripten.

My use-case for this is compiling [Cesium for Unity](https://github.com/CesiumGS/cesium-unity) for the web. Compiling Unity applications to WebAssembly requires using Unity's version of Emscripten, which is quite old (v3.1.39), and is not able to compile `ktx_js` successfully. This isn't really worth fixing because the JavaScript bindings aren't used in this context anyway. KTX functionality is only called from Emscripten'd native code, never from regular JS code.

So with this low-impact PR, it's easy to disable this unnecessary part of the KTX software suite in order to get a successful build.

The slightly bigger picture here is to then expose this via a vcpkg feature flag.
