### PR TITLE
Revise mkversion invocation

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -187,7 +187,7 @@ function( create_version_header dest_path target )
         add_custom_command(
             OUTPUT ${version_h_output}
             # On Windows this command has to be invoked by a shell in order to work
-            COMMAND ${BASH_EXECUTABLE} -c "\"${mkversion}\" ${MKV_VERSION_OPT} \"-o\" \"version.h\" \"${dest_path}\""
+            COMMAND "${BASH_EXECUTABLE}" -- "${mkversion}" ${MKV_VERSION_OPT} -o version.h "${dest_path}"
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Generate ${version_h_output}"
             VERBATIM


### PR DESCRIPTION
This is an *untested* rewrite of the line invoking `mkversion` on Windows, based on past vcpkg experience. (The current port version 4.4.2 doesn't invoke mkversion.)

The original `"\"...\" ...."` fails *for some configurations*.
It is a single CMake list item, with embedded quotes which go into a build system rule which may or may not get the inner quotes correctly for the actual invocation of the command.

The rule of thumb is:
- Quote for CMake.  
  There is *only outer quotes* for items in a *cmake list*.
- Do not assume a particular shell for commands executed by the build system.  
  There are different generators for different build systems.
  With ninja build files, commands may be executed via a shell or directly, depending on the system.
  With any type of *inner quotes*, portability will be limited.

The new line is a CMake list of command and items, with quoting for CMake when items can expand with special characters inside.
(Now this newest version contains an embedded CMake variable `${MKV_VERSION_OPT}` which I didn't quote because I assume it is of list type, i.e. potentially expanding to multiple command line arguments.)
