### PR TITLE
Avoid using user-controlled paths as regex patterns (fix #1084)

### DIFF
--- a/scripts/mkversion
+++ b/scripts/mkversion
@@ -160,13 +160,14 @@ if [ $write_all -eq 1 ]; then
     fi
   done
 else
-  if [[ $workdir =~ $(pwd)(/(.*$)?)? ]]; then
+  relative_path=$(realpath --relative-base=$(pwd) -- $workdir)
+  if [[ $relative_path =~ ^[^/] ]]; then
     # Trailing part of workdir gives object location in repo.
-    if [ -n "${BASH_REMATCH[2]}" ]; then
+    if [[ $relative_path != . ]]; then
       if [ "$OBJ" == "." ]; then
-        OBJ=${BASH_REMATCH[2]}
+        OBJ=$relative_path
       else
-        OBJ=${BASH_REMATCH[2]}/$OBJ
+        OBJ=$relative_path/$OBJ
       fi
     # else  We are in the repo root
     fi


### PR DESCRIPTION
This might not work on MacOS, but is fine on Linux and Windows.

Otherwise, #1084 happens, and building the library after cloning it to a path like `C:\C++Libraries\KTX-Software` doesn't work.

If `realpath` isn't available on MacOS, then I guess `$(pwd)` could be run through a `sed` script that regex-escaped it, but there are still some edge cases that that wouldn't handle well. e.g. with symlinks.

Fixes #1084.