### PR TITLE
Fix docstring typo in ktx.h

### DIFF
--- a/lib/include/ktx.h
+++ b/lib/include/ktx.h
@@ -372,7 +372,7 @@ typedef struct ktxTexture {
  * full pyramid but always starts at the base level.
  */
 /**
- * @typedef ktxTexture::numLevels
+ * @typedef ktxTexture::numLayers
  * @~English
  * @brief Number of array layers in the texture.
  */


### PR DESCRIPTION
Docstring for `numLayers` was written as `numLevels` which made it not appear in the doxygen pages