### PR TITLE
Update actions to Node.js 24-dependent versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,7 +59,7 @@ jobs:
       WERROR: ON
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Fetch all history to make sure tags are
         # included (used for version creation)

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -121,7 +121,7 @@ jobs:
     # by the preceding steps and uploads the zip.
     - name: upload artifact
       id: upload-artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: KTX-Software-${{env.KTX_VERSION}}-Android
         path: install-android

--- a/.github/workflows/check-libktx-only.yml
+++ b/.github/workflows/check-libktx-only.yml
@@ -91,7 +91,7 @@ jobs:
       WERROR: ON
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Fetch all history to make sure tags are
         # included (used for version creation)

--- a/.github/workflows/check-libktx-only.yml
+++ b/.github/workflows/check-libktx-only.yml
@@ -130,7 +130,7 @@ jobs:
 
     - name: Upload artifact libktx
       if: matrix.static == 'OFF'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: libktx-${{ env.KTX_VERSION }}-${{ runner.os }}-${{ env.ARCH }}
         path: ${{env.BUILD_DIR_TL}}/Release/*ktx*

--- a/.github/workflows/check-mkvk.yml
+++ b/.github/workflows/check-mkvk.yml
@@ -59,7 +59,7 @@ jobs:
       WERROR: ON
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Clone KTX-Specification repo
       run: |

--- a/.github/workflows/check-reuse.yml
+++ b/.github/workflows/check-reuse.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       GIT_LFS_SKIP_SMUDGE: 1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,7 @@ jobs:
       BUILD_DIR: build
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Fetch all history to make sure tags are
         # included (used for version creation)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Upload generated HTML documentation for GitHub Pages
       if: matrix.os == 'ubuntu-latest'
       id: deployment
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: ${{ env.BUILD_DIR }}/docs/html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,7 +87,7 @@ jobs:
       run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11.4'
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -16,7 +16,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run clang-format
       uses: jidicula/clang-format-action@v4.13.0
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -223,7 +223,7 @@ jobs:
       # Should a specific version of Python ever be wanted, use this.
 #      - name: Set up Python
 #        if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: '3.13'
 
@@ -256,7 +256,7 @@ jobs:
         # Maintaining cross-platform access is desirable so the code can be
         # easily copied to a multi-platform workflow. NUGET_FEED_URL is set
         # here to keep the vcpkg cache environment variables together.
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           # JSON in use here. #<comments> in the script will break it.
           # Pre-installed vcpkg location is indicated by a non-standard env.
@@ -321,7 +321,7 @@ jobs:
       # job would attempt to upload a same-named artifact.
       - name: Upload artifact Install Package
         if: matrix.options.package == 'YES'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: KTX-Software-${{env.PACKAGE_NAME_SUFFIX}}
           path: ${{env.BUILD_DIR}}/KTX-Software-*-*
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload artifact pyktx
         if: matrix.options.package == 'YES' && matrix.options.py == 'ON'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pyktx-${{env.PACKAGE_NAME_SUFFIX}}
           path: ${{env.BUILD_DIR}}/${{env.PYTHON_DIST_DIR}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -177,7 +177,7 @@ jobs:
       VULKAN_SDK_VER: ${{ matrix.vk_sdk_ver }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch all history to make sure tags are
           # included (used for version creation)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -187,7 +187,7 @@ jobs:
       # Should a specific version of Python ever be wanted, use this.
 #      - name: Set up Python
 #        if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
-#        uses: actions/setup-python@v5
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: '3.14'
 
@@ -229,7 +229,7 @@ jobs:
         # Maintaining cross-platform access is desirable so the code can be
         # easily copied to a multi-platform workflow. NUGET_FEED_URL is set
         # here to keep the vcpkg cache environment variables together.
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           # JSON in use here. #<comments> in the script will break it.
           # Pre-installed vcpkg location is indicated by a non-standard env.
@@ -305,7 +305,7 @@ jobs:
       # job would attempt to upload a same-named artifact.
       - name: Upload artifact Install Package
         if: matrix.options.package == 'YES'  && (matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: KTX-Software-${{env.PACKAGE_NAME_SUFFIX}}
           path: ${{env.BUILD_DIR}}/KTX-Software-*-*
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload artifact pyktx
         if:  matrix.options.py == 'ON' && matrix.options.package == 'YES' && (matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pyktx-${{env.PACKAGE_NAME_SUFFIX}}
           path: ${{env.BUILD_DIR}}/${{env.PYTHON_DIST_DIR}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -152,7 +152,7 @@ jobs:
       VULKAN_SDK: /Users/runner/VulkanSDK/${{ matrix.vulkan_sdk_version }}/macOS
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch all history to make sure tags are
           # included (used for version creation)

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -59,7 +59,7 @@ jobs:
       WERROR: ON
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Fetch all history to make sure tags are
         # included (used for version creation)

--- a/.github/workflows/publish-pyktx.yml
+++ b/.github/workflows/publish-pyktx.yml
@@ -78,7 +78,7 @@ jobs:
     #if: ${{ github.event.workflow_run.conclusion == 'success' }}
     # Maybe it is possible to test for a release tag here too.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up .netrc
         env:
@@ -116,7 +116,7 @@ jobs:
     #if: ${{ github.event.workflow_run.conclusion == 'success' }}
     # Maybe it is possible to test for a release tag here too.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up .netrc
         env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -115,7 +115,7 @@ jobs:
       VULKAN_SDK_VERSION: ${{ matrix.vulkan_sdk_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch all history to make sure tags are
           # included (used for version creation)

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -189,7 +189,7 @@ jobs:
       # job would attempt to upload a same-named artifact.
       - name: Upload artifact Install Package
         if: matrix.options.package == 'YES'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: KTX-Software-${{env.PACKAGE_NAME_SUFFIX}}
           path: ${{env.BUILD_DIR}}/KTX-Software-*-*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -211,7 +211,7 @@ jobs:
       # Maintaining cross-platform access is desirable so the code can be
       # easily copied to a multi-platform workflow. NUGET_FEED_URL is set
       # here to keep the vcpkg cache environment variables together.
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         # JSON in use here. #<comments> in the script will break it.
         # Pre-installed vcpkg location is indicated by a non-standard env.
@@ -264,7 +264,7 @@ jobs:
     # Install a version that works.
     - name: Set up Python 3.12
       if: matrix.options.py == 'ON' && matrix.check_mkvk != 'ONLY'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -349,7 +349,7 @@ jobs:
     # job would attempt to upload a same-named artifact.
     - name: Upload artifact Install Package
       if: matrix.options.package == 'YES' && matrix.toolset == 'CLangCL'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: KTX-Software-${{env.KTX_VERSION}}-Windows-${{matrix.arch}}
         path: ${{env.BUILD_DIR}}/KTX-Software-*.exe*
@@ -357,7 +357,7 @@ jobs:
 
     - name: Upload artifact pyktx
       if: matrix.options.package == 'YES' && matrix.options.py == 'ON' && matrix.toolset == 'CLangCL'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pyktx-${{env.KTX_VERSION}}-Windows-${{matrix.arch}}
         path: ${{env.BUILD_DIR}}/${{env.PYTHON_DIST_DIR}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -164,7 +164,7 @@ jobs:
       VULKAN_SDK_VERSION: 1.4.313.2
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Fetch all history to make sure tags are
         # included (used for version creation)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -247,7 +247,7 @@ jobs:
 
     - name: Set up JDK.
       if: matrix.options.jni == 'ON' && matrix.check_mkvk != 'ONLY'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
to avoid deprecated Node.js version 20, with the exception of ts-graphviz/setup-graphviz for which a
Node.js 24 compliant version is not yet available.