### PR TITLE
Improve HDR support in loadtests.

### DIFF
--- a/tests/loadtests/appfwSDL/GLAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/GLAppSDL.cpp
@@ -40,9 +40,43 @@
 void setWindowsIcon(SDL_Window *sdlWindow);
 #endif
 
+#define SUPPORT_HDR 0
+// GLAppSDL does not support HDR because:
+// - Apple's OpenGL does not expose the extensions for the compressed HDR formats, ASTC HDR
+//   and BC6H, even though the hardware supports them; thus HDR display is not very useful
+//   on those platforms;
+// - on Apple OSes, it is not possible to display HDR from the window created by SDL for OpenGL;
+//   to do so requires a window backed by a CAMetalLayer with its boolean field
+//   wantsExtendedDynamicRangeContent set to true; the SDL window has no CAMetalLayer;
+// - when the compositor on Apple OSes displays the content of a window that is not enabled
+//   for HDR, it copies the data to the display which then decodes it as if it was sRGB data;
+// - there is no portable way in SDL to determine if a window is HDR enabled, or not, so no way
+//   to distinguish between a GL_LINEAR renderbuffer being displayed as linear or being
+//   displayed as sRGB, as in the preceeding bullet, meaning correct color cannot be
+//   guaranteed;
+// - the author does not have suitable hardware to test how GNU/Linux and Windows handle
+//   HDR and whether it can be displayed from an SDL created window.
+//
+// The disabled code has been left in case it proves useful in the future.
+
 bool
 GLAppSDL::initialize(Args& args)
 {
+#if SUPPORT_HDR
+    const char* use_hdr_surface = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),
+                                                         "KTX_GL_LT_USE_HDR_SURFACE");
+    if (use_hdr_surface != nullptr && !SDL_strncasecmp(use_hdr_surface, "YES", 3))
+        hdr = true;
+
+    for (uint32_t i = 1; i < args.size(); i++) {
+        if (args[i].compare("--hdr") == 0) {
+            hdr = true;
+            args.erase(args.begin() + i--);
+            continue;
+        }
+    }
+#endif
+
     if (!AppBaseSDL::initialize(args))
         return false;
 
@@ -51,9 +85,30 @@ GLAppSDL::initialize(Args& args)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minorVersion);
     // On SDL3 this defaults to 8. On SDL2 it was 0.
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
-#if !defined(__EMSCRIPTEN__)
     if (majorVersion >= 3)
-      SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1);
+        SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1);
+#if SUPPORT_HDR
+    if (hdr) {
+#if SDL_PLATFORM_APPLE || SDL_PLATFORM_EMSCRIPTEN
+        //   Emscripten's WebGL-based OpenGL {,ES} does not support float framebuffers or
+        // HDR display.
+        //   HDR display from SDL OpenGL windows on Apple platforms is not supported as
+        // described in the comment where SUPPORT_HDR is defined.
+        std::stringstream message;
+        message << "Ignoring --hdr. HDR display is not supported on "
+                << (SDL_PLATFORM_APPLE ? "SDL with Apple" : "Emscripten")
+                << " OpenGL or OpenGL ES implementations.";
+        (void)SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, szName,
+                                       message.str().c_str(), NULL);
+#else
+        // Due to the author not having suitable hardware, whether HDR will be displayed correctly
+        // on Android, GNU/Linux or Windows is unknown.
+        SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 16);
+        SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 16);
+        SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 16);
+        SDL_GL_SetAttribute(SDL_GL_FLOATBUFFERS, 1);
+#endif
+    }
 #endif
 #if defined(DEBUG) && !defined(__EMSCRIPTEN__)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
@@ -153,8 +208,6 @@ GLAppSDL::initialize(Args& args)
         glewdll = SDL_LoadObject("glew32.dll");
 #endif
         if (glewdll == NULL) {
-            std::string sName(szName);
-
             (void)SDL_ShowSimpleMessageBox(
                 SDL_MESSAGEBOX_ERROR,
                 szName,
@@ -186,8 +239,6 @@ GLAppSDL::initialize(Args& args)
         }
 
         if (loadError) {
-            std::string sName(szName);
-
             (void)SDL_ShowSimpleMessageBox(
                 SDL_MESSAGEBOX_ERROR,
                 szName,
@@ -197,8 +248,6 @@ GLAppSDL::initialize(Args& args)
         }
         int iResult = pGlewInit();
         if (iResult != GLEW_OK) {
-            std::string sName(szName);
-
             (void)SDL_ShowSimpleMessageBox(
                           SDL_MESSAGEBOX_ERROR,
                           szName,

--- a/tests/loadtests/appfwSDL/GLAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/GLAppSDL.cpp
@@ -41,23 +41,27 @@ void setWindowsIcon(SDL_Window *sdlWindow);
 #endif
 
 #define SUPPORT_HDR 0
-// GLAppSDL does not support HDR because:
-// - Apple's OpenGL does not expose the extensions for the compressed HDR formats, ASTC HDR
-//   and BC6H, even though the hardware supports them; thus HDR display is not very useful
-//   on those platforms;
-// - on Apple OSes, it is not possible to display HDR from the window created by SDL for OpenGL;
-//   to do so requires a window backed by a CAMetalLayer with its boolean field
-//   wantsExtendedDynamicRangeContent set to true; the SDL window has no CAMetalLayer;
-// - when the compositor on Apple OSes displays the content of a window that is not enabled
-//   for HDR, it copies the data to the display which then decodes it as if it was sRGB data;
-// - there is no portable way in SDL to determine if a window is HDR enabled, or not, so no way
-//   to distinguish between a GL_LINEAR renderbuffer being displayed as linear or being
-//   displayed as sRGB, as in the preceeding bullet, meaning correct color cannot be
-//   guaranteed;
-// - the author does not have suitable hardware to test how GNU/Linux and Windows handle
-//   HDR and whether it can be displayed from an SDL created window.
+// GLAppSDL HDR support is disabled because:
+// 1. Apple's OpenGL does not expose the extensions for the compressed HDR formats, ASTC HDR
+//    and BC6H, even though the hardware supports them; thus HDR display is not very useful
+//    on those platforms;
+// 2. on Apple OSes, it is not possible to display HDR from the window created by SDL for OpenGL;
+//    to do so requires a window backed by a CAMetalLayer with its boolean field
+//    wantsExtendedDynamicRangeContent set to true; the SDL window has no CAMetalLayer;
+// 3. because of no. 1, investigating alternative ways of creating the window is not worth
+//    the time;
+// 4. when the compositor on Apple OSes displays the content of the GL_LINEAR, RGB16F backbuffer
+//    to the window created by SDL, it copies the data to the display which then decodes it as if
+//    it was sRGB data; maybe the compositor would handle it differently for an HDR-enabled
+//    window;
+// 5. there is no portable way in SDL to determine if a window is HDR enabled, or not, so no way
+//    to distinguish between a GL_LINEAR renderbuffer being displayed as linear or being
+//    displayed as sRGB, as in no. 4, meaning correct color cannot be guaranteed;
+// 6. the author does not have suitable hardware to test enabling HDR on Android, GNU/Linux
+//    and Windows or whether it can be displayed from an SDL created window.
 //
-// The disabled code has been left in case it proves useful in the future.
+// The disabled code has been left in place to provide a starting point for anyone who wants
+// to try on Android, GNU/Linux or Windows.
 
 bool
 GLAppSDL::initialize(Args& args)
@@ -92,8 +96,8 @@ GLAppSDL::initialize(Args& args)
 #if SDL_PLATFORM_APPLE || SDL_PLATFORM_EMSCRIPTEN
         //   Emscripten's WebGL-based OpenGL {,ES} does not support float framebuffers or
         // HDR display.
-        //   HDR display from SDL OpenGL windows on Apple platforms is not supported as
-        // described in the comment where SUPPORT_HDR is defined.
+        //   HDR display from SDL OpenGL windows on Apple platforms is not supported for
+        // the reasons described in the comment where SUPPORT_HDR is defined.
         std::stringstream message;
         message << "Ignoring --hdr. HDR display is not supported on "
                 << (SDL_PLATFORM_APPLE ? "SDL with Apple" : "Emscripten")
@@ -101,8 +105,6 @@ GLAppSDL::initialize(Args& args)
         (void)SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, szName,
                                        message.str().c_str(), NULL);
 #else
-        // Due to the author not having suitable hardware, whether HDR will be displayed correctly
-        // on Android, GNU/Linux or Windows is unknown.
         SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 16);
         SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 16);
         SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 16);

