### PR TITLE
Fix C++20 build issues.

### DIFF
--- a/tools/ktx/command.h
+++ b/tools/ktx/command.h
@@ -444,7 +444,13 @@ class InputStream {
 
 public:
     InputStream(const std::string& filepath, Reporter& report);
-
+#if defined(__cpp_lib_char8_t)
+    // This is a simplest way to make this work when compiled with >= c++20
+    // and the caller of this is passing the output of std::filesystem::path::u8string().
+    // At some point we should consider making filepath a u8string.
+    InputStream(const std::u8string& filepath, Reporter& report) :
+           InputStream(from_u8string(filepath), report) { }
+#endif
     const std::string& str() {
         return filepath;
     }
@@ -473,10 +479,8 @@ protected:
 public:
     OutputStream(const std::string& filepath, Reporter& report);
 #if defined(__cpp_lib_char8_t)
-    // This is a simplest way to make this work when compiled with >= c++20
-    // and the caller of this is passing the output of std::filesystem::path::u8string().
-    // At some point we should consider making filepath a u8string.
-    OutputStream::OutputStream(const std::u8string& filepath, Reporter& report) :
+    // See comment under same ifdef in InputStream constructor.
+    OutputStream(const std::u8string& filepath, Reporter& report) :
            OutputStream(from_u8string(filepath), report) { }
 #endif
 

--- a/tools/ktx/command_convert.cpp
+++ b/tools/ktx/command_convert.cpp
@@ -187,7 +187,11 @@ void CommandConvert::executeConvert() {
 
     // In c++20 options.{input,output}Filepath should be changed to u8string
     // and u8path() replaced with path.
+#if defined(__cpp_lib_char8_t)
+   auto outputFilepath = std::filesystem::path(to_u8string(options.outputFilepath));
+#else
     auto outputFilepath = std::filesystem::u8path(options.outputFilepath);
+#endif
     bool usingInputName = false;
     // If no output path given or output is a directory, use input path/filename
     // changing extension to or adding ".ktx2".
@@ -197,7 +201,11 @@ void CommandConvert::executeConvert() {
     } else if (!outputFilepath.has_filename() || std::filesystem::is_directory(outputFilepath)) {
         // is_directory() above handles case where outputFilepath is not '/' terminated but
         // exists and is a directory.
+#if defined(__cpp_lib_char8_t)
+        auto inputFilepath = std::filesystem::path(to_u8string(options.inputFilepath));
+#else
         auto inputFilepath = std::filesystem::u8path(options.inputFilepath);
+#endif
         outputFilepath /= inputFilepath.filename();
         usingInputName = true;
     }

--- a/tools/ktx/utility.h
+++ b/tools/ktx/utility.h
@@ -7,6 +7,7 @@
 
 #include "ktx.h"
 #include "imageio_utility.h"
+#include "platform_utils.h"
 #include <fmt/ostream.h>
 #include <fmt/printf.h>
 #include <algorithm>
@@ -302,6 +303,16 @@ template <typename Iterator>
 [[nodiscard]] inline std::string fmtOutFile(std::string_view filepath) {
     return filepath == "-" ? std::string("stdout") : std::string(filepath);
 }
+
+#if defined(__cpp_lib_char8_t)
+[[nodiscard]] inline std::string fmtInFile(std::u8string_view filepath) {
+    return filepath == u8"-" ? std::string("stdin") : from_u8string(filepath);
+}
+
+[[nodiscard]] inline std::string fmtOutFile(std::u8string_view filepath) {
+    return filepath == u8"-" ? std::string("stdout") : from_u8string(filepath);
+}
+#endif
 
 // -------------------------------------------------------------------------------------------------
 

--- a/utils/platform_utils.h
+++ b/utils/platform_utils.h
@@ -121,7 +121,13 @@ inline int unlinkUTF8(const std::string& path) {
     inline std::string from_u8string(const std::u8string& s) {
         return std::string(s.begin(), s.end());
     }
-    inline std::string to_u8string(const std::string& s) {
+    inline std::string from_u8string(const std::u8string_view& s) {
+        return std::string(s.begin(), s.end());
+    }
+    inline std::u8string to_u8string(const std::string& s) {
+        return std::u8string(s.begin(), s.end());
+    }
+    inline std::u8string to_u8string(const std::string_view& s) {
         return std::u8string(s.begin(), s.end());
     }
 


### PR DESCRIPTION
- Remove OutputString:: prefix from in class definition of constructor.
- Add u8string overload of InputStream constructor.
- Fix return type of from_u8string.
- Add from_u8string and to_u8string overloads that take u8string_view and string_view respectively.
- Provide overloads of fmtInFile and fmtOutFile that take u8string_view.
- Avoid use of filesystem::path::u8path in c++20 to avoid deprecation warning.