### PR TITLE
Update setup-graphviz for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,7 +105,7 @@ jobs:
       uses: ssciwr/doxygen-install@v1
 
     - name: Install Graphviz
-      uses: ts-graphviz/setup-graphviz@v2
+      uses: MarkCallow/setup-graphviz@v3
 
     - name: Smudge dates (macOS and Ubuntu)
       if:  matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,7 +105,7 @@ jobs:
       uses: ssciwr/doxygen-install@v1
 
     - name: Install Graphviz
-      uses: MarkCallow/setup-graphviz@v3.0.0
+      uses: MarkCallow/setup-graphviz@v3
 
     - name: Smudge dates (macOS and Ubuntu)
       if:  matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,7 +105,7 @@ jobs:
       uses: ssciwr/doxygen-install@v1
 
     - name: Install Graphviz
-      uses: MarkCallow/setup-graphviz@v3
+      uses: MarkCallow/setup-graphviz@v3.0.0
 
     - name: Smudge dates (macOS and Ubuntu)
       if:  matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Install Graphviz
         if: matrix.options.doc == 'ON'
-        uses: ts-graphviz/setup-graphviz@v2
+        uses: MarkCallow/setup-graphviz@v3
 
       # Should a specific version of Python ever be wanted, use this.
 #      - name: Set up Python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -195,7 +195,7 @@ jobs:
 
     - name: Install Graphviz
       if: matrix.options.doc == 'ON'
-      uses: ts-graphviz/setup-graphviz@v2
+      uses: MarkCallow/setup-graphviz@v3
 
     - name: Install AzureSignTool
       if: matrix.check_mkvk != 'ONLY'


### PR DESCRIPTION
So CI builds will continue to function after Sep 16th 2026 when Node.js 20 will be removed from the runners. The changes will also simplify things after June 2nd when actions will be "forced to run to run with Node.js 24 by default".