### PR TITLE
ci: un-parallelize build commands due to occasional failures on Windows

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -80,9 +80,9 @@ jobs:
     - name: Configure Mingw x64
       run: cmake -B build -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR
     - name: Build Mingw x64 Debug
-      run: cmake --build build --config Debug  # multi-core builds are not supported
+      run: cmake --build build --config Debug -j $(nproc)
     - name: Build Mingw x64 Release
-      run: cmake --build build --config Release  # multi-core builds are not supported
+      run: cmake --build build --config Release -j $(nproc)
     - name: Test Mingw build
       run: ctest --output-on-failure --test-dir build -C Release -j $(nproc)
 #    - name: Upload test log

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -80,9 +80,9 @@ jobs:
     - name: Configure Mingw x64
       run: cmake -B build -G "Ninja Multi-Config" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DKTX_FEATURE_TOOLS=TRUE -DKTX_FEATURE_TOOLS_CTS=TRUE -DKTX_WERROR=$WERROR
     - name: Build Mingw x64 Debug
-      run: cmake --build build --config Debug -j $(nproc)
+      run: cmake --build build --config Debug  # multi-core builds are not supported
     - name: Build Mingw x64 Release
-      run: cmake --build build --config Release -j $(nproc)
+      run: cmake --build build --config Release  # multi-core builds are not supported
     - name: Test Mingw build
       run: ctest --output-on-failure --test-dir build -C Release -j $(nproc)
 #    - name: Upload test log

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,6 +25,13 @@ Supported platforms (please see their specific requirements first)
 
 The minimal way to a build is to clone this repository and follow the instructions for your desired build below.
 
+> **Note:**
+>
+> Multi-core builds (i.e., running CMake build command with `-j[N]` N > 1) is
+> not supported. Multi-core builds may, occasionally, fail due to
+> filesystem race condition caused by calls to `add_custom_command` in CMake.
+> Running CTest in parallel is, on the other hand, well supported.
+
 _libktx_ only
 -------------
 To build only _libktx_ and nothing else, run the following in a terminal

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -47,9 +47,10 @@ done
 
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
-# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-njobs=$(nproc)
+# To be supplied as `-j $njobs`. This is set to 1 because multi-core builds
+# might, occasionally, fail due to some filesystem race condition(s) caused by
+# `add_custom_command` calls in CMake.
+njobs=1
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -47,10 +47,8 @@ done
 
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. This is set to 1 because multi-core builds
-# might, occasionally, fail due to some filesystem race condition(s) caused by
-# `add_custom_command` calls in CMake.
-njobs=1
+# To be supplied as `-j $njobs`. On GH CIs, this is most likely to be 4.
+njobs=$(nproc)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_android_debug.sh
+++ b/scripts/build_android_debug.sh
@@ -40,9 +40,9 @@ cmake . "${cmake_args[@]}"
 pushd "$BUILD_DIR"
 
 echo "Build KTX-Software (Android $ANDROID_ABI Debug)"
-cmake --build . --config Debug -j 1
+cmake --build . --config Debug -j
 # echo "Test KTX-Software (Android $ANDROID_ABI Debug)"
-# ctest --output-on-failure -C Debug # --verbose
+# ctest --output-on-failure -C Debug -j $(nproc) # --verbose
 echo "Install KTX-Software (Android $ANDROID_ABI Debug)"
 cmake --install . --config Debug --prefix ../install-android-debug/$ANDROID_ABI
 

--- a/scripts/build_android_debug.sh
+++ b/scripts/build_android_debug.sh
@@ -40,7 +40,7 @@ cmake . "${cmake_args[@]}"
 pushd "$BUILD_DIR"
 
 echo "Build KTX-Software (Android $ANDROID_ABI Debug)"
-cmake --build . --config Debug -j
+cmake --build . --config Debug -j 1
 # echo "Test KTX-Software (Android $ANDROID_ABI Debug)"
 # ctest --output-on-failure -C Debug # --verbose
 echo "Install KTX-Software (Android $ANDROID_ABI Debug)"

--- a/scripts/build_android_debug.sh
+++ b/scripts/build_android_debug.sh
@@ -40,7 +40,7 @@ cmake . "${cmake_args[@]}"
 pushd "$BUILD_DIR"
 
 echo "Build KTX-Software (Android $ANDROID_ABI Debug)"
-cmake --build . --config Debug -j
+cmake --build . --config Debug -j $(nproc)
 # echo "Test KTX-Software (Android $ANDROID_ABI Debug)"
 # ctest --output-on-failure -C Debug -j $(nproc) # --verbose
 echo "Install KTX-Software (Android $ANDROID_ABI Debug)"

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -88,10 +88,11 @@ done
 
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
-# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+# To be supplied as `-j $njobs`. This is set to 1 because multi-core builds
+# might, occasionally, fail due to some filesystem race condition(s) caused by
+# `add_custom_command` calls in CMake.
 # Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
-njobs=$(sysctl -n hw.logicalcpu)
+njobs=1
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -155,7 +155,7 @@ do
   IFS=$oldifs # Because of ; IFS set above will still be present.
   # Build and test
   echo "Build KTX-Software (Linux $ARCH $config)"
-  cmake --build . --config $config
+  cmake --build . --config $config -j 1  # -j $njobs
   if [ "$ARCH" = "$(uname -m)" ]; then
     echo "Test KTX-Software (Linux $ARCH $config)"
     ctest --output-on-failure -C $config -j $njobs #--verbose

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -136,8 +136,10 @@ for arg in "${cmake_args[@]}"; do
 done
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
-# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+# To be supplied as `-j $njobs`. Make sure this is only supplied to ctest and
+# not to cmake build command because multi-core builds might, occasionally, fail
+# due to some filesystem race condition(s) caused by `add_custom_command` calls
+# in CMake.
 njobs=$(nproc)
 
 # Print cmake command to be able to verify configuration and replicate locally
@@ -153,7 +155,7 @@ do
   IFS=$oldifs # Because of ; IFS set above will still be present.
   # Build and test
   echo "Build KTX-Software (Linux $ARCH $config)"
-  cmake --build . --config $config -j $njobs
+  cmake --build . --config $config
   if [ "$ARCH" = "$(uname -m)" ]; then
     echo "Test KTX-Software (Linux $ARCH $config)"
     ctest --output-on-failure -C $config -j $njobs #--verbose

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -111,9 +111,10 @@ done
 
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
-# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-# Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
+# To be supplied as `-j $njobs`. Make sure this is only supplied to ctest and
+# not to cmake build command because multi-core builds might, occasionally, fail
+# due to some filesystem race condition(s) caused by `add_custom_command` calls
+# in CMake. Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
 njobs=$(sysctl -n hw.logicalcpu)
 
 # Print cmake command to be able to verify configuration and replicate locally
@@ -135,9 +136,9 @@ do
   #if [ "$config" = "Debug" ]; then continue; fi
   echo "Build KTX-Software (macOS $ARCHS $config)"
   if [ -n "$CODE_SIGN_IDENTITY" -a "$config" = "Release" ]; then
-    cmake --build . --config $config -j $njobs | handle_compiler_output
+    cmake --build . --config $config | handle_compiler_output
   else
-    cmake --build . --config $config -j $njobs -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
+    cmake --build . --config $config -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
   fi
 
   # Rosetta 2 should let x86_64 tests run on an Apple Silicon Mac hence the -o.

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -136,9 +136,9 @@ do
   #if [ "$config" = "Debug" ]; then continue; fi
   echo "Build KTX-Software (macOS $ARCHS $config)"
   if [ -n "$CODE_SIGN_IDENTITY" -a "$config" = "Release" ]; then
-    cmake --build . --config $config | handle_compiler_output
+    cmake --build . --config $config -j 1 | handle_compiler_output
   else
-    cmake --build . --config $config -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
+    cmake --build . --config $config -j 1 -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
   fi
 
   # Rosetta 2 should let x86_64 tests run on an Apple Silicon Mac hence the -o.

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -169,6 +169,10 @@ foreach ($item in $cmake_args) {
 $config_display = $config_display -replace ', $', ''
 echo $config_display
 
+# To be supplied as `-j $njobs`. This is set to 1, because multi-core builds
+# might, occasionally, fail due to some filesystem race condition(s).
+$njobs = 1
+
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . $cmake_args"
 cmake . $cmake_args
@@ -196,7 +200,7 @@ foreach ($config in $configArray) {
   try {
     #git status
     echo "Build KTX-Software (Windows $ARCH $config)"
-    cmake --build . --config $config
+    cmake --build . --config $config -j $njobs
     # Return an error code if cmake fails
     if(!$?){
       popd

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -169,10 +169,6 @@ foreach ($item in $cmake_args) {
 $config_display = $config_display -replace ', $', ''
 echo $config_display
 
-# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
-# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
-$njobs = [Environment]::ProcessorCount
-
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . $cmake_args"
 cmake . $cmake_args
@@ -200,7 +196,7 @@ foreach ($config in $configArray) {
   try {
     #git status
     echo "Build KTX-Software (Windows $ARCH $config)"
-    cmake --build . --config $config -j $njobs
+    cmake --build . --config $config
     # Return an error code if cmake fails
     if(!$?){
       popd


### PR DESCRIPTION
As discussed. See commit message for details.

Added small Note in `BUILDING.md` so that users/developers running `cmake --build build/ -j[N]` won't (hopefully) be surprised when building occasionally fails on Windows (not sure about other platforms).