### PR TITLE
Fix handling of DFD linear qualifier

### DIFF
--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -2670,10 +2670,24 @@ KTXTexture2 CommandCreate::createTexture(const ImageSpec& target) {
     if (KTX_SUCCESS != ret)
         fatal(rc::KTX_FAILURE, "Failed to create ktxTexture: libktx error: {}", ktxErrorString(ret));
 
-    KHR_DFDSETVAL(texture->pDfd + 1, PRIMARIES, target.format().primaries());
-    KHR_DFDSETVAL(texture->pDfd + 1, TRANSFER, target.format().transfer());
+    uint32_t* pBdb = texture->pDfd + 1;
+    KHR_DFDSETVAL(pBdb, PRIMARIES, target.format().primaries());
+    KHR_DFDSETVAL(pBdb, TRANSFER, target.format().transfer());
     if(options.premultiplyAlpha) {
-        KHR_DFDSETVAL(texture->pDfd+1, FLAGS, KHR_DF_FLAG_ALPHA_PREMULTIPLIED);
+        KHR_DFDSETVAL(pBdb, FLAGS, KHR_DF_FLAG_ALPHA_PREMULTIPLIED);
+    }
+    // Qualifier is only set for non-linear transfer functions. ktxTexture2_Create will
+    // already have set the qualifier for _SRGB formats.
+    if (target.format().transfer() != KHR_DF_TRANSFER_UNSPECIFIED
+        && target.format().transfer() != KHR_DF_TRANSFER_LINEAR
+        && !isFormatSRGB(options.vkFormat)) {
+        uint32_t sampleCount = KHR_DFDSAMPLECOUNT(pBdb);
+        for (uint32_t s = 0; s < sampleCount; s++) {
+            if (KHR_DFDSVAL(pBdb, s, CHANNELID) == KHR_DF_CHANNEL_RGBSDA_ALPHA) {
+                uint32_t qualifiers = KHR_DFDSVAL(pBdb, s, QUALIFIERS);
+                KHR_DFDSETSVAL(pBdb, s, QUALIFIERS, qualifiers | KHR_DF_SAMPLE_DATATYPE_LINEAR);
+            }
+        }
     }
 
     // Add KTXorientation metadata

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -2670,21 +2670,9 @@ KTXTexture2 CommandCreate::createTexture(const ImageSpec& target) {
     if (KTX_SUCCESS != ret)
         fatal(rc::KTX_FAILURE, "Failed to create ktxTexture: libktx error: {}", ktxErrorString(ret));
 
-    uint32_t* bdb = texture->pDfd + 1;
-    KHR_DFDSETVAL(bdb, PRIMARIES, target.format().primaries());
-    KHR_DFDSETVAL(bdb, TRANSFER, target.format().transfer());
-    if (!isFormatSRGB(options.vkFormat) && isTransferNonLinear(target.format().transfer())) {
-        // Handle the case where the transfer function is not the default for the format,
-        // e.g. not LINEAR for a *_UNORM texture.
-        for (uint32_t s = 0; s < KHR_DFDSAMPLECOUNT(bdb); s++) {
-            if (KHR_DFDSVAL(bdb, s, CHANNELID) == KHR_DF_CHANNEL_RGBSDA_ALPHA) {
-                uint8_t qualifiers = KHR_DFDSVAL(bdb, s, QUALIFIERS);
-                qualifiers |= KHR_DF_SAMPLE_DATATYPE_LINEAR;
-                KHR_DFDSETSVAL(bdb, s, QUALIFIERS, qualifiers);
-            }
-        }
-    }
-    if (options.premultiplyAlpha) {
+    KHR_DFDSETVAL(texture->pDfd + 1, PRIMARIES, target.format().primaries());
+    KHR_DFDSETVAL(texture->pDfd + 1, TRANSFER, target.format().transfer());
+    if(options.premultiplyAlpha) {
         KHR_DFDSETVAL(texture->pDfd+1, FLAGS, KHR_DF_FLAG_ALPHA_PREMULTIPLIED);
     }
 

--- a/tools/ktx/command_create.cpp
+++ b/tools/ktx/command_create.cpp
@@ -2670,9 +2670,21 @@ KTXTexture2 CommandCreate::createTexture(const ImageSpec& target) {
     if (KTX_SUCCESS != ret)
         fatal(rc::KTX_FAILURE, "Failed to create ktxTexture: libktx error: {}", ktxErrorString(ret));
 
-    KHR_DFDSETVAL(texture->pDfd + 1, PRIMARIES, target.format().primaries());
-    KHR_DFDSETVAL(texture->pDfd + 1, TRANSFER, target.format().transfer());
-    if(options.premultiplyAlpha) {
+    uint32_t* bdb = texture->pDfd + 1;
+    KHR_DFDSETVAL(bdb, PRIMARIES, target.format().primaries());
+    KHR_DFDSETVAL(bdb, TRANSFER, target.format().transfer());
+    if (!isFormatSRGB(options.vkFormat) && isTransferNonLinear(target.format().transfer())) {
+        // Handle the case where the transfer function is not the default for the format,
+        // e.g. not LINEAR for a *_UNORM texture.
+        for (uint32_t s = 0; s < KHR_DFDSAMPLECOUNT(bdb); s++) {
+            if (KHR_DFDSVAL(bdb, s, CHANNELID) == KHR_DF_CHANNEL_RGBSDA_ALPHA) {
+                uint8_t qualifiers = KHR_DFDSVAL(bdb, s, QUALIFIERS);
+                qualifiers |= KHR_DF_SAMPLE_DATATYPE_LINEAR;
+                KHR_DFDSETSVAL(bdb, s, QUALIFIERS, qualifiers);
+            }
+        }
+    }
+    if (options.premultiplyAlpha) {
         KHR_DFDSETVAL(texture->pDfd+1, FLAGS, KHR_DF_FLAG_ALPHA_PREMULTIPLIED);
     }
 

--- a/tools/ktx/formats.h
+++ b/tools/ktx/formats.h
@@ -263,6 +263,10 @@ namespace ktx {
     }
 }
 
+[[nodiscard]] inline bool isTransferNonLinear(khr_df_transfer_e tf) {
+    return (tf != KHR_DF_TRANSFER_UNSPECIFIED && tf != KHR_DF_TRANSFER_LINEAR);
+}
+
 // -------------------------------------------------------------------------------------------------
 
 [[nodiscard]] inline bool isFormatValid(VkFormat format) noexcept {

--- a/tools/ktx/formats.h
+++ b/tools/ktx/formats.h
@@ -263,10 +263,6 @@ namespace ktx {
     }
 }
 
-[[nodiscard]] inline bool isTransferNonLinear(khr_df_transfer_e tf) {
-    return (tf != KHR_DF_TRANSFER_UNSPECIFIED && tf != KHR_DF_TRANSFER_LINEAR);
-}
-
 // -------------------------------------------------------------------------------------------------
 
 [[nodiscard]] inline bool isFormatValid(VkFormat format) noexcept {

--- a/tools/ktx/validate.cpp
+++ b/tools/ktx/validate.cpp
@@ -1037,9 +1037,20 @@ void ValidationContext::validateDFDBasic(uint32_t blockIndex, const uint32_t* df
                                 toString(khr_df_model_e(block.model), khr_df_model_channels_e(parsed.channelId)),
                                 toString(expectedColorModel.value_or(KHR_DF_MODEL_UNSPECIFIED), khr_df_model_channels_e(expected.channelId)),
                                 toString(VkFormat(header.vkFormat)));
-                    if (parsed.qualifierLinear != expected.qualifierLinear)
-                        error(DFD::FormatMismatch, blockIndex, i + 1, "qualifierLinear", parsed.qualifierLinear,
-                                expected.qualifierLinear, toString(VkFormat(header.vkFormat)));
+                    if (block.transfer == KHR_DF_TRANSFER_UNSPECIFIED || block.transfer == KHR_DF_TRANSFER_LINEAR) {
+                        if (parsed.qualifierLinear)
+                            error(DFD::InvalidQualifierLinearForLinearTF, blockIndex, i + 1, parsed.qualifierLinear,
+                                  toString(khr_df_transfer_e(block.transfer)), 0);
+                    } else {
+                        if (parsed.channelId == KHR_DF_CHANNEL_RGBSDA_ALPHA && !parsed.qualifierLinear)
+                            error(DFD::InvalidQualifierLinearForNonLinearTF, blockIndex, i + 1,
+                                  parsed.qualifierLinear, toString(khr_df_transfer_e(block.transfer)),
+                                  parsed.channelId, "(alpha)", 1);
+                        if (parsed.channelId != KHR_DF_CHANNEL_RGBSDA_ALPHA && parsed.qualifierLinear)
+                            error(DFD::InvalidQualifierLinearForNonLinearTF, blockIndex, i + 1,
+                                  parsed.qualifierLinear, toString(khr_df_transfer_e(block.transfer)),
+                                  parsed.channelId, "(non-alpha)", 0);
+                    }
                     if (parsed.qualifierExponent != expected.qualifierExponent)
                         error(DFD::FormatMismatch, blockIndex, i + 1, "qualifierExponent", parsed.qualifierExponent,
                                 expected.qualifierExponent, toString(VkFormat(header.vkFormat)));

--- a/tools/ktx/validate.cpp
+++ b/tools/ktx/validate.cpp
@@ -1041,7 +1041,7 @@ void ValidationContext::validateDFDBasic(uint32_t blockIndex, const uint32_t* df
                         if (parsed.qualifierLinear)
                             error(DFD::InvalidQualifierLinearForLinearTF, blockIndex, i + 1, parsed.qualifierLinear,
                                   toString(khr_df_transfer_e(block.transfer)), 0);
-                    } else {
+                    } else if (block.transfer <= KHR_DF_TRANSFER_HLG_UNNORMALIZED_OETF) {
                         if (parsed.channelId == KHR_DF_CHANNEL_RGBSDA_ALPHA && !parsed.qualifierLinear)
                             error(DFD::InvalidQualifierLinearForNonLinearTF, blockIndex, i + 1,
                                   parsed.qualifierLinear, toString(khr_df_transfer_e(block.transfer)),
@@ -1050,7 +1050,9 @@ void ValidationContext::validateDFDBasic(uint32_t blockIndex, const uint32_t* df
                             error(DFD::InvalidQualifierLinearForNonLinearTF, blockIndex, i + 1,
                                   parsed.qualifierLinear, toString(khr_df_transfer_e(block.transfer)),
                                   parsed.channelId, "(non-alpha)", 0);
-                    }
+                    } // else
+                        // Invalid transfer function, an error that has already been logged.
+                        // No meaningful help would be provided by chacking the qualifier.
                     if (parsed.qualifierExponent != expected.qualifierExponent)
                         error(DFD::FormatMismatch, blockIndex, i + 1, "qualifierExponent", parsed.qualifierExponent,
                                 expected.qualifierExponent, toString(VkFormat(header.vkFormat)));

--- a/tools/ktx/validation_messages.h
+++ b/tools/ktx/validation_messages.h
@@ -489,6 +489,14 @@ struct DFD {
         6107, "Invalid sample upper for UASTC or BasisLZ/ETC1S texture in the basic DFD block.",
         "DFD block #{} sample #{} upper in basic DFD block is {} but for {} textures it must be {}."
     };
+    static constexpr IssueError InvalidQualifierLinearForLinearTF{
+        6108, "Invalid sample qualifierLinear for linear or unspecified transfer function in the basic DFD block.",
+        "DFD block #{} sample #{} qualifierLinear is {} but for {} it must be {}."
+    };
+    static constexpr IssueError InvalidQualifierLinearForNonLinearTF{
+        6109, "Invalid sample qualifierLinear for non-linear transfer function in the basic DFD block.",
+        "DFD block #{} sample #{} qualifierLinear is {} but for {} and channelId {} {} it must be {}."
+    };
 
     // 62xx - InterpretDFD related issues:
 


### PR DESCRIPTION
Fix `ktx create` to set the linear qualifier according to the transfer function and channel id, instead of always setting it to the default value for the output VkFormat.

Fix the validator to allow values that differ from the default provided they comply with the KTX specification.

Fixes #1156.