### PR TITLE
Fix creating static ktx_read convenience lib

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -472,7 +472,7 @@ macro(add_lib_dependencies target lib)
         add_dependencies(${target} ${lib})
         add_custom_command( TARGET ${target}
             POST_BUILD
-            COMMAND libtool -static -o $<TARGET_FILE:${target}> $<TARGET_FILE:ktx> $<TARGET_FILE:${lib}>
+            COMMAND libtool -static -o $<TARGET_FILE:${target}> $<TARGET_FILE:${target}> $<TARGET_FILE:${lib}>
         )
         target_include_directories(${target} PRIVATE $<TARGET_PROPERTY:${lib},INTERFACE_INCLUDE_DIRECTORIES>)
 


### PR DESCRIPTION
Fixes "duplicate member name" warnings:
~~~
[130/148] : [...] libtool -static -o /Users/vcpkg/Data/b/ktx/x64-osx-rel/libktx_read.a /Users/vcpkg/Data/b/ktx/x64-osx-rel/libktx.a /Users/vcpkg/Data/b/ktx/x64-osx-rel/external/astc-encoder/Source/libastcenc-avx2-static.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: warning for architecture: x86_64h duplicate member name 'astcenc_averages_and_directions.cpp.o' from '/Users/vcpkg/Data/b/ktx/x64-osx-rel/external/astc-encoder/Source/libastcenc-avx2-static.a(astcenc_averages_and_directions.cpp.o)' and '/Users/vcpkg/Data/b/ktx/x64-osx-rel/libktx.a(astcenc_averages_and_directions.cpp.o)'
~~~
