### PR TITLE
Fix build issues

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -474,7 +474,7 @@ macro(common_libktx_settings target enable_write library_type)
         target_compile_options(
             ${target}
         PRIVATE
-            $<$<AND:$<BOOL:${BASISU_SUPPORT_SSE}>,$<CXX_COMPILER_ID:AppleClang,Clang,GNU>>:
+            $<$<AND:$<BOOL:${BASISU_SSE}>,$<CXX_COMPILER_ID:AppleClang,Clang,GNU>>:
                 -msse4.1
             >
         )
@@ -489,7 +489,7 @@ macro(common_libktx_settings target enable_write library_type)
         target_link_libraries(
             ${target}
         PRIVATE
-            $<$<BOOL:${BASISU_SUPPORT_OPENCL}>:${OpenCL_LIBRARY}>
+            $<$<BOOL:${BASISU_OPENCL}>:${OpenCL_LIBRARY}>
         )
     endif()
 
@@ -598,7 +598,7 @@ endif()
 # macOS simultaneous multiple architectures are supported by the ASTC
 # encoder but not by the BasisU encoder. The latter supports only SSE
 # SIMD that is enabled by compile time defines which makes it not amenable
-# to a standard Xcode universal binary build. To ensure BASISU_SUPPORT_SSE
+# to a standard Xcode universal binary build. To ensure BASISU_SSE
 # is disabled when building for multiple architectures use only the
 # value of CMAKE_OSX_ARCHITECTURES to decide if a universal build
 # has been requested. Do not expose the astc-encoder's

--- a/tools/imageio/imageio.h
+++ b/tools/imageio/imageio.h
@@ -536,6 +536,14 @@ class ImageInput {
         }
     }
 
+#if defined(__GNUC__) && !defined(__clang__)
+  #pragma GCC diagnostic push
+  // GCC complains of writing 1 byte into a region of size 0 when called
+  // from ImageInput::convert at line 658. Given that the write argument
+  // passed from there is an array of size 4, this looks like a compiler
+  // bug. Silence the error.
+  #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     template<class Tr, class Tw>
     inline static void
     rescale(Tw* write, Tw maxw, const Tr* read, Tr maxr, size_t nvals)
@@ -547,6 +555,9 @@ class ImageInput {
             }
         }
     }
+#if defined(__GNUC__) && !defined(__clang__)
+  #pragma GCC diagnostic pop
+#endif
 
     template<class T>
     inline static T


### PR DESCRIPTION
1. Suppress what looks to be a bogus stringop-overflow warning from GCC, observed with both versions 13 and 15.
2. Change outdated SSE and OPENCL option names to current names so they are acted on properly.

Given the issues being fixed here, I am unable to understand why our CI builds have been green.