### PR TITLE
Update dfdutils for UB fix (left shift on signed int channel setting sign bit)

### DIFF
--- a/external/dfdutils/.gitrepo
+++ b/external/dfdutils/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/KhronosGroup/dfdutils.git
 	branch = main
-	commit = fd3349ca0b177b77f3edf2d4acfa7206168b7993
-	parent = 50536fd44edf3c5d265745196fea4ffbbf2edcf6
+	commit = 875e493a7bea48a3ea7efa70d722ed2caeaf4d69
+	parent = e2f948066c108b56b8d0052b460b2ac7d34886aa
 	method = merge
 	cmdver = 0.4.9

--- a/external/dfdutils/createdfd.c
+++ b/external/dfdutils/createdfd.c
@@ -117,10 +117,16 @@ static void writeSample(uint32_t *DFD, int sampleNo, int channel,
     if (channel == 3) channel = KHR_DF_CHANNEL_RGBSDA_ALPHA;
     channel = setChannelFlags(channel, suffix);
 
+    // `channel` is cast into an uint32_t to avoid the following issue:
+    //  When `channel` is 192, the following UB occurs: 11000000 << 24
+    //  Setting sign bit of an integer via a left shift operation is UB.
+    //
+    //  TODO: This is the least intrusive solution for the moment. Ideally,
+    //        writeSample should take uint32_t params.
     sample[KHR_DF_SAMPLEWORD_BITOFFSET] =
         (offset << KHR_DF_SAMPLESHIFT_BITOFFSET) |
         ((bits - 1) << KHR_DF_SAMPLESHIFT_BITLENGTH) |
-        (channel << KHR_DF_SAMPLESHIFT_CHANNELID);
+        ((uint32_t)channel << KHR_DF_SAMPLESHIFT_CHANNELID);
 
     sample[KHR_DF_SAMPLEWORD_SAMPLEPOSITION_ALL] = 0;
 


### PR DESCRIPTION
subrepo:
  subdir:   "external/dfdutils"
  merged:   "875e493a7"
upstream:
  origin:   "https://github.com/KhronosGroup/dfdutils.git"
  branch:   "main"
  commit:   "875e493a7"
git-subrepo:
  version:  "0.4.9"
  origin:   "https://github.com/MarkCallow/git-subrepo.git"
  commit:   "4f60dd7"