### PR TITLE
Set codec quality level for UASTC HDR 4x4 options

### DIFF
--- a/lib/src/basis_encode.cpp
+++ b/lib/src/basis_encode.cpp
@@ -903,6 +903,7 @@ ktxTexture2_CompressBasisEx(ktxTexture2* This, ktxBasisParams* params)
         cparams.m_uastc_hdr_4x4_options.m_allow_uber_mode = params->uastcHDRUberMode;
         cparams.m_uastc_hdr_4x4_options.m_ultra_quant = params->uastcHDRUltraQuant;
         cparams.m_astc_hdr_6x6_options.m_rec2020_bt2100_color_gamut = params->rec2020;
+        cparams.m_astc_hdr_6x6_options.set_user_level(params->uastcHDRLevel);
         if (params->uastcHDRLambda > 0.0f)
         {
             cparams.m_astc_hdr_6x6_options.m_lambda = params->uastcHDRLambda;


### PR DESCRIPTION
This fix propagates the "--uastc-quality level" effort level, and the "--uastc-hdr-6x6i-level" effort level, to the UASTC HDR 4x4 and UASTC HDR 6x6i compressors in the basisu library, otherwise these ktx command line options don't have any effect. 

Example to set quality 0 (fastest):

```
ktx create --format R16G16B16_SFLOAT --generate-mipmap --zstd 2 --encode uastc-hdr-4x4 --uastc-quality 0 desk.exr 1.ktx2
```

The fix is simple - it looks like most of the work to get the parameter for UASTC HDR 4x4 was already done, it just needs to be hooked up:

```
        cparams.m_hdr_favor_astc = params->uastcHDRFavorAstc;
        cparams.m_uastc_hdr_4x4_options.set_quality_level(params->uastcHDRQuality); // <-- ADDED LINE
        cparams.m_uastc_hdr_4x4_options.m_allow_uber_mode = params->uastcHDRUberMode;
        cparams.m_uastc_hdr_4x4_options.m_ultra_quant = params->uastcHDRUltraQuant;
```

Also - the same problem with UASTC HDR 6x6i. Most of the work to hook up the effort level option was already done, but the library wasn't being called to set the level.

```
       cparams.m_astc_hdr_6x6_options.set_user_level(params->uastcHDRLevel); // <-- ADDED LINE
```

Thanks.