--- a/tests/loadtests/appfwSDL/GLAppSDL.h
+++ b/tests/loadtests/appfwSDL/GLAppSDL.h
@@ -30,10 +30,10 @@ class GLAppSDL : public AppBaseSDL {
                const int majorVersion,
                const int minorVersion)
             : AppBaseSDL(name),
+              hdr(false),
               profile(profile),
               majorVersion(majorVersion), minorVersion(minorVersion)
     {
-        appTitle = name;
         w_width = width;
         w_height = height;
     };
@@ -50,6 +50,8 @@ class GLAppSDL : public AppBaseSDL {
 
     int w_width;
     int w_height;
+
+    bool hdr;
 
     const SDL_GLProfile profile;
     const int majorVersion;

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -86,10 +86,10 @@ VulkanAppSDL::initialize(Args& args)
         {"extended-srgb", VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT},
     };
     std::string colorSpaceStr;
-    const char* use_hdr_surface = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),
-                                                         "KTX_VK_LT_USE_HDR_SURFACE");
 #if !SDL_PLATFORM_APPLE || SDL_PLATFORM_MACOS
     // Apple locked systems have no way to pass environment variables to bundled apps.
+    const char* use_hdr_surface = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),
+                                                         "KTX_VK_LT_USE_HDR_SURFACE");
     if (use_hdr_surface != nullptr && !SDL_strncasecmp(use_hdr_surface, "YES", 3))
         hdr = true;
     const char* css = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -79,21 +79,28 @@ bool
 VulkanAppSDL::initialize(Args& args)
 {
     static const std::unordered_map<std::string, VkColorSpaceKHR> csValues {
-        {"adobergb", VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT},
+        {"adobergb", VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT}, // Not supported on Apple devices.
         {"bt2020", VK_COLOR_SPACE_BT2020_LINEAR_EXT},
-        {"bt709", VK_COLOR_SPACE_BT709_LINEAR_EXT},
+        {"bt709", VK_COLOR_SPACE_BT709_LINEAR_EXT}, // Not supported on Apple devces.
         {"display-p3", VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT},
         {"extended-srgb", VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT},
     };
     std::string colorSpaceStr;
     const char* use_hdr_surface = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),
                                                          "KTX_VK_LT_USE_HDR_SURFACE");
+#if !SDL_PLATFORM_APPLE || SDL_PLATFORM_MACOS
+    // Apple locked systems have no way to pass environment variables to bundled apps.
     if (use_hdr_surface != nullptr && !SDL_strncasecmp(use_hdr_surface, "YES", 3))
         hdr = true;
     const char* css = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),
                                                  "KTX_VK_LT_SURFACE_COLOR_SPACE");
     if (css != nullptr) colorSpaceStr = css;
+#else
+    hdr = true;
+#endif
 
+    // Apple locked systems also have no way to pass command-line options to bundled apps.
+    // These are not disabled so that they can be changed when debugging.
     for (uint32_t i = 1; i < args.size(); i++) {
         if (args[i].compare("--validate") == 0) {
             validate = true;
@@ -105,6 +112,14 @@ VulkanAppSDL::initialize(Args& args)
             args.erase(args.begin() + i--);
             continue;
         }
+#if SDL_PLATFORM_APPLE && !SDL_PLATFORM_MACOS
+        // So hdr can be disabled when debugging, if necessary.
+        if (args[i].compare("++hdr") == 0) {
+            hdr = false;
+            args.erase(args.begin() + i--);
+            continue;
+        }
+#endif
         if (args[i].compare("--cs") == 0) {
             if (args.size() < i + 2) {
                 (void)SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, szName,
@@ -739,7 +754,6 @@ VulkanAppSDL::createSurface()
                                 VK_FORMAT_R16G16B16A16_SFLOAT,
                                 VulkanSwapchain::colorSpaceSelector::eSpecific,
                                 colorSpace);
-        // VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT, VK_COLOR_SPACE_BT2020_LINEAR_EXT
     } catch(unsupported_surface_format&) {
         std::string msg = "VulkanSwapchain::initSurface: ";
         msg += "No matching HDR surface format found. Reverting to SDR.";
@@ -990,6 +1004,12 @@ bool
 VulkanAppSDL::createSwapchain()
 {
     vkctx.swapchain.create(&w_width, &w_height, enableVSync);
+#if SDL_PLATFORM_APPLE && !SDL_PLATFORM_MACOS
+    extern void setWantsExtendedDynamicRangeContent(SDL_Window* window, bool enable);
+    if (hdr)
+        setWantsExtendedDynamicRangeContent(pswMainWindow, hdr);
+#endif
+
     return true;
 } // createSwapchain
 

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -87,11 +87,11 @@ VulkanAppSDL::initialize(Args& args)
     };
     std::string colorSpaceStr;
     const char* use_hdr_surface = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),
-                                                         "VK_USE_HDR_SURFACE");
+                                                         "KTX_VK_LT_USE_HDR_SURFACE");
     if (use_hdr_surface != nullptr && !SDL_strncasecmp(use_hdr_surface, "YES", 3))
         hdr = true;
     const char* css = SDL_GetEnvironmentVariable(SDL_GetEnvironment(),
-                                                 "VK_SURFACE_COLOR_SPACE");
+                                                 "KTX_VK_LT_SURFACE_COLOR_SPACE");
     if (css != nullptr) colorSpaceStr = css;
 
     for (uint32_t i = 1; i < args.size(); i++) {
@@ -124,7 +124,7 @@ VulkanAppSDL::initialize(Args& args)
         } else {
             std::stringstream msg;
             msg << "Invalid color space, " << colorSpaceStr
-                << ", given for --cs or VK_SURFACE_COLOR_SPACE";
+                << ", given for --cs or KTX_VK_LT_SURFACE_COLOR_SPACE";
             (void)SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, szName,
                                            msg.str().c_str(), NULL);
             return false;

--- a/tests/loadtests/appfwSDL/cocoaSetEDR.mm
+++ b/tests/loadtests/appfwSDL/cocoaSetEDR.mm
@@ -1,0 +1,32 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4 expandtab: */
+
+/*
+ * Copyright 2026 Mark Callow.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <Cocoa/Cocoa.h>
+#include <QuartzCore/QuartzCore.h>
+#include <SDL3/SDL.h>
+
+void
+setWantsExtendedDynamicRangeContent(SDL_Window* window, bool enable)
+{
+    SDL_PropertiesID wprops = SDL_GetWindowProperties(window);
+    NSInteger tag =
+      SDL_GetNumberProperty(wprops, SDL_PROP_WINDOW_COCOA_METAL_VIEW_TAG_NUMBER, 0);
+    NSWindow* nswindow =
+      (NSWindow*)SDL_GetPointerProperty(wprops, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+
+    NSView* contentView = nswindow.contentView;
+    NSArray* subviews = contentView.subviews;
+    for (NSView* view in subviews) {
+        if (view.tag == tag) {
+            CALayer* layer = view.layer;
+            if ([layer isKindOfClass:[CAMetalLayer class]]) {
+                ((CAMetalLayer*)layer).wantsExtendedDynamicRangeContent = enable;
+            }
+            break;
+        }
+    }
+}

--- a/tests/loadtests/appfwSDL/uikitSetEDR.mm
+++ b/tests/loadtests/appfwSDL/uikitSetEDR.mm
@@ -1,0 +1,30 @@
+/* -*- tab-width: 4; -*- */
+/* vi: set sw=2 ts=4 expandtab: */
+
+/*
+ * Copyright 2026 Mark Callow.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <UIKit/UIKit.h>
+#include <QuartzCore/QuartzCore.h>
+#include <SDL3/SDL.h>
+
+void
+setWantsExtendedDynamicRangeContent(SDL_Window* window, bool enable)
+{
+    SDL_PropertiesID wprops = SDL_GetWindowProperties(window);
+    NSInteger tag =
+      SDL_GetNumberProperty(wprops, SDL_PROP_WINDOW_UIKIT_METAL_VIEW_TAG_NUMBER, 0);
+    UIWindow* uiwindow =
+      (UIWindow*)SDL_GetPointerProperty(wprops, SDL_PROP_WINDOW_UIKIT_WINDOW_POINTER, nullptr);
+
+    UIView *metalView = [uiwindow viewWithTag:tag];
+    if (metalView != nil) {
+        CALayer* layer = metalView.layer;
+        if ([layer isKindOfClass:[CAMetalLayer class]]) {
+            if (@available(iOS 16.0, *)) {
+              ((CAMetalLayer*)layer).wantsExtendedDynamicRangeContent = enable;
+            }
+        }
+    }
+}

--- a/tests/loadtests/glloadtests/GLLoadTests.cpp
+++ b/tests/loadtests/glloadtests/GLLoadTests.cpp
@@ -42,16 +42,24 @@ bool
 GLLoadTests::initialize(Args& args)
 {
     bool explicitlyLoadOpenGL = false;
+
+    if (!GLAppSDL::initialize(args))
+        return false;
+
     for (uint32_t i = 1; i < args.size(); i++) {
         if (args[i].compare("--load-gl") == 0) {
             explicitlyLoadOpenGL = true;
             args.erase(args.begin() + i);
             break;
         }
+        if (args[i].substr(0, 2).compare("--") == 0) {
+            std::stringstream message;
+            message << "Unknown option, " << args[i] << ", specified";
+            SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+                szName, message.str().c_str(), NULL);
+            return false;
+        }
     }
-
-    if (!GLAppSDL::initialize(args))
-        return false;
 
     // --load-gl allows testing of explicitly loading the OpenGL pointers.
     // Default is for ktxTexture_GLUpload to implicitly load them.

--- a/tests/loadtests/glloadtests/shader-based/DrawTexture.cpp
+++ b/tests/loadtests/glloadtests/shader-based/DrawTexture.cpp
@@ -92,10 +92,7 @@ DrawTexture::DrawTexture(uint32_t width, uint32_t height,
         throw std::runtime_error(message.str());
     }
 
-    if (ktxTexture_NeedsTranscoding(kTexture)) {
-        TextureTranscoder tc;
-        tc.transcode((ktxTexture2*)kTexture, transcodeTarget);
-    }
+    (void)transcodeIfNeeded(kTexture);
 
     ktxresult = ktxTexture_GLUpload(kTexture, &gnTexture, &target, &glerror);
 
@@ -269,12 +266,12 @@ DrawTexture::DrawTexture(uint32_t width, uint32_t height,
     glBindVertexArray(0);
 
     const GLchar *actualColorFs, *actualDecalFs;
-    if (framebufferColorEncoding() == GL_LINEAR) {
-        actualColorFs = pszColorSrgbEncodeFs;
-        actualDecalFs = pszDecalSrgbEncodeFs;
-    } else {
+    if (colorEncodingSRGBOrTrueLinear()) {
         actualColorFs = pszColorFs;
         actualDecalFs = pszDecalFs;
+    } else {
+        actualColorFs = pszColorSrgbEncodeFs;
+        actualDecalFs = pszDecalSrgbEncodeFs;
     }
     try {
         makeShader(GL_VERTEX_SHADER, pszVs, &gnVs);

--- a/tests/loadtests/glloadtests/shader-based/EncodeTexture.cpp
+++ b/tests/loadtests/glloadtests/shader-based/EncodeTexture.cpp
@@ -112,10 +112,7 @@ EncodeTexture::EncodeTexture(uint32_t width, uint32_t height,
         }
     }
 
-    if (ktxTexture2_NeedsTranscoding(kTexture)) {
-        TextureTranscoder tc;
-        tc.transcode((ktxTexture2*)kTexture);
-    }
+    (void)transcodeIfNeeded(ktxTexture(kTexture));
 
     ktxresult = ktxTexture_GLUpload(ktxTexture(kTexture), &gnTexture, &target,
                                     &glerror);
@@ -208,10 +205,10 @@ EncodeTexture::EncodeTexture(uint32_t width, uint32_t height,
                  cube_index_buffer, GL_STATIC_DRAW);
 
     const GLchar* actualDecalFs;
-    if (framebufferColorEncoding() == GL_LINEAR) {
-        actualDecalFs = pszDecalSrgbEncodeFs;
-    } else {
+    if (colorEncodingSRGBOrTrueLinear()) {
         actualDecalFs = pszDecalFs;
+    } else {
+        actualDecalFs = pszDecalSrgbEncodeFs;
     }
     try {
         makeShader(GL_VERTEX_SHADER, pszVs, &gnVs);

--- a/tests/loadtests/glloadtests/shader-based/GL3LoadTestSample.cpp
+++ b/tests/loadtests/glloadtests/shader-based/GL3LoadTestSample.cpp
@@ -118,82 +118,6 @@ GL3LoadTestSample::makeProgram(GLuint vs, GLuint fs, GLuint* program)
     }
 }
 
-#if !defined(GL_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT)
-#define GL_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT 0x8A54
-#define GL_COMPRESSED_RGB_PVRTC_2BPPV1_IMG  0x8C01
-#define GL_COMPRESSED_RGBA_PVRTC_2BPPV2_IMG 0x9137
-#endif
-#if !defined(GL_COMPRESSED_RG_RGTC2)
-#define GL_COMPRESSED_RG_RGTC2              0x8DBD
-#endif
-#if !defined(GL_COMPRESSED_RGBA_BPTC_UNORM)
-#define GL_COMPRESSED_RGBA_BPTC_UNORM       0x8E8C
-#endif
-#if !defined(GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT)
-#define GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT 0x8E8E
-#endif
-
-void
-GL3LoadTestSample::determineCompressedTexFeatures(compressedTexFeatures& features)
-{
-    ktx_int32_t numCompressedFormats;
-
-    memset(&features, false, sizeof(features));
-
-    glGetIntegerv(GL_NUM_COMPRESSED_TEXTURE_FORMATS, &numCompressedFormats);
-    GLint* formats = new GLint[numCompressedFormats];
-    glGetIntegerv(GL_COMPRESSED_TEXTURE_FORMATS, formats);
-
-    for (ktx_int32_t i = 0; i < numCompressedFormats; i++) {
-        if (formats[i] == GL_COMPRESSED_RGBA8_ETC2_EAC)
-            features.etc2 = true;
-        if (formats[i] == GL_ETC1_RGB8_OES)
-            features.etc1 = true;
-        if (formats[i] == GL_COMPRESSED_RGBA_S3TC_DXT5_EXT)
-            features.bc3 = true;
-        if (formats[i] == GL_COMPRESSED_RG_RGTC2)
-            features.rgtc = true;
-        if (formats[i] == GL_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT)
-            features.pvrtc_srgb = true;
-        if (formats[i] == GL_COMPRESSED_RGB_PVRTC_2BPPV1_IMG)
-            features.pvrtc1 = true;
-        if (formats[i] == GL_COMPRESSED_RGBA_PVRTC_2BPPV2_IMG)
-            features.pvrtc2 = true;
-        if (formats[i] == GL_COMPRESSED_RGBA_ASTC_4x4_KHR)
-            features.astc_ldr = true;
-        if (formats[i] == GL_COMPRESSED_RGBA_BPTC_UNORM)
-            features.bc7 = true;
-        if (formats[i] == GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT)
-            features.bc6h = true;
-    }
-    delete[] formats;
-
-    // Just in case COMPRESSED_TEXTURE_FORMATS didn't return anything.
-    // There is no ETC2 extension. It went into core in OpenGL ES 2.0.
-    // ARB_es_compatibility is not a good indicator. ETC2 could be supported
-    // by software decompression. Better to report unsupported.
-    if (!features.etc1 && SDL_GL_ExtensionSupported("GL_OES_compressed_ETC1_RGB8_texture"))
-        features.etc1 = true;;
-    if (!features.bc3 && SDL_GL_ExtensionSupported("GL_EXT_texture_compression_s3tc"))
-        features.bc3 = true;
-    if (!features.rgtc && SDL_GL_ExtensionSupported("GL_ARB_texture_compression_rgtc"))
-        features.rgtc = true;
-    if (!features.pvrtc1 && SDL_GL_ExtensionSupported("GL_IMG_texture_compression_pvrtc"))
-        features.pvrtc1 = true;
-    if (!features.pvrtc2 && SDL_GL_ExtensionSupported("GL_IMG_texture_compression_pvrtc2"))
-        features.pvrtc2 = true;
-    if (!features.pvrtc_srgb && SDL_GL_ExtensionSupported("GL_EXT_pvrtc_sRGB"))
-        features.pvrtc_srgb = true;
-    if (!(features.bc7 && features.bc6h) && SDL_GL_ExtensionSupported("GL_ARB_texture_compression_bptc"))
-        features.bc6h = features.bc7 = true;
-    if (!features.astc_ldr && SDL_GL_ExtensionSupported("GL_KHR_texture_compression_astc_ldr"))
-        features.astc_ldr = true;
-    // The only way to identify this support is the extension string.
-    // The format name is the same.
-    if (SDL_GL_ExtensionSupported("GL_KHR_texture_compression_astc_hdr"))
-        features.astc_hdr = true;
-}
-
 bool
 GL3LoadTestSample::contextSupportsSwizzle()
 {
@@ -222,14 +146,15 @@ GL3LoadTestSample::contextSupportsSwizzle()
   #define SDL_PLATFORM_IOS 0
 #endif
 
+#if !defined(GL_BACK_LEFT)
+#define GL_BACK_LEFT 0x0402
+#endif
+
 GLint
 GL3LoadTestSample::framebufferColorEncoding()
 {
     GLint encoding = GL_SRGB;
     GLenum attachment;
-#if !defined(GL_BACK_LEFT)
-#define GL_BACK_LEFT 0x0402
-#endif
     if (strstr((const char*)glGetString(GL_VERSION), "GL ES") == NULL)
         attachment = GL_BACK_LEFT;
     else if (SDL_PLATFORM_IOS)
@@ -242,6 +167,75 @@ GL3LoadTestSample::framebufferColorEncoding()
                                       GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING,
                                       &encoding);
     return encoding;
+}
+
+#define SUPPORT_HDR 0
+#if SUPPORT_HDR
+GLint
+GL3LoadTestSample::framebufferAttachmentType()
+{
+    GLint type;
+    GLenum attachment;
+    if (strstr((const char*)glGetString(GL_VERSION), "GL ES") == NULL)
+        attachment = GL_BACK_LEFT;
+    else if (SDL_PLATFORM_IOS)
+        // iOS does not use the default framebuffer.
+        attachment = GL_COLOR_ATTACHMENT0;
+    else
+        attachment = GL_BACK;
+
+    glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, attachment,
+                                      GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE,
+                                      &type);
+    return type;
+}
+#endif
+
+/*
+ * @internal
+ * @~English
+ * @brief Check color encoding.
+ *
+ * This provides a central place for tests to determine whether test samples need to do
+ * their own sRGB encoding to get correct color.
+ *
+ * GLAppSDL creates an GL_SRGB framebuffer for LDR rendering, if supported by the
+ * implementation. In this case framebufferColorEncoding() will return @c GL_SRGB. On
+ * implementations that do not support @c GL_SRGB framebuffers, e.g. WebGL, we have found
+ * that @c GL_LINEAR framebuffers are simply copied to the display which decodes the content
+ * as if sRGB. In such cases test samples must do their own sRGB encoding to work around
+ * these fake GL_LINEAR buffers.
+ *
+ * GLAppSDL creates a GL_LINEAR half-float or float framebuffer for HDR rendering.
+ */
+bool
+GL3LoadTestSample::colorEncodingSRGBOrTrueLinear()
+{
+    if (framebufferColorEncoding() == GL_SRGB)
+        return true;
+
+    // Encoding is GL_LINEAR.
+#if SUPPORT_HDR
+    // This test is intended to distinguish a half-float or float and therefore genuinely
+    // GL_LINEAR framebuffer from the fake ones. Unfortunately we have observed on Apple
+    // OSes that when HDR display is not enabled for a window, the compositor clamps and
+    // copies the data to the display where it is decoded as sRGB. There is no portable
+    // query in SDL that would let us determine if the window is HDR enabled which would
+    // be needed to fix this test.
+    //
+    // Due to inability to enable HDR display for SDL OpenGL windows on Apple OSes and
+    // to the author's lack of suitable hardware for other platforms, it is only
+    // an educated guess that a half-float or float GL_LINEAR framebuffer displayed
+    // as HDR will be genuinely linear.
+    //
+    GLint colorType = framebufferAttachmentType();
+    if (colorType == GL_SIGNED_NORMALIZED || colorType == GL_UNSIGNED_NORMALIZED)
+        return false;
+    else
+        return true;
+#else
+    return false;
+#endif
 }
 
 // Emscripten assimp port not yet available.
@@ -276,6 +270,18 @@ GL3LoadTestSample::loadMesh(std::string,
 {
 }
 #endif
+
+bool
+GL3LoadTestSample::transcodeIfNeeded(ktxTexture* kTexture)
+{
+    if (ktxTexture_IsTranscodable(kTexture)) {
+        // ktxTexture2_TranscodeBasis has an early out for the UASTC HDR 4x4 to ASTC HDR 4x4
+        // so just call the transcoder.
+        transcoder.transcode((ktxTexture2*)kTexture);
+        return true;
+    }
+    return false;
+}
 
 
 

--- a/tests/loadtests/glloadtests/shader-based/GL3LoadTestSample.h
+++ b/tests/loadtests/glloadtests/shader-based/GL3LoadTestSample.h
@@ -13,6 +13,8 @@
 #include "LoadTestSample.h"
 #include "mygl.h"
 #include "utils/GLMeshLoader.hpp"
+#include "GLTextureTranscoder.hpp"
+
 
 #define ARRAY_LEN(a) (sizeof(a) / sizeof(a[0]))
 
@@ -31,6 +33,8 @@ class GL3LoadTestSample : public LoadTestSample {
     virtual void resize(uint32_t width, uint32_t height) = 0;
     virtual void run(uint32_t msTicks) = 0;
 
+    bool transcodeIfNeeded(ktxTexture* kTexture);
+
     //virtual void getOverlayText(TextOverlay *textOverlay) { };
 
     typedef LoadTestSample* (*PFN_create)(uint32_t width, uint32_t height,
@@ -48,22 +52,10 @@ class GL3LoadTestSample : public LoadTestSample {
     std::string ktxfilename;
     int externalFile = 0;
 
-    struct compressedTexFeatures {
-        bool astc_ldr;
-        bool astc_hdr;
-        bool bc6h;
-        bool bc7;
-        bool etc1;
-        bool etc2;
-        bool bc3;
-        bool pvrtc1;
-        bool pvrtc_srgb;
-        bool pvrtc2;
-        bool rgtc;
-    };
+    TextureTranscoder transcoder;
 
-    static void determineCompressedTexFeatures(compressedTexFeatures& features);
-    static GLint framebufferColorEncoding();
+    static bool colorEncodingSRGBOrTrueLinear();
+
     void loadMesh(std::string filename, glMeshLoader::MeshBuffer& meshBuffer,
                   std::vector<glMeshLoader::VertexLayout> vertexLayout,
                   float scale);
@@ -71,6 +63,10 @@ class GL3LoadTestSample : public LoadTestSample {
     static void makeShader(GLenum type, const GLchar* const source,
                            GLuint* shader);
     static void makeProgram(GLuint vs, GLuint fs, GLuint* program);
+
+  private:
+    static GLint framebufferColorEncoding();
+    static GLint framebufferAttachmentType();
 };
 
 #endif /* GL3_LOAD_TEST_SAMPLE_H */

--- a/tests/loadtests/glloadtests/shader-based/InstancedSampleBase.cpp
+++ b/tests/loadtests/glloadtests/shader-based/InstancedSampleBase.cpp
@@ -128,11 +128,7 @@ InstancedSampleBase::InstancedSampleBase(uint32_t width, uint32_t height,
         throw std::runtime_error(message.str());
     }
 
-    if (ktxTexture_NeedsTranscoding(kTexture)) {
-        transcodeTarget = KTX_TTF_NOSELECTION;
-        TextureTranscoder tc;
-        tc.transcode((ktxTexture2*)kTexture, transcodeTarget);
-    }
+    (void)transcodeIfNeeded(kTexture);
 
     ktxresult = ktxTexture_GLUpload(kTexture, &gnTexture, &texTarget,
                                     &glerror);

--- a/tests/loadtests/glloadtests/shader-based/Texture3d.cpp
+++ b/tests/loadtests/glloadtests/shader-based/Texture3d.cpp
@@ -81,11 +81,11 @@ Texture3d::Texture3d(uint32_t width, uint32_t height,
 
     fs.push_back(pszInstancingFsDeclarations);
     fs.push_back(pszFsSampler3dDeclaration);
-    if (framebufferColorEncoding() == GL_LINEAR) {
+    if (colorEncodingSRGBOrTrueLinear()) {
+        fs.push_back(pszInstancingFsMain);
+    } else {
         fs.push_back(pszSrgbEncodeFunc);
         fs.push_back(pszInstancingSrgbEncodeFsMain);
-    } else {
-        fs.push_back(pszInstancingFsMain);;
     }
     vs.push_back(pszInstancingVsDeclarations);
     vs.push_back(psz3dVsMain);

--- a/tests/loadtests/glloadtests/shader-based/TextureArray.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TextureArray.cpp
@@ -80,11 +80,11 @@ TextureArray::TextureArray(uint32_t width, uint32_t height,
 
     fs.push_back(pszInstancingFsDeclarations);
     fs.push_back(pszFsArraySamplerDeclaration);
-    if (framebufferColorEncoding() == GL_LINEAR) {
+    if (colorEncodingSRGBOrTrueLinear()) {
+        fs.push_back(pszInstancingFsMain);;
+    } else {
         fs.push_back(pszSrgbEncodeFunc);
         fs.push_back(pszInstancingSrgbEncodeFsMain);
-    } else {
-        fs.push_back(pszInstancingFsMain);;
     }
     vs.push_back(pszInstancingVsDeclarations);
     vs.push_back(pszArrayVsMain);

--- a/tests/loadtests/glloadtests/shader-based/TextureCubemap.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TextureCubemap.cpp
@@ -271,11 +271,7 @@ TextureCubemap::TextureCubemap(uint32_t width, uint32_t height,
         throw std::runtime_error(message.str());
     }
 
-    if (ktxTexture_NeedsTranscoding(kTexture)) {
-        TextureTranscoder tc;
-        tc.transcode((ktxTexture2*)kTexture);
-        //transcoded = true;
-    }
+    (void)transcodeIfNeeded(kTexture);
 
     ktxresult = ktxTexture_GLUpload(kTexture,
                                     &gnCubemapTexture, &cubemapTexTarget,
@@ -612,12 +608,12 @@ TextureCubemap::preparePrograms()
     const GLchar* actualReflectFs;
     const GLchar* actualSkyboxFs;
 
-    if (framebufferColorEncoding() == GL_LINEAR) {
-        actualReflectFs = pszReflectSrgbEncodeFs;
-        actualSkyboxFs = pszSkyboxSrgbEncodeFs;
-    } else {
+    if (colorEncodingSRGBOrTrueLinear()) {
         actualReflectFs = pszReflectFs;
         actualSkyboxFs = pszSkyboxFs;
+    } else {
+        actualReflectFs = pszReflectSrgbEncodeFs;
+        actualSkyboxFs = pszSkyboxSrgbEncodeFs;
     }
     try {
         makeShader(GL_VERTEX_SHADER, pszReflectVs, &gnReflectVs);

--- a/tests/loadtests/glloadtests/shader-based/TextureMipmap.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TextureMipmap.cpp
@@ -105,11 +105,11 @@ TextureMipmap::TextureMipmap(uint32_t width, uint32_t height,
     InstancedSampleBase::ShaderSource vs;
 
     fs.push_back(pszLodFsDeclarations);
-    if (framebufferColorEncoding() == GL_LINEAR) {
+    if (colorEncodingSRGBOrTrueLinear()) {
+        fs.push_back(pszLodFsMain);;
+    } else {
         fs.push_back(pszSrgbEncodeFunc);
         fs.push_back(pszLodSrgbEncodeFsMain);
-    } else {
-        fs.push_back(pszLodFsMain);;
     }
     vs.push_back(pszInstancingVsDeclarations);
     vs.push_back(pszLodVsMain);

--- a/tests/loadtests/glloadtests/shader-based/TexturedCube.cpp
+++ b/tests/loadtests/glloadtests/shader-based/TexturedCube.cpp
@@ -159,10 +159,10 @@ TexturedCube::TexturedCube(uint32_t width, uint32_t height,
                  cube_index_buffer, GL_STATIC_DRAW);
 
     const GLchar* actualDecalFs;
-    if (framebufferColorEncoding() == GL_LINEAR) {
-        actualDecalFs = pszDecalSrgbEncodeFs;
-    } else {
+    if (colorEncodingSRGBOrTrueLinear()) {
         actualDecalFs = pszDecalFs;
+    } else {
+        actualDecalFs = pszDecalSrgbEncodeFs;
     }
     try {
         makeShader(GL_VERTEX_SHADER, pszVs, &gnVs);

--- a/tests/loadtests/glloadtests/utils/GLTextureTranscoder.hpp
+++ b/tests/loadtests/glloadtests/utils/GLTextureTranscoder.hpp
@@ -30,21 +30,24 @@ class TextureTranscoder {
     TextureTranscoder() {
         determineCompressedTexFeatures(deviceFeatures);
         if (deviceFeatures.astc_ldr)
-            defaultTf = KTX_TTF_ASTC_4x4_RGBA;
+            defaultLDRTf = KTX_TTF_ASTC_4x4_RGBA;
         else if (deviceFeatures.bc3)
-            defaultTf = KTX_TTF_BC1_OR_3;
+            defaultLDRTf = KTX_TTF_BC1_OR_3;
         else if (deviceFeatures.etc2)
-            defaultTf = KTX_TTF_ETC; // Let transcoder decide RGB or RGBA
+            defaultLDRTf = KTX_TTF_ETC; // Let transcoder decide RGB or RGBA
         else if (deviceFeatures.pvrtc1)
-            defaultTf = KTX_TTF_PVRTC1_4_RGBA;
+            defaultLDRTf = KTX_TTF_PVRTC1_4_RGBA;
         else if (deviceFeatures.etc1)
-            defaultTf = KTX_TTF_ETC1_RGB;
-        else {
-            std::stringstream message;
+            defaultLDRTf = KTX_TTF_ETC1_RGB;
+        else
+            defaultLDRTf = KTX_TTF_NOSELECTION;
 
-            message << "OpenGL implementation does not support any available transcode target.";
-            throw std::runtime_error(message.str());
-        }
+        if (deviceFeatures.astc_hdr)
+            defaultHDRTf = KTX_TTF_ASTC_HDR_4x4_RGBA;
+        else if (deviceFeatures.bc6h)
+            defaultHDRTf = KTX_TTF_BC6HU;
+        else
+            defaultHDRTf = KTX_TTF_NOSELECTION;
     }
 
     void transcode(ktxTexture2* kTexture,
@@ -55,12 +58,31 @@ class TextureTranscoder {
             tf = otf;
         } else {
             khr_df_model_e colorModel = ktxTexture2_GetColorModel_e(kTexture);
+            bool hdr = true;
             if (colorModel == KHR_DF_MODEL_UASTC && deviceFeatures.astc_ldr) {
                 tf = KTX_TTF_ASTC_4x4_RGBA;
+                hdr = false;
             } else if (colorModel == KHR_DF_MODEL_ETC1S && deviceFeatures.etc2) {
                 tf = KTX_TTF_ETC;
+                hdr = false;
+            } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_4x4
+                       && deviceFeatures.astc_hdr) {
+                tf = KTX_TTF_ASTC_HDR_4x4_RGBA;
+            } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_6x6
+                       && deviceFeatures.astc_hdr) {
+                tf = KTX_TTF_ASTC_HDR_6x6_RGBA;
+            } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_4x4
+                    || colorModel == KHR_DF_MODEL_UASTC_HDR_6x6) {
+                    tf = defaultHDRTf;
             } else {
-                tf = defaultTf;
+                    tf = defaultLDRTf;
+            }
+            if (tf == KTX_TTF_NOSELECTION) {
+                std::stringstream message;
+
+                message << "This OpenGL implementation does not support any available"
+                        << (hdr ? " HDR " : " LDR ") << "transcode target.";
+                throw std::runtime_error(message.str());
             }
         }
         ktxresult = ktxTexture2_TranscodeBasis(kTexture, tf, 0);
@@ -75,7 +97,8 @@ class TextureTranscoder {
     }
 
   protected:
-    ktx_transcode_fmt_e defaultTf;
+    ktx_transcode_fmt_e defaultLDRTf;
+    ktx_transcode_fmt_e defaultHDRTf;
 
     struct compressedTexFeatures {
         bool astc_ldr;

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -182,7 +182,7 @@ add_executable( vkloadtests
 )
 
 # Keep this in case something changes in the Vulkan implementation and we need to
-# explicitly set wantsExtendedDynamicRangeContent as we have to on locked OSes.
+# explicitly set wantsExtendedDynamicRangeContent as we must on locked OSes.
 #if(APPLE_MAC_OS)
 #    target_sources(
 #        vkloadtests

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -181,6 +181,24 @@ add_executable( vkloadtests
     vkloadtests.cmake
 )
 
+# Keep this in case something changes in the Vulkan implementation and we need to
+# explicitly set wantsExtendedDynamicRangeContent as we have to on locked OSes.
+#if(APPLE_MAC_OS)
+#    target_sources(
+#        vkloadtests
+#    PUBLIC
+#        appfwSDL/cocoaSetEDR.mm
+#    )
+#endif()
+if(APPLE_LOCKED_OS)
+    target_sources(
+        vkloadtests
+    PUBLIC
+        appfwSDL/uikitSetEDR.mm
+    )
+endif()
+
+
 set_code_sign(vkloadtests)
 
 # If VulkanAppSDL is ever made into its own target change the target here.

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "VulkanLoadTestSample.h"
-#include "VulkanTextureTranscoder.hpp"
 
 #include <random>
 #include <unordered_map>
@@ -195,8 +194,7 @@ VulkanLoadTestSample::transcodeIfNeeded(ktxTexture* kTexture)
     if (ktxTexture_IsTranscodable(kTexture)) {
         // ktxTexture2_TranscodeBasis has an early out for the UASTC HDR 4x4 to ASTC HDR 4x4
         // so just call the transcoder.
-        TextureTranscoder tc(vkctx);
-        tc.transcode((ktxTexture2*)kTexture);
+        transcoder.transcode((ktxTexture2*)kTexture);
         return true;
     }
     return false;

--- a/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
+++ b/tests/loadtests/vkloadtests/VulkanLoadTestSample.h
@@ -13,6 +13,7 @@
 #include "LoadTestSample.h"
 #include "VulkanAppSDL.h"
 #include "VulkanContext.h"
+#include "VulkanTextureTranscoder.hpp"
 // MeshLoader needs vulkantools.h to be already included. It is included by
 // vulkantextoverlay.hpp via VulkanAppSDL.h.
 #include "utils/VulkanMeshLoader.hpp"
@@ -44,7 +45,7 @@ class VulkanLoadTestSample : public LoadTestSample {
                      /* const char* const szArgs, */
                      const std::string sBasePath, int32_t yflip = -1)
            : LoadTestSample(width, height, /*szArgs,*/ sBasePath, yflip),
-             vkctx(vkctx),
+             vkctx(vkctx), transcoder(vkctx),
              defaultClearColor(std::array<float,4>({0.025f, 0.025f, 0.025f, 1.0f}))
     {
     }
@@ -136,6 +137,7 @@ class VulkanLoadTestSample : public LoadTestSample {
     };
 
     VulkanContext& vkctx;
+    TextureTranscoder transcoder;
 
     // Saved for clean-up
     std::vector<VkShaderModule> shaderModules;

--- a/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
@@ -58,6 +58,13 @@ VulkanLoadTests::initialize(Args& args)
         return false;
 
     for (auto it = args.begin() + 1; it != args.end(); it++) {
+        if (it->substr(0, 2).compare("--") == 0) {
+            std::stringstream message;
+            message << "Unknown option, " << *it << ", specified";
+            SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+                szName, message.str().c_str(), NULL);
+            return false;
+        }
         infiles.push_back(*it);
     }
     if (infiles.size() > 0) {

--- a/tests/loadtests/vkloadtests/resources/ios/Info.plist.in
+++ b/tests/loadtests/vkloadtests/resources/ios/Info.plist.in
@@ -46,10 +46,5 @@
     </array>
     <key>UIApplicationSupportsIndirectInputEvents</key>
     <string>YES</string>
-    <key>LSEnvironment</key>
-    <dict>
-        <key>KTX_VK_LT_USE_HDR_SURFACE</key>
-        <string>YES</string>
-    </dict>
 </dict>
 </plist>

--- a/tests/loadtests/vkloadtests/resources/ios/Info.plist.in
+++ b/tests/loadtests/vkloadtests/resources/ios/Info.plist.in
@@ -48,9 +48,8 @@
     <string>YES</string>
     <key>LSEnvironment</key>
     <dict>
-        <key>VK_USE_HDR_SURFACE</key>
+        <key>KTX_VK_LT_USE_HDR_SURFACE</key>
         <string>YES</string>
     </dict>
-
 </dict>
 </plist>

--- a/tests/loadtests/vkloadtests/resources/mac/Info.plist.in
+++ b/tests/loadtests/vkloadtests/resources/mac/Info.plist.in
@@ -80,7 +80,7 @@
     <array/>
     <key>LSEnvironment</key>
     <dict>
-        <key>VK_USE_HDR_SURFACE</key>
+        <key>KTX_VK_LT_USE_HDR_SURFACE</key>
         <string>YES</string>
     </dict>
 </dict>

--- a/tests/loadtests/vkloadtests/utils/VulkanTextureTranscoder.hpp
+++ b/tests/loadtests/vkloadtests/utils/VulkanTextureTranscoder.hpp
@@ -27,7 +27,7 @@ class TextureTranscoder {
         } else {
             std::stringstream message;
 
-            message << "Vulkan implementation does not support any available SDR transcode target.";
+            message << "Vulkan implementation does not support any available LDR transcode target.";
             throw std::runtime_error(message.str());
         }
         if (vkctx.gpuFeatureAstcHdr)
@@ -36,28 +36,32 @@ class TextureTranscoder {
             defaultHDRTf = KTX_TTF_BC6HU;
     }
 
-    void transcode(ktxTexture2* kTexture) {
+    void transcode(ktxTexture2* kTexture,
+                   ktx_transcode_fmt_e otf = KTX_TTF_NOSELECTION) {
         KTX_error_code ktxresult;
         ktx_transcode_fmt_e tf;
-        khr_df_model_e colorModel = ktxTexture2_GetColorModel_e(kTexture);
-
-        if (colorModel == KHR_DF_MODEL_UASTC
-            && vkctx.gpuFeatures.textureCompressionASTC_LDR) {
-            tf = KTX_TTF_ASTC_4x4_RGBA;
-        } else if (colorModel == KHR_DF_MODEL_ETC1S
-                   && vkctx.gpuFeatures.textureCompressionETC2) {
-            tf = KTX_TTF_ETC;
-        } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_4x4
-                   && vkctx.gpuFeatureAstcHdr) {
-            tf = KTX_TTF_ASTC_HDR_4x4_RGBA;
-        } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_6x6
-                   && vkctx.gpuFeatureAstcHdr) {
-            tf = KTX_TTF_ASTC_HDR_6x6_RGBA;
-        } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_4x4
-                || colorModel == KHR_DF_MODEL_UASTC_HDR_6x6) {
-                tf = defaultHDRTf;
+        if (otf != KTX_TTF_NOSELECTION) {
+            tf = otf;
         } else {
-                tf = defaultLDRTf;
+            khr_df_model_e colorModel = ktxTexture2_GetColorModel_e(kTexture);
+            if (colorModel == KHR_DF_MODEL_UASTC
+                && vkctx.gpuFeatures.textureCompressionASTC_LDR) {
+                tf = KTX_TTF_ASTC_4x4_RGBA;
+            } else if (colorModel == KHR_DF_MODEL_ETC1S
+                       && vkctx.gpuFeatures.textureCompressionETC2) {
+                tf = KTX_TTF_ETC;
+            } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_4x4
+                       && vkctx.gpuFeatureAstcHdr) {
+                tf = KTX_TTF_ASTC_HDR_4x4_RGBA;
+            } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_6x6
+                       && vkctx.gpuFeatureAstcHdr) {
+                tf = KTX_TTF_ASTC_HDR_6x6_RGBA;
+            } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_4x4
+                    || colorModel == KHR_DF_MODEL_UASTC_HDR_6x6) {
+                    tf = defaultHDRTf;
+            } else {
+                    tf = defaultLDRTf;
+            }
         }
 
         ktxresult = ktxTexture2_TranscodeBasis(kTexture, tf, 0);


### PR DESCRIPTION
The headline fix enables HDR display on i{,Pad}OS devices working around what appears to be a MoltenVK bug.

Other fixes:
* prefix environment variables for hdr and color space in vkloadtests to avoid possible confusion with Vulkan SDK variables
* remove LSEnvironment setting from i{,Pad}OS properties as it it only supported on macOS
* add optional transcode format parameter to VulkanTextureTranscoder to match GLTextureTranscoder
* add transcoder objects to VulkanLoadTestSample and GLLoadTestSample so they are only initialized once
* add HDR format support to GLTextureTranscoder
* add `transcodeIfNeeded` function to GLLoadTestSample and make all samples use it
* check for unknown command line options during initialization of vkloadtests and {es,gl}3loadtest apps.
* add `colorEncodingSRGBOrTrueLinear` function to GLLoadTestSample and make all samples use it to centralize the determination code
* add disabled HDR support to GLAppSDL, disabled because it can't be supported on Apple devices and can't be tested on other OSes due to lack of hardware.
