### PR TITLE
Write PNG colorspace info for linear inputs.

### DIFF
--- a/tools/ktx/command_extract.cpp
+++ b/tools/ktx/command_extract.cpp
@@ -881,6 +881,12 @@ void CommandExtract::savePNG(std::string filepath, bool appendExtension,
     if (format.transfer() == KHR_DF_TRANSFER_SRGB) {
         state.info_png.srgb_defined = 1;
         state.info_png.srgb_intent = 0;
+    } else if (format.transfer() == KHR_DF_TRANSFER_LINEAR
+               || format.transfer() == KHR_DF_TRANSFER_UNSPECIFIED) {
+        // Virtually every tool takes absence of colorspace info to mean sRGB so write gamma 1.
+        state.info_png.srgb_defined = 0;
+        state.info_png.gama_defined = 1;
+        state.info_png.gama_gamma = 100000;
     }
 
     // Output primaries as cHRM chunk


### PR DESCRIPTION
Update CTS ref.

Fixes #1194.

Thanks to @walcht for the patch.

The good news is that a bunch of tests failed. I.e the tests include many linear inputs. Now that the golden files have been regenerated, the CTS will flag any regression. 