### PR TITLE
Parallelize CI builds and tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,8 +68,12 @@ jobs:
             sse: ON, opencl: OFF
           }
         # We perform ASan/UBSan/TSan on only one job because they greatly slow
-        # down test runs. We use a linux runner because they consume the fewest
-        # GH Actions credits
+        # down test runs. We only use a linux runner because they, most likely,
+        # consume the fewest GH Actions credits.
+        # TODO: at some point, we can reduce CI runners time by adding
+        #       ASan/UBSan/TSan to the `Default` job and removing this
+        #       additional job but then we may also get additional errors about
+        #       load tests.
         - name: ASan GCC (x86_64)
           os: ubuntu-latest
           generator: Ninja

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -77,12 +77,8 @@ jobs:
       run: git submodule update --init --recursive tests/cts
     - name: Install Ninja
       run: choco install ninja --no-progress
-      # Print cmake command to be able to verify configuration and replicate locally
     - name: Configure Mingw x64
-      run: |
-        cmake_args="-G \"Ninja Multi-Config\" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR"
-        echo "running cmake command: cmake -B build ${cmake_args}"
-        cmake -B build ${cmake_args}
+      run: cmake -B build -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR
     - name: Build Mingw x64 Debug
       run: cmake --build build --config Debug -j $(nproc)
     - name: Build Mingw x64 Release

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -80,11 +80,11 @@ jobs:
     - name: Configure Mingw x64
       run: cmake -B build -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR
     - name: Build Mingw x64 Debug
-      run: cmake --build build --config Debug -j $(nproc)
+      run: cmake --build build --config Debug -j $(($(nproc) + 1))
     - name: Build Mingw x64 Release
-      run: cmake --build build --config Release -j $(nproc)
+      run: cmake --build build --config Release -j $(($(nproc) + 1))
     - name: Test Mingw build
-      run: ctest --output-on-failure --test-dir build -C Release -j $(nproc)
+      run: ctest --output-on-failure --test-dir build -C Release -j $(($(nproc) + 1))
 #    - name: Upload test log
 #      shell: pwsh
 #      if: ${{ failure() }}

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -80,11 +80,11 @@ jobs:
     - name: Configure Mingw x64
       run: cmake -B build -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR
     - name: Build Mingw x64 Debug
-      run: cmake --build build --config Debug -j $(($(nproc) + 1))
+      run: cmake --build build --config Debug -j $(nproc)
     - name: Build Mingw x64 Release
-      run: cmake --build build --config Release -j $(($(nproc) + 1))
+      run: cmake --build build --config Release -j $(nproc)
     - name: Test Mingw build
-      run: ctest --output-on-failure --test-dir build -C Release -j $(($(nproc) + 1))
+      run: ctest --output-on-failure --test-dir build -C Release -j $(nproc)
 #    - name: Upload test log
 #      shell: pwsh
 #      if: ${{ failure() }}

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -77,14 +77,18 @@ jobs:
       run: git submodule update --init --recursive tests/cts
     - name: Install Ninja
       run: choco install ninja --no-progress
+      # Print cmake command to be able to verify configuration and replicate locally
     - name: Configure Mingw x64
-      run: cmake -B build -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR
+      run: |
+        cmake_args="-G \"Ninja Multi-Config\" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR"
+        echo "running cmake command: cmake -B build ${cmake_args}"
+        cmake -B build ${cmake_args}
     - name: Build Mingw x64 Debug
-      run: cmake --build build --config Debug
+      run: cmake --build build --config Debug -j $(nproc)
     - name: Build Mingw x64 Release
-      run: cmake --build build --config Release
+      run: cmake --build build --config Release -j $(nproc)
     - name: Test Mingw build
-      run: ctest --output-on-failure --test-dir build -C Release
+      run: ctest --output-on-failure --test-dir build -C Release -j $(nproc)
 #    - name: Upload test log
 #      shell: pwsh
 #      if: ${{ failure() }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -333,7 +333,9 @@ jobs:
     - name: Test Windows build
       # Tests built for arm64 can't be run as the CI runners are all x64.
       if: matrix.options.tests == 'ON'
-      run: ctest --output-on-failure --test-dir $env:BUILD_DIR -C Release
+      run: |
+        $njobs = [Environment]::ProcessorCount
+        ctest --output-on-failure --test-dir $env:BUILD_DIR -C Release -j $njobs
 
 #    - name: Upload test log
 #      if: ${{ failure() }}

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -49,7 +49,7 @@ echo ${config_display%??}
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(nproc)
+njobs=$(($(nproc) + 1))
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -49,7 +49,7 @@ echo ${config_display%??}
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(($(nproc) + 1))
+njobs=$(nproc)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -46,14 +46,21 @@ for arg in "${cmake_args[@]}"; do
 done
 
 echo ${config_display%??}
+
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+njobs=$(nproc)
+
+# Print cmake command to be able to verify configuration and replicate locally
+echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"
 cmake . "${cmake_args[@]}"
 
 pushd "$BUILD_DIR"
 
 echo "Build KTX-Software (Android $ANDROID_ABI $CONFIGURATION)"
-cmake --build . --config $CONFIGURATION -j
+cmake --build . --config $CONFIGURATION -j $njobs
 # echo "Test KTX-Software (Android $ANDROID_ABI Release)"
-# ctest --output-on-failure -C $CONFIGURATION # --verbose
+# ctest --output-on-failure -C $CONFIGURATION -j $njobs # --verbose
 echo "Install KTX-Software (Android $ANDROID_ABI $CONFIGURATION)"
 cmake --install . --config $CONFIGURATION --prefix ../$INSTALL_DIR
 

--- a/scripts/build_android_debug.sh
+++ b/scripts/build_android_debug.sh
@@ -35,12 +35,19 @@ for arg in "${cmake_args[@]}"; do
 done
 
 echo ${config_display%??}
+
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+njobs=$(($(nproc) + 1))
+
+# Print cmake command to be able to verify configuration and replicate locally
+echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"
 cmake . "${cmake_args[@]}"
 
 pushd "$BUILD_DIR"
 
 echo "Build KTX-Software (Android $ANDROID_ABI Debug)"
-cmake --build . --config Debug -j
+cmake --build . --config Debug -j $njobs
 # echo "Test KTX-Software (Android $ANDROID_ABI Debug)"
 # ctest --output-on-failure -C Debug # --verbose
 echo "Install KTX-Software (Android $ANDROID_ABI Debug)"

--- a/scripts/build_android_debug.sh
+++ b/scripts/build_android_debug.sh
@@ -35,19 +35,12 @@ for arg in "${cmake_args[@]}"; do
 done
 
 echo ${config_display%??}
-
-# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
-# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(($(nproc) + 1))
-
-# Print cmake command to be able to verify configuration and replicate locally
-echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"
 cmake . "${cmake_args[@]}"
 
 pushd "$BUILD_DIR"
 
 echo "Build KTX-Software (Android $ANDROID_ABI Debug)"
-cmake --build . --config Debug -j $njobs
+cmake --build . --config Debug -j
 # echo "Test KTX-Software (Android $ANDROID_ABI Debug)"
 # ctest --output-on-failure -C Debug # --verbose
 echo "Install KTX-Software (Android $ANDROID_ABI Debug)"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -91,7 +91,7 @@ echo ${config_display%??}
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
 # Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
-njobs=$(sysctl -n hw.logicalcpu)
+njobs=$(($(sysctl -n hw.logicalcpu) + 1))
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -91,7 +91,7 @@ echo ${config_display%??}
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
 # Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
-njobs=$(($(sysctl -n hw.logicalcpu) + 1))
+njobs=$(sysctl -n hw.logicalcpu)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -90,7 +90,8 @@ echo ${config_display%??}
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(nproc)
+# Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
+njobs=$(sysctl -n hw.logicalcpu)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -87,6 +87,13 @@ for arg in "${cmake_args[@]}"; do
 done
 
 echo ${config_display%??}
+
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+njobs=$(nproc)
+
+# Print cmake command to be able to verify configuration and replicate locally
+echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"
 cmake . "${cmake_args[@]}"
 
 pushd $BUILD_DIR
@@ -97,7 +104,7 @@ IFS=, ; for config in $CONFIGURATION
 do
   IFS=$oldifs # Because of ; IFS set above will still be present.
   echo "Build KTX-Software (iOS $config)"
-  cmake --build . --config $config -- -sdk iphoneos CODE_SIGN_IDENTITY="" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO | handle_compiler_output
+  cmake --build . --config $config -j $njobs -- -sdk iphoneos CODE_SIGN_IDENTITY="" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO | handle_compiler_output
   # A simulator build would look like this but note that due to the way vcpkg
   # manifest mode works, different CMake configurations are needed for
   # device and simulator. Hence a different BUILD_DIR and separate run

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -138,7 +138,7 @@ echo ${config_display%??}
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(nproc)
+njobs=$(($(nproc) + 1))
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -136,6 +136,10 @@ for arg in "${cmake_args[@]}"; do
 done
 echo ${config_display%??}
 
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+njobs=$(nproc)
+
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"
 cmake . "${cmake_args[@]}"
@@ -149,10 +153,10 @@ do
   IFS=$oldifs # Because of ; IFS set above will still be present.
   # Build and test
   echo "Build KTX-Software (Linux $ARCH $config)"
-  cmake --build . --config $config
+  cmake --build . --config $config -j $njobs
   if [ "$ARCH" = "$(uname -m)" ]; then
     echo "Test KTX-Software (Linux $ARCH $config)"
-    ctest --output-on-failure -C $config #--verbose
+    ctest --output-on-failure -C $config -j $njobs #--verbose
   fi
   if [ "$config" = "Release" -a "$PACKAGE" = "YES" ]; then
     echo "Pack KTX-Software (Linux $ARCH $config)"

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -138,7 +138,7 @@ echo ${config_display%??}
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(($(nproc) + 1))
+njobs=$(nproc)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -113,7 +113,8 @@ echo ${config_display%??}
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(nproc)
+# Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
+njobs=$(sysctl -n hw.logicalcpu)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -114,7 +114,7 @@ echo ${config_display%??}
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
 # Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
-njobs=$(($(sysctl -n hw.logicalcpu) + 1))
+njobs=$(sysctl -n hw.logicalcpu)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -110,6 +110,13 @@ for arg in "${cmake_args[@]}"; do
 done
 
 echo ${config_display%??}
+
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+njobs=$(nproc)
+
+# Print cmake command to be able to verify configuration and replicate locally
+echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"
 cmake . "${cmake_args[@]}"
 
 # Cause the build pipes below to set the exit to the exit code of the
@@ -127,15 +134,15 @@ do
   #if [ "$config" = "Debug" ]; then continue; fi
   echo "Build KTX-Software (macOS $ARCHS $config)"
   if [ -n "$CODE_SIGN_IDENTITY" -a "$config" = "Release" ]; then
-    cmake --build . --config $config | handle_compiler_output
+    cmake --build . --config $config -j $njobs | handle_compiler_output
   else
-    cmake --build . --config $config -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
+    cmake --build . --config $config -j $njobs -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
   fi
 
   # Rosetta 2 should let x86_64 tests run on an Apple Silicon Mac hence the -o.
   if [ "$ARCHS" = "$(uname -m)" -o "$ARCHS" = "x86_64" ]; then
     echo "Test KTX-Software (macOS $ARCHS $config)"
-    ctest --output-on-failure -C $config # --verbose
+    ctest --output-on-failure -C $config -j $njobs # --verbose
   fi
 
   if [ "$config" = "Release" -a "$PACKAGE" = "YES" ]; then

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -114,7 +114,7 @@ echo ${config_display%??}
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
 # Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
-njobs=$(sysctl -n hw.logicalcpu)
+njobs=$(($(sysctl -n hw.logicalcpu) + 1))
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -171,7 +171,7 @@ echo $config_display
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-$njobs = [Environment]::ProcessorCount
+$njobs = [Environment]::ProcessorCount + 1
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . $cmake_args"

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -169,6 +169,12 @@ foreach ($item in $cmake_args) {
 $config_display = $config_display -replace ', $', ''
 echo $config_display
 
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+$njobs = [Environment]::ProcessorCount
+
+# Print cmake command to be able to verify configuration and replicate locally
+echo "running cmake command (in source directory): cmake . $cmake_args"
 cmake . $cmake_args
 
 # Return an error code if cmake config fails.
@@ -194,7 +200,7 @@ foreach ($config in $configArray) {
   try {
     #git status
     echo "Build KTX-Software (Windows $ARCH $config)"
-    cmake --build . --config $config
+    cmake --build . --config $config -j $njobs
     # Return an error code if cmake fails
     if(!$?){
       popd

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -171,7 +171,7 @@ echo $config_display
 
 # To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
 # bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-$njobs = [Environment]::ProcessorCount + 1
+$njobs = [Environment]::ProcessorCount
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . $cmake_args"


### PR DESCRIPTION
As discussed, tests *should* now be able to run in parallel and CIs may benefit from running tests in parallel (also build steps may benefit as well).

* Use -j $(nproc) on linux, macos, and windows CIs to speed up CMake building and testing steps.

* Add `echo ${cmake_command}` to all CMake configuration steps for consistently with the already-added echo statement in `scripts/build_linux` (this is useful to replicate CMake configuration command locally).

CMake build stats on my system (time refers to real time. CMake was configured as follows: `cmake -S . -B build/ -DKTX_FEATURE_TOOLS=ON -DKTX_FEATURE_TOOLS_CTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DKTX_FEATURE_DOC=OFF -DSANITIZE="address"`, on `Linux 6.17.0-40-generic #40~24.04.1-Ubuntu`):
- `cmake --build build/ --config Debug -j 1` (default): 2m10.458s
- `cmake --build build/ --config Debug -j 4` (GH runners best, probably): 0m39.705s

Compared against CI from latest commit: https://github.com/KhronosGroup/KTX-Software/actions/runs/29578243343/

Stats (cmake test times) with `njobs=$(nproc)` all in seconds:
| CI Name                                      | Time ST | Time MT    | speed up |
| ------------------------------------------- | ------------ | -----------    | ------------ |
| Linux Default                               |   1427.77 |  601.10     | ~2.4 |
| Linux ASan GCC (x86_64)          |     3870.06 | 1609.89 | ~2.4 |
| Linux Package (x86_64)              |    379.56   | 159.39    | ~2.4 |
| Windows Visual Studio 17 2022  |     544.25  | 212.50    | ~2.55 |
| Linux CI Summary                       |   1h 40m 2s  | 31m 21s  | ~3 |

Stats (cmake test times) with `njobs=$(nproc) + 1` all in seconds (Why? If build and/or test commands are IO-bound, setting to `nbr_hardware_threads + 1` might result is even better speed ups):
| CI Name                                      | `njobs=$(nproc)` | `njobs=$(($(nproc) + 1))` | speed up |
| ------------------------------------------- | ------------ | ----------- | ------------ |
| Linux Default                                | 601.10 | 594.79  |  ~1 |
| Linux ASan GCC (x86_64)          |  1609.89 |  1685.05 | ~0.95 |
| Linux Package (x86_64)              | 159.39  | 151.28 | ~1 |
| Windows Visual Studio 17 2022  | 212.50 | 214.20 | ~1 |
| Linux CI Summary                       | 31m 21s  | 33m 54s  | ~0.92 |

Conclusion: using `njobs=$(nproc)` results in better performance than `njobs=$(($(nproc) + 1))` and at least ~2.5 faster CIs than ST CIs.