### PR TITLE
Fix use of StreambufStream for output by ktx tool suite

### DIFF
--- a/lib/include/ktx.h
+++ b/lib/include/ktx.h
@@ -859,7 +859,7 @@ typedef ktx_uint32_t ktxTextureCreateFlags;
  * using the 64-bit stream functions.
  */
 #if defined(_MSC_VER) && defined(_WIN64)
-  typedef unsigned __int64 ktx_off_t;
+  typedef __int64 ktx_off_t;
 #else
   typedef   off_t ktx_off_t;
 #endif

--- a/tests/streamtests/streamtests.cc
+++ b/tests/streamtests/streamtests.cc
@@ -260,7 +260,8 @@ TEST_F(ktxStreamTest, CanCreateKtx1FromCppStream)
     StreambufStreamTest ktx1Stream{std::move(_ktx1Streambuf), std::ios::in};
     KtxTexture<ktxTexture1> texture1;
 
-    KTX_error_code err = ktxTexture1_CreateFromStream(ktx1Stream.stream(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
+    KTX_error_code err = ktxTexture1_CreateFromStream(ktx1Stream.stream(),
+                                                      KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                                       texture1.pHandle());
     EXPECT_EQ(err, KTX_SUCCESS) << "Failed to create KTX1 from C++ stream: " << ktxErrorString(err);
     ASSERT_NE(texture1, nullptr) << "Newly-created KTX1 is null";
@@ -272,21 +273,92 @@ TEST_F(ktxStreamTest, CanCreateKtx2FromCppStream)
     StreambufStreamTest ktx2Stream{std::move(_ktx2Streambuf), std::ios::in};
     KtxTexture<ktxTexture2> texture2;
 
-    KTX_error_code err = ktxTexture2_CreateFromStream(ktx2Stream.stream(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, texture2.pHandle());
-    EXPECT_EQ(err, KTX_SUCCESS) << "Failed to create KTX2 from C++ stream: " << ktxErrorString(err);
-    ASSERT_NE(texture2, nullptr) << "Newly-created KTX2 is null";
+    KTX_error_code err = ktxTexture2_CreateFromStream(ktx2Stream.stream(),
+                                                      KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
+                                                      texture2.pHandle());
+    EXPECT_EQ(err, KTX_SUCCESS) << "Failed to create KTX1 from C++ stream: " << ktxErrorString(err);
+    ASSERT_NE(texture2, nullptr) << "Newly-created KTX1 is null";
     EXPECT_TRUE(ktx2Stream.destructed()) << "ktxStream should have been destructed (LOAD_IMAGE_DATA_BIT set)";
 }
 
 TEST_F(ktxStreamTest, CanCreateAutoKtxFromCppStream)
 {
-    StreambufStreamTest ktxStream{std::move(_ktx2Streambuf), std::ios::in}; // Or could use the KTx1, no difference
+    StreambufStreamTest ktxStream{std::move(_ktx2Streambuf), std::ios::in}; // Or could use the KTX1, no difference
     KtxTexture<ktxTexture> texture;
 
-    KTX_error_code err = ktxTexture_CreateFromStream(ktxStream.stream(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, texture.pHandle());
+    KTX_error_code err = ktxTexture_CreateFromStream(ktxStream.stream(),
+                                                     KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
+                                                     texture.pHandle());
     EXPECT_EQ(err, KTX_SUCCESS) << "Failed to create auto-detected KTX from C++ stream: " << ktxErrorString(err);
     ASSERT_NE(texture, nullptr) << "Newly-created auto-detected KTX is null";
     EXPECT_TRUE(ktxStream.destructed()) << "ktxStream should have been destructed (LOAD_IMAGE_DATA_BIT set)";
+}
+
+TEST_F(ktxStreamTest, CanCreateKtx1FromStdCin)
+{
+    // Save cin's read buffer
+    std::streambuf* real_cin_sbuf = std::cin.rdbuf();
+    // Open input file and get its streambuf.
+    std::unique_ptr<std::streambuf> filebuf = testImageFilebuf(ktxPath, SAMPLE_KTX1);
+    // Redirect cin to read from filebuf.
+    std::cin.rdbuf(filebuf.get());
+
+    StreambufStreamTest ktx1Stream{std::cin.rdbuf(), std::ios::in};
+    KtxTexture<ktxTexture1> texture1;
+
+    KTX_error_code err = ktxTexture1_CreateFromStream(ktx1Stream.stream(),
+                                                      KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
+                                                      texture1.pHandle());
+    EXPECT_EQ(err, KTX_SUCCESS) << "Failed to create KTX2 from C++ stream: " << ktxErrorString(err);
+    ASSERT_NE(texture1, nullptr) << "Newly-created KTX2 is null";
+    EXPECT_TRUE(ktx1Stream.destructed()) << "ktxStream should have been destructed (LOAD_IMAGE_DATA_BIT set)";
+
+    // cout to its old self
+    std::cin.rdbuf(real_cin_sbuf);
+}
+
+TEST_F(ktxStreamTest, CanCreateKtx2FromStdCin)
+{
+    // Save cin's read buffer
+    std::streambuf* real_cin_sbuf = std::cin.rdbuf();
+    // Open input file and get its streambuf.
+    std::unique_ptr<std::streambuf> filebuf = testImageFilebuf(ktx2Path, SAMPLE_KTX2);
+    // Redirect cin to read from filebuf.
+    std::cin.rdbuf(filebuf.get());
+
+    StreambufStreamTest ktx2Stream{std::cin.rdbuf(), std::ios::in};
+    KtxTexture<ktxTexture2> texture2;
+
+    KTX_error_code err = ktxTexture2_CreateFromStream(ktx2Stream.stream(), KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT, texture2.pHandle());
+    EXPECT_EQ(err, KTX_SUCCESS) << "Failed to create KTX2 from C++ stream: " << ktxErrorString(err);
+    ASSERT_NE(texture2, nullptr) << "Newly-created KTX2 is null";
+    EXPECT_TRUE(ktx2Stream.destructed()) << "ktxStream should have been destructed (LOAD_IMAGE_DATA_BIT set)";
+
+    // cout to its old self
+    std::cin.rdbuf(real_cin_sbuf);
+}
+
+TEST_F(ktxStreamTest, CanCreateAutoFromStdCin)
+{
+    // Save cin's read buffer
+    std::streambuf* real_cin_sbuf = std::cin.rdbuf();
+    // Open input file and get its streambuf.
+    std::unique_ptr<std::streambuf> filebuf = testImageFilebuf(ktx2Path, SAMPLE_KTX2);
+    // Redirect cin to read from filebuf.
+    std::cin.rdbuf(filebuf.get());
+
+    StreambufStreamTest ktxStream{std::cin.rdbuf(), std::ios::in};
+    KtxTexture<ktxTexture> texture;
+
+    KTX_error_code err = ktxTexture_CreateFromStream(ktxStream.stream(),
+                                                     KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
+                                                     texture.pHandle());
+    EXPECT_EQ(err, KTX_SUCCESS) << "Failed to create KTX2 from C++ stream: " << ktxErrorString(err);
+    ASSERT_NE(texture, nullptr) << "Newly-created KTX2 is null";
+    EXPECT_TRUE(ktxStream.destructed()) << "ktxStream should have been destructed (LOAD_IMAGE_DATA_BIT set)";
+
+    // cout to its old self
+    std::cin.rdbuf(real_cin_sbuf);
 }
 
 TEST_F(ktxStreamTest, CanWriteKtx1AsKtx2ToCppStream)

--- a/tests/streamtests/streamtests.cc
+++ b/tests/streamtests/streamtests.cc
@@ -294,6 +294,9 @@ TEST_F(ktxStreamTest, CanCreateAutoKtxFromCppStream)
     EXPECT_TRUE(ktxStream.destructed()) << "ktxStream should have been destructed (LOAD_IMAGE_DATA_BIT set)";
 }
 
+// As the source is the streambuf from a reading a disk file, these tests of std::cin are
+// unable to test for correct handling when seeking is not possible. Looking for ideas
+// on how to test that within gtest.
 TEST_F(ktxStreamTest, CanCreateKtx1FromStdCin)
 {
     // Save cin's read buffer

--- a/tools/ktx/command.cpp
+++ b/tools/ktx/command.cpp
@@ -121,77 +121,84 @@ InputStream::InputStream(const std::string& filepath, Reporter& report) :
 OutputStream::OutputStream(const std::string& filepath, Reporter& report) :
         filepath(filepath) {
 
+#if !USE_OUTPUT_STREAM
     if (filepath == "-") {
-        #if defined(_WIN32)
-        // Set "stdout" to binary mode
-        const auto setmodeResult = _setmode(_fileno(stdout), _O_BINARY);
-        if (setmodeResult == -1)
-            report.fatal(rc::IO_FAILURE, "Failed to set stdout mode to binary: {}.", setmodeResult);
-        // #else
-        // std::freopen(nullptr, "wb", stdout);
-        #endif
+#if defined(_WIN32)
+          // Set "stdout" to binary mode
+          const auto setmodeResult = _setmode(_fileno(stdout), _O_BINARY);
+          if (setmodeResult == -1)
+              report.fatal(rc::IO_FAILURE, "Failed to set stdout mode to binary: {}.", setmodeResult);
+          // #else
+          // std::freopen(nullptr, "wb", stdout);
+#endif
         file = stdout;
     } else {
 #if defined(_WIN32)
-        file = _wfopen(DecodeUTF8Path(filepath).c_str(), L"wb");
+          file = _wfopen(DecodeUTF8Path(filepath).c_str(), L"wb");
 #else
-        file = fopen(DecodeUTF8Path(filepath).c_str(), "wb");
+          file = fopen(DecodeUTF8Path(filepath).c_str(), "wb");
 #endif
         if (!file)
             report.fatal(rc::IO_FAILURE, "Could not open output file \"{}\": {}.", filepath, errnoMessage());
     }
-
+#else
     // TODO: Investigate and resolve the portability issue with the C++ streams. The issue will most likely
     //       be in StreambufStream's position reporting and seeking. Currently a fallback is implemented in C above.
-    // if (filepath == "-") {
-    //     #if defined(_WIN32)
-    //     // Set "stdout" to binary mode
-    //     const auto setmodeResult = _setmode(_fileno(stdout), _O_BINARY);
-    //     if (setmodeResult == -1)
-    //         report.fatal(rc::IO_FAILURE, "Failed to set stdout mode to binary: {}", setmodeResult);
-    //     // #else
-    //     // std::freopen(nullptr, "wb", stdout);
-    //     #endif
-    //     activeStream = &std::cout;
-    // } else {
-    //     file.open(DecodeUTF8Path(filepath).c_str(), std::ios::binary | std::ios::out);
-    //     if (!file)
-    //         report.fatal(rc::IO_FAILURE, "Could not open output file \"{}\": {}", filepath, errnoMessage());
-    //     activeStream = &file;
-    // }
+     if (filepath == "-") {
+         #if defined(_WIN32)
+         // Set "stdout" to binary mode
+         const auto setmodeResult = _setmode(_fileno(stdout), _O_BINARY);
+         if (setmodeResult == -1)
+             report.fatal(rc::IO_FAILURE, "Failed to set stdout mode to binary: {}", setmodeResult);
+         // #else
+         // std::freopen(nullptr, "wb", stdout);
+         #endif
+         activeStream = &std::cout;
+     } else {
+         file.open(DecodeUTF8Path(filepath).c_str(), std::ios::binary | std::ios::out);
+         if (!file)
+             report.fatal(rc::IO_FAILURE, "Could not open output file \"{}\": {}", filepath, errnoMessage());
+         activeStream = &file;
+     }
+#endif
 }
 
 OutputStream::~OutputStream() {
-    if (file != stdout) {
+    if (!isStdout()) {
+#if !USE_OUTPUT_STREAM
         fclose(file);
+#else
+        file.close();
+#endif
         if (removeAtDestruct) std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
     }
 }
 
 void OutputStream::write(const char* data, std::size_t size, Reporter& report) {
+#if !USE_OUTPUT_STREAM
     const auto written = std::fwrite(data, 1, size, file);
     if (written != size)
+#else
+    activeStream->write(data, size);
+    if (!activeStream->good())
+#endif
         report.fatal(rc::IO_FAILURE, "Failed to write output file \"{}\": {}.", fmtOutFile(filepath), errnoMessage());
 }
 
 void OutputStream::writeKTX2(ktxTexture* texture, Reporter& report) {
+#if !USE_OUTPUT_STREAM
     const auto ret = ktxTexture_WriteToStdioStream(texture, file);
-    if (KTX_SUCCESS != ret) {
-        if (file != stdout)
-            std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
-        report.fatal(rc::IO_FAILURE, "Failed to write KTX file \"{}\": KTX error: {}.", filepath, ktxErrorString(ret));
-    }
-
+#else
     // TODO: Investigate and resolve the portability issue with the C++ streams. The issue will most likely
     //       be in StreambufStream's position reporting and seeking. Currently a fallback is implemented in C above.
-    // StreambufStream<std::streambuf*> stream(activeStream->rdbuf(), std::ios::in | std::ios::binary);
-    // const auto ret = ktxTexture_WriteToStream(texture, stream.stream());
-    //
-    // if (KTX_SUCCESS != ret) {
-    //     if (activeStream != &std::cout)
-    //         std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
-    //     report.fatal(rc::IO_FAILURE, "Failed to write KTX file \"{}\": {}.", fmtOutFile(filepath), ktxErrorString(ret));
-    // }
+     StreambufStream<std::streambuf*> stream(activeStream->rdbuf(), std::ios::in | std::ios::binary);
+     const auto ret = ktxTexture_WriteToStream(texture, stream.stream());
+#endif
+    if (KTX_SUCCESS != ret) {
+         if (!isStdout())
+             std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
+         report.fatal(rc::IO_FAILURE, "Failed to write KTX file \"{}\": {}.", fmtOutFile(filepath), ktxErrorString(ret));
+     }
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/tools/ktx/command.cpp
+++ b/tools/ktx/command.cpp
@@ -121,38 +121,15 @@ InputStream::InputStream(const std::string& filepath, Reporter& report) :
 OutputStream::OutputStream(const std::string& filepath, Reporter& report) :
         filepath(filepath) {
 
-#if !USE_OUTPUT_STREAM
-    if (filepath == "-") {
-#if defined(_WIN32)
-          // Set "stdout" to binary mode
-          const auto setmodeResult = _setmode(_fileno(stdout), _O_BINARY);
-          if (setmodeResult == -1)
-              report.fatal(rc::IO_FAILURE, "Failed to set stdout mode to binary: {}.", setmodeResult);
-          // #else
-          // std::freopen(nullptr, "wb", stdout);
-#endif
-        file = stdout;
-    } else {
-#if defined(_WIN32)
-          file = _wfopen(DecodeUTF8Path(filepath).c_str(), L"wb");
-#else
-          file = fopen(DecodeUTF8Path(filepath).c_str(), "wb");
-#endif
-        if (!file)
-            report.fatal(rc::IO_FAILURE, "Could not open output file \"{}\": {}.", filepath, errnoMessage());
-    }
-#else
-    // TODO: Investigate and resolve the portability issue with the C++ streams. The issue will most likely
-    //       be in StreambufStream's position reporting and seeking. Currently a fallback is implemented in C above.
      if (filepath == "-") {
-         #if defined(_WIN32)
+#if defined(_WIN32)
          // Set "stdout" to binary mode
          const auto setmodeResult = _setmode(_fileno(stdout), _O_BINARY);
          if (setmodeResult == -1)
              report.fatal(rc::IO_FAILURE, "Failed to set stdout mode to binary: {}", setmodeResult);
          // #else
          // std::freopen(nullptr, "wb", stdout);
-         #endif
+#endif
          activeStream = &std::cout;
      } else {
          file.open(DecodeUTF8Path(filepath).c_str(), std::ios::binary | std::ios::out);
@@ -160,45 +137,30 @@ OutputStream::OutputStream(const std::string& filepath, Reporter& report) :
              report.fatal(rc::IO_FAILURE, "Could not open output file \"{}\": {}", filepath, errnoMessage());
          activeStream = &file;
      }
-#endif
 }
 
 OutputStream::~OutputStream() {
     if (!isStdout()) {
-#if !USE_OUTPUT_STREAM
-        fclose(file);
-#else
         file.close();
-#endif
         if (removeAtDestruct) std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
     }
 }
 
 void OutputStream::write(const char* data, std::size_t size, Reporter& report) {
-#if !USE_OUTPUT_STREAM
-    const auto written = std::fwrite(data, 1, size, file);
-    if (written != size)
-#else
+
     activeStream->write(data, size);
     if (!activeStream->good())
-#endif
         report.fatal(rc::IO_FAILURE, "Failed to write output file \"{}\": {}.", fmtOutFile(filepath), errnoMessage());
 }
 
 void OutputStream::writeKTX2(ktxTexture* texture, Reporter& report) {
-#if !USE_OUTPUT_STREAM
-    const auto ret = ktxTexture_WriteToStdioStream(texture, file);
-#else
-    // TODO: Investigate and resolve the portability issue with the C++ streams. The issue will most likely
-    //       be in StreambufStream's position reporting and seeking. Currently a fallback is implemented in C above.
-     StreambufStream<std::streambuf*> stream(activeStream->rdbuf(), std::ios::in | std::ios::binary);
-     const auto ret = ktxTexture_WriteToStream(texture, stream.stream());
-#endif
+    StreambufStream<std::streambuf*> stream(activeStream->rdbuf(), std::ios::out | std::ios::binary);
+    const auto ret = ktxTexture_WriteToStream(texture, stream.stream());
     if (KTX_SUCCESS != ret) {
-         if (!isStdout())
-             std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
-         report.fatal(rc::IO_FAILURE, "Failed to write KTX file \"{}\": {}.", fmtOutFile(filepath), ktxErrorString(ret));
-     }
+        if (!isStdout())
+            std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
+        report.fatal(rc::IO_FAILURE, "Failed to write KTX file \"{}\": {}.", fmtOutFile(filepath), ktxErrorString(ret));
+    }
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/tools/ktx/command.h
+++ b/tools/ktx/command.h
@@ -469,12 +469,16 @@ public:
 
 /// Helper to handle stdout and fstream uniformly
 class OutputStream {
+#define USE_OUTPUT_STREAM 1
 protected:
     std::string filepath;
-    FILE* file;
     bool removeAtDestruct = false;
-    // std::ostream* activeStream = nullptr;
-    // std::ofstream file; // Unused for stdin/stdout
+#if !USE_OUTPUT_STREAM
+    FILE* file;
+#else
+    std::ostream* activeStream = nullptr;
+    std::ofstream file; // Unused for stdin/stdout
+#endif
 
 public:
     OutputStream(const std::string& filepath, Reporter& report);
@@ -490,8 +494,14 @@ public:
         return filepath;
     }
 
+#if !USE_OUTPUT_STREAM
     bool isStdout() { return (file == stdout); }
     void flush() { fflush(file); }
+#else
+    bool isStdout() { return (activeStream == &std::cout); }
+    void flush() { activeStream->flush(); }
+#endif
+
     void removeOnDestruct() { removeAtDestruct = true; }
     void writeKTX2(ktxTexture* texture, Reporter& report);
     void write(const char* data, std::size_t size, Reporter& report);

--- a/tools/ktx/command.h
+++ b/tools/ktx/command.h
@@ -469,16 +469,11 @@ public:
 
 /// Helper to handle stdout and fstream uniformly
 class OutputStream {
-#define USE_OUTPUT_STREAM 1
 protected:
     std::string filepath;
     bool removeAtDestruct = false;
-#if !USE_OUTPUT_STREAM
-    FILE* file;
-#else
     std::ostream* activeStream = nullptr;
     std::ofstream file; // Unused for stdin/stdout
-#endif
 
 public:
     OutputStream(const std::string& filepath, Reporter& report);
@@ -494,13 +489,8 @@ public:
         return filepath;
     }
 
-#if !USE_OUTPUT_STREAM
-    bool isStdout() { return (file == stdout); }
-    void flush() { fflush(file); }
-#else
     bool isStdout() { return (activeStream == &std::cout); }
     void flush() { activeStream->flush(); }
-#endif
 
     void removeOnDestruct() { removeAtDestruct = true; }
     void writeKTX2(ktxTexture* texture, Reporter& report);

--- a/tools/ktx/command_convert.cpp
+++ b/tools/ktx/command_convert.cpp
@@ -97,9 +97,14 @@ public:
 #endif
 
     void writeKTX2(ktxTexture1* texture, Reporter& report) {
+#if !USE_OUTPUT_STREAM
         const auto ret = ktxTexture1_WriteKTX2ToStdioStream(texture, file);
+#else
+     StreambufStream<std::streambuf*> stream(activeStream->rdbuf(), std::ios::in | std::ios::binary);
+     const auto ret = ktxTexture1_WriteKTX2ToStream(texture, stream.stream());
+#endif
         if (KTX_SUCCESS != ret) {
-            if (file != stdout)
+            if (!isStdout())
                 std::filesystem::remove(DecodeUTF8Path(filepath).c_str());
             report.fatal(rc::IO_FAILURE, "Failed to write KTX file \"{}\": KTX error: {}.",
                          filepath, ktxErrorString(ret));

--- a/tools/ktx/command_convert.cpp
+++ b/tools/ktx/command_convert.cpp
@@ -97,12 +97,8 @@ public:
 #endif
 
     void writeKTX2(ktxTexture1* texture, Reporter& report) {
-#if !USE_OUTPUT_STREAM
-        const auto ret = ktxTexture1_WriteKTX2ToStdioStream(texture, file);
-#else
-     StreambufStream<std::streambuf*> stream(activeStream->rdbuf(), std::ios::in | std::ios::binary);
-     const auto ret = ktxTexture1_WriteKTX2ToStream(texture, stream.stream());
-#endif
+        StreambufStream<std::streambuf*> stream(activeStream->rdbuf(), std::ios::out | std::ios::binary);
+        const auto ret = ktxTexture1_WriteKTX2ToStream(texture, stream.stream());
         if (KTX_SUCCESS != ret) {
             if (!isStdout())
                 std::filesystem::remove(DecodeUTF8Path(filepath).c_str());

--- a/utils/sbufstream.h
+++ b/utils/sbufstream.h
@@ -118,6 +118,7 @@ protected:
 
     inline static StreambufStream* parent(ktxStream *str)
     {
+        assert(str->type == eStreamTypeCustom);
         return reinterpret_cast<StreambufStream*>(str->data.custom_ptr.address);
     }
 
@@ -166,17 +167,32 @@ protected:
     static KTX_error_code getpos(ktxStream* str, ktx_off_t *offset)
     {
         auto self = parent(str);
-        *offset = ktx_off_t(self->_streambuf->pubseekoff(0, std::ios::cur, self->_seek_mode));
-        logstream << "\tgetpos: " << *offset << std::endl;
-        return KTX_SUCCESS;
+        ktx_off_t seekoffval =
+              ktx_off_t(self->_streambuf->pubseekoff(0, std::ios::cur, self->_seek_mode));
+        logstream << "\tgetpos: " << seekoffval << std::endl;
+        if (seekoffval != -1) {
+            *offset = seekoffval;
+            return KTX_SUCCESS;
+        } else {
+            return KTX_FILE_ISPIPE; // Not seekable.
+        }
     }
 
-    static KTX_error_code setpos(ktxStream* str, ktx_off_t offset)
+    static KTX_error_code setpos(ktxStream* str, ktx_off_t pos)
     {
         auto self = parent(str);
-        const auto newpos = std::streamoff(offset);
-        const std::streampos setpos = self->_streambuf->pubseekoff(newpos, std::ios::beg, self->_seek_mode);
-        logstream << "\tsetpos: " << offset << std::endl;
+        const auto newpos = std::streamoff(pos);
+        const std::streampos setpos =
+                self->_streambuf->pubseekoff(newpos, std::ios::beg, self->_seek_mode);
+        logstream << "\tsetpos: " << pos << std::endl;
+        if (setpos == -1) {
+            // Not seekable
+            if (pos > str->readpos)
+                return str->skip(str, pos - str->readpos);
+            else
+                return KTX_FILE_ISPIPE;
+        }
+
         return (setpos == newpos) ? KTX_SUCCESS : KTX_FILE_SEEK_ERROR;
     }
 

--- a/utils/sbufstream.h
+++ b/utils/sbufstream.h
@@ -147,7 +147,23 @@ protected:
 
         const std::streampos curpos = self->_streambuf->pubseekoff(0, std::ios::cur, self->_seek_mode);
         const std::streampos newpos = self->_streambuf->pubseekoff(std::streamoff(count), std::ios::cur, self->_seek_mode);
-        return (curpos > newpos) ? KTX_SUCCESS : KTX_FILE_SEEK_ERROR;
+
+        if (curpos == -1) {
+            if (self->streambuf() == std::cin.rdbuf()) {
+                for (ktx_uint32_t i = 0; i < count; i++) {
+                    int ret = self->_streambuf->sbumpc();
+                    if (ret == EOF) {
+                        return KTX_FILE_UNEXPECTED_EOF;
+                    }
+                }
+                str->readpos += count;
+                return KTX_SUCCESS;
+            } else {
+                return KTX_FILE_ISPIPE;
+            }
+        }
+        str->readpos += count;
+        return (newpos > curpos) ? KTX_SUCCESS : KTX_FILE_SEEK_ERROR;
     }
 
     static KTX_error_code write(ktxStream* str, const void* src, ktx_size_t size, ktx_size_t count)
@@ -164,35 +180,38 @@ protected:
         return (nput == ntotal) ? KTX_SUCCESS : KTX_FILE_WRITE_ERROR;
     }
 
-    static KTX_error_code getpos(ktxStream* str, ktx_off_t *offset)
+    static KTX_error_code getpos(ktxStream* str, ktx_off_t *pos)
     {
         auto self = parent(str);
-        ktx_off_t seekoffval =
-              ktx_off_t(self->_streambuf->pubseekoff(0, std::ios::cur, self->_seek_mode));
-        logstream << "\tgetpos: " << seekoffval << std::endl;
-        if (seekoffval != -1) {
-            *offset = seekoffval;
-            return KTX_SUCCESS;
-        } else {
-            return KTX_FILE_ISPIPE; // Not seekable.
+        const ktx_off_t seekoffval =
+                  ktx_off_t(self->_streambuf->pubseekoff(0, std::ios::cur, self->_seek_mode));
+        logstream << "\tgetpos: " << *pos << std::endl;
+
+        if (seekoffval == -1) {
+            if (self->streambuf() == std::cin.rdbuf())
+                *pos = str->readpos;
+            else
+                return KTX_FILE_ISPIPE;
         }
+        *pos = seekoffval;
+        return KTX_SUCCESS;
     }
 
     static KTX_error_code setpos(ktxStream* str, ktx_off_t pos)
     {
         auto self = parent(str);
         const auto newpos = std::streamoff(pos);
+
         const std::streampos setpos =
                 self->_streambuf->pubseekoff(newpos, std::ios::beg, self->_seek_mode);
-        logstream << "\tsetpos: " << pos << std::endl;
+        logstream << "\tsetpos: " << setpos << std::endl;
+
         if (setpos == -1) {
-            // Not seekable
-            if (pos > str->readpos)
+            if (self->streambuf() == std::cin.rdbuf() && pos > str->readpos)
                 return str->skip(str, pos - str->readpos);
             else
                 return KTX_FILE_ISPIPE;
         }
-
         return (setpos == newpos) ? KTX_SUCCESS : KTX_FILE_SEEK_ERROR;
     }
 
@@ -200,6 +219,9 @@ protected:
     {
         auto self = parent(str);
         const std::streampos oldpos = self->_streambuf->pubseekoff(0, std::ios::cur, self->_seek_mode);
+        if (oldpos == -1)
+            return KTX_FILE_ISPIPE;
+
         *size = ktx_size_t(self->_streambuf->pubseekoff(0, std::ios::end));
         const std::streampos newpos = self->_streambuf->pubseekoff(oldpos, std::ios::beg, self->_seek_mode);
         logstream << "\t  size: " << *size << 'B' << std::endl;

--- a/utils/sbufstream.h
+++ b/utils/sbufstream.h
@@ -183,7 +183,7 @@ protected:
     static KTX_error_code getpos(ktxStream* str, ktx_off_t *pos)
     {
         auto self = parent(str);
-        const ktx_off_t seekoffval =
+        const auto seekoffval =
                   ktx_off_t(self->_streambuf->pubseekoff(0, std::ios::cur, self->_seek_mode));
         logstream << "\tgetpos: " << *pos << std::endl;
 


### PR DESCRIPTION
The issue was that ktxStream `getpos()` in the `StreambufStream` implementation was always returning KTX_SUCCESS even when the stream was not seekable. This led to a failed assert, so the failures were only seen in Debug configurations. 

Add support to `StreambufStream` for reading from std::cin and add tests to streamtests. The _ktx_ tool suite reads std::cin into a buffer which it passes to `StreambufStream` so does not need this functionality but as `StreambufStream` is available for anyone to use, it should support it.

Remove the stdio workaround the tool suite was using instead of StreambufStream.

### IMPORTANT NOTE
This changes the typedef of `ktx_off_t` on Windows from an unsigned to a signed type which was always intended. The error was spotted during this work as it caused a signed/unsigned mismatch with value of -1 returned by `std::streambuf::pubseekoff` on failure.