### PR TITLE
Update install-nsis version to get fix for cloudflare blocking EnvVar.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -176,7 +176,7 @@ jobs:
       # Earlier runner images only have NSIS 3.08 so install latest everywhere.
       # Since v1.1.0 install-nsis also installs long string support.
       if: matrix.options.package == 'YES'
-      uses: repolevedavaj/install-nsis@v1.2
+      uses: repolevedavaj/install-nsis@v1.2.1
       with:
         nsis-version: '3.12'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,9 +174,9 @@ jobs:
     - name: Install NSIS
       # NSIS was removed from windows-2025 (windows-latest as of this writing).
       # Earlier runner images only have NSIS 3.08 so install latest everywhere.
-      # install-nsis v1.1.0 also installs long string support.
+      # Since v1.1.0 install-nsis also installs long string support.
       if: matrix.options.package == 'YES'
-      uses: repolevedavaj/install-nsis@v1.2.0
+      uses: repolevedavaj/install-nsis@v1.2
       with:
         nsis-version: '3.12'
 


### PR DESCRIPTION
Update the patch number because repolevedavaj/install-nsis has not created a tag that would allow use of a patch-less version number.

Fixes the CI failure caused by cloudflare now blocking EnvVar. See https://github.com/repolevedavaj/install-nsis/issues/44.