### PR TITLE
Fix parallel build of loadtest apps

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,13 +25,6 @@ Supported platforms (please see their specific requirements first)
 
 The minimal way to a build is to clone this repository and follow the instructions for your desired build below.
 
-> **Note:**
->
-> Multi-core builds (i.e., running CMake build command with `-j[N]` N > 1) is
-> not supported. Multi-core builds may, occasionally, fail due to
-> filesystem race condition caused by calls to `add_custom_command` in CMake.
-> Running CTest in parallel is, on the other hand, well supported.
-
 _libktx_ only
 -------------
 To build only _libktx_ and nothing else, run the following in a terminal

--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -88,11 +88,10 @@ done
 
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. This is set to 1 because multi-core builds
-# might, occasionally, fail due to some filesystem race condition(s) caused by
-# `add_custom_command` calls in CMake.
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
 # Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
-njobs=1
+njobs=$(sysctl -n hw.logicalcpu)
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . ${cmake_args[@]}"

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -136,10 +136,8 @@ for arg in "${cmake_args[@]}"; do
 done
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. Make sure this is only supplied to ctest and
-# not to cmake build command because multi-core builds might, occasionally, fail
-# due to some filesystem race condition(s) caused by `add_custom_command` calls
-# in CMake.
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
 njobs=$(nproc)
 
 # Print cmake command to be able to verify configuration and replicate locally
@@ -155,7 +153,7 @@ do
   IFS=$oldifs # Because of ; IFS set above will still be present.
   # Build and test
   echo "Build KTX-Software (Linux $ARCH $config)"
-  cmake --build . --config $config -j 1  # -j $njobs
+  cmake --build . --config $config -j $njobs
   if [ "$ARCH" = "$(uname -m)" ]; then
     echo "Test KTX-Software (Linux $ARCH $config)"
     ctest --output-on-failure -C $config -j $njobs #--verbose

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -111,10 +111,9 @@ done
 
 echo ${config_display%??}
 
-# To be supplied as `-j $njobs`. Make sure this is only supplied to ctest and
-# not to cmake build command because multi-core builds might, occasionally, fail
-# due to some filesystem race condition(s) caused by `add_custom_command` calls
-# in CMake. Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+# Equivalent of `nproc` on MacOS is `sysctl -n hw.logicalcpu`
 njobs=$(sysctl -n hw.logicalcpu)
 
 # Print cmake command to be able to verify configuration and replicate locally
@@ -136,9 +135,9 @@ do
   #if [ "$config" = "Debug" ]; then continue; fi
   echo "Build KTX-Software (macOS $ARCHS $config)"
   if [ -n "$CODE_SIGN_IDENTITY" -a "$config" = "Release" ]; then
-    cmake --build . --config $config -j 1 | handle_compiler_output
+    cmake --build . --config $config -j $njobs | handle_compiler_output
   else
-    cmake --build . --config $config -j 1 -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
+    cmake --build . --config $config -j $njobs -- $XCODE_NO_CODESIGN_ENV | handle_compiler_output
   fi
 
   # Rosetta 2 should let x86_64 tests run on an Apple Silicon Mac hence the -o.

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -169,9 +169,9 @@ foreach ($item in $cmake_args) {
 $config_display = $config_display -replace ', $', ''
 echo $config_display
 
-# To be supplied as `-j $njobs`. This is set to 1, because multi-core builds
-# might, occasionally, fail due to some filesystem race condition(s).
-$njobs = 1
+# To be supplied as `-j $njobs`. We might add `+ 1` if the particular cmd is IO
+# bound (this is done in a lot of CIs). On GH CIs, this is most likely to be 4.
+$njobs = [Environment]::ProcessorCount
 
 # Print cmake command to be able to verify configuration and replicate locally
 echo "running cmake command (in source directory): cmake . $cmake_args"

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -201,9 +201,9 @@ elseif(WIN32)
     )
 endif()
 
-set( ktx_icon_sources ${KTX_APP_ICON_SOURCE} ${KTX_DOC_ICON_SOURCE} )
+set( KTX_ICON_SOURCES ${KTX_APP_ICON_SOURCE} ${KTX_DOC_ICON_SOURCE} )
 source_group( "Resources" FILES
-    ${ktx_icon_sources}
+    ${KTX_ICON_SOURCES}
 )
 
 set( LOAD_TEST_COLLADA_MODELS
@@ -304,7 +304,7 @@ unset( load_test_common_ktx_image_sources )
 #    SOURCES ${LOAD_TEST_COMMON_MODELS}
 #)
 
-if(NOT APPLE)
+if(NOT APPLE AND NOT EMSCRIPTEN)
     # Arrange to copy resources next to the executable for ease of use
     # during debugging and testing. Not needed on Apple because resources
     # are copied into the built bundles.
@@ -332,7 +332,7 @@ if(NOT APPLE)
     # will issue a warning that the command completed successfully but
     # no output was generated.
 
-    list(TRANSFORM ktx_icon_sources REPLACE
+    list(TRANSFORM KTX_ICON_SOURCES REPLACE
         "^${PROJECT_SOURCE_DIR}/icons/[a-zA-Z]+/" ${BUILDTIME_RESOURCES_DIR}/
         OUTPUT_VARIABLE ktx_icon_copies
     )
@@ -340,9 +340,9 @@ if(NOT APPLE)
         OUTPUT ${ktx_icon_copies}
         # Make the directory
         COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_icon_sources} ${BUILDTIME_RESOURCES_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${KTX_ICON_SOURCES} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Create buildtime resource destination and copy icons to it"
-        DEPENDS ${ktx_icon_sources}
+        DEPENDS ${KTX_ICON_SOURCES}
         VERBATIM
     )
     add_custom_target(
@@ -350,7 +350,6 @@ if(NOT APPLE)
         DEPENDS ${ktx_icon_copies}
     )
     unset(ktx_icon_copies)
-    unset(ktx_icon_sources)
 
     set(load_test_common_models_copied
         ${LOAD_TEST_COLLADA_MODELS}

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -305,11 +305,10 @@ if(NOT APPLE AND NOT EMSCRIPTEN)
 
     list( REMOVE_DUPLICATES combined_resources )
     list( SORT combined_resources )
-
     list( TRANSFORM combined_resources REPLACE "^[-a-zA-Z0-9_:/<>].*/" ${BUILDTIME_RESOURCES_DIR}/
         OUTPUT_VARIABLE combined_resource_copies
     )
-    cmake_print_variables(combined_resource_copies)
+
     add_custom_command(
         OUTPUT ${combined_resource_copies}
         COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
@@ -338,7 +337,6 @@ if(NOT APPLE AND NOT EMSCRIPTEN)
 
     unset( combined_resource_copies )
     unset( combined_resources )
-
 endif()
 
 

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -234,13 +234,17 @@ set( LOAD_TEST_COMMON_MODEL_SOURCES
      ${LOAD_TEST_COLLADA_MODEL_SOURCES}
      ${LOAD_TEST_OBJ_MODEL_SOURCES}
 )
+source_group("Resources/Models" FILES ${LOAD_TEST_COMMON_MODEL_SOURCES})
 
 set( LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES
     ${KTX_APP_ICON_SOURCE}
     ${KTX_DOC_ICON_SOURCE}
     ${LOAD_TEST_COMMON_MODEL_SOURCES}
 )
-
+source_group("Resources" FILES
+    ${KTX_APP_ICON_SOURCE} ${KTX_DOC_ICON_SOURCE}
+)
+source_group("Resources/Models" ${LOAD_TEST_COMMON_MODEL_SOURCES})
 
 set( load_test_common_ktx2_image_sources
     astc_8x8_unorm_array_7.ktx2
@@ -292,6 +296,8 @@ set( LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES
     ${load_test_common_ktx2_image_sources}
     ${load_test_common_ktx_image_sources}
 )
+source_group("Resources/KTX Images" FILES ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES})
+
 unset( load_test_common_ktx2_image_sources )
 unset( load_test_common_ktx_image_sources )
 

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -242,67 +242,160 @@ set( LOAD_TEST_COMMON_MODEL_SOURCES
 )
 source_group("Resources/Models" FILES ${LOAD_TEST_COMMON_MODEL_SOURCES})
 
-set( load_test_common_ktx2_image_sources
-    astc_8x8_unorm_array_7.ktx2
-    bc3_unorm_array_7.ktx2
-    color_grid_uastc_zstd_5.ktx2
-    color_grid_zstd_5.ktx2
-    color_grid_blze.ktx2
-    cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
-    cubemap_yokohama_blze.ktx2
-    etc2_unorm_array_7.ktx2
-    Iron_Bars_001_normal_blze.ktx2
-    Iron_Bars_001_normal_uastc_zstd_10.ktx2
-    kodim17_blze.ktx2
-    orient_down_metadata.ktx2
-    orient_up_metadata.ktx2
-    pattern_02_bc2.ktx2
-    skybox_zstd_22.ktx2
-)
-list( TRANSFORM load_test_common_ktx2_image_sources
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
-)
-
-set( load_test_common_ktx_image_sources
-    astc_8x8_unorm_array_7.ktx
-    bc3_unorm_array_7.ktx
-    etc1.ktx                     # For {es1,gl3,es3}loadtests
-    etc2_rgb.ktx
-    etc2_rgba1.ktx               # For {es1,gl3,es3}loadtests
-    etc2_rgba8.ktx
-    etc2_srgb.ktx
-    etc2_srgba1.ktx              # For {gl3,es3}loadtests
-    etc2_srgba8.ktx
-    etc2_unorm_array_7.ktx
-    hi_mark_sq.ktx               # For {es1,gl3,es3}loadtests
-    metalplate_amg.ktx
-    not4_r8g8b8_srgb.ktx
-    orient_down_metadata.ktx
-    orient_up_metadata.ktx
-    pattern_02_bc2.ktx
-    r8g8b8_srgb.ktx
-    r8g8b8_srgb_mip.ktx         # For {es1,gl3,es3}loadtests
-    r8g8b8_unorm_amg.ktx
-    r8g8b8a8_srgb.ktx
-)
-list( TRANSFORM load_test_common_ktx_image_sources
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
-)
-set( LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES
-    ${load_test_common_ktx2_image_sources}
-    ${load_test_common_ktx_image_sources}
-)
-source_group("Resources/KTX Images" FILES ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES})
-
-unset( load_test_common_ktx2_image_sources )
-unset( load_test_common_ktx_image_sources )
-
 # A custom loadtest_models target does not work as configure fails at
 # an install_target that uses this with an error "the target is not
 # an executable, library or module."
 #add_custom_target( loadtest_models
 #    SOURCES ${LOAD_TEST_COMMON_MODELS}
 #)
+
+set(test_resources_dir "${PROJECT_SOURCE_DIR}/tests/resources")
+# These KTX FILES lists are needed for installations such as on iOS and macOS
+# where each app has its own resource directory.
+if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "Vulkan")
+    set( VKLOADTESTS_KTX2_FILE_SOURCES
+        alpha_complex_straight.ktx2
+        alpha_complex_premultiplied.ktx2
+        Desk_uastc_hdr4x4_zstd_15.ktx2
+        Desk_uastc_hdr6x6i.ktx2
+        ktx_document_blze.ktx2
+        ktx_document_uastc_rdo_4_zstd_5.ktx2
+        r8g8b8a8_srgb_array_7_mip.ktx2
+        astc_8x8_unorm_array_7.ktx2
+        bc3_unorm_array_7.ktx2
+        color_grid_uastc_zstd_5.ktx2
+        color_grid_zstd_5.ktx2
+        color_grid_blze.ktx2
+        cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
+        cubemap_yokohama_blze.ktx2
+        etc2_unorm_array_7.ktx2
+        Iron_Bars_001_normal_blze.ktx2
+        Iron_Bars_001_normal_uastc_zstd_10.ktx2
+        kodim17_blze.ktx2
+        orient_down_metadata.ktx2
+        orient_up_metadata.ktx2
+        pattern_02_bc2.ktx2
+        skybox_zstd_22.ktx2
+    )
+    list( TRANSFORM VKLOADTESTS_KTX2_FILE_SOURCES
+        PREPEND "${test_resources_dir}/ktx2/"
+    )
+    set( VKLOADTESTS_KTX1_FILE_SOURCES
+        astc_8x8_unorm_array_7.ktx
+        bc3_unorm_array_7.ktx
+        etc1.ktx
+        etc2_rgb.ktx
+        etc2_rgba1.ktx
+        etc2_rgba8.ktx
+        etc2_srgb.ktx
+        etc2_srgba1.ktx
+        etc2_srgba8.ktx
+        etc2_unorm_array_7.ktx
+        hi_mark_sq.ktx
+        metalplate_amg.ktx
+        not4_r8g8b8_srgb.ktx
+        orient_down_metadata.ktx
+        orient_up_metadata.ktx
+        pattern_02_bc2.ktx
+        r8g8b8_srgb.ktx
+        r8g8b8_srgb_mip.ktx
+        r8g8b8_unorm_amg.ktx
+        r8g8b8a8_srgb.ktx
+    )
+    list( TRANSFORM VKLOADTESTS_KTX1_FILE_SOURCES
+        PREPEND "${test_resources_dir}/ktx/"
+    )
+    set( VKLOADTESTS_KTX_FILE_SOURCES
+        ${VKLOADTESTS_KTX2_FILE_SOURCES}
+        ${VKLOADTESTS_KTX1_FILE_SOURCES}
+    )
+endif()
+
+if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "OpenGL")
+    set( GLLOADTESTS_KTX2_FILE_SOURCES
+        FlightHelmet_baseColor_blze.ktx2
+        r8g8b8_srgb_mip.ktx2
+        r8g8b8a8_srgb.ktx2
+        r8g8b8a8_srgb_3d_7.ktx2
+        astc_8x8_unorm_array_7.ktx2
+        bc3_unorm_array_7.ktx2
+        color_grid_uastc_zstd_5.ktx2
+        color_grid_zstd_5.ktx2
+        color_grid_blze.ktx2
+        cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
+        cubemap_yokohama_blze.ktx2
+        etc2_unorm_array_7.ktx2
+        Iron_Bars_001_normal_blze.ktx2
+        Iron_Bars_001_normal_uastc_zstd_10.ktx2
+        kodim17_blze.ktx2
+        orient_down_metadata.ktx2
+        orient_up_metadata.ktx2
+        pattern_02_bc2.ktx2
+        skybox_zstd_22.ktx2
+    )
+    list( TRANSFORM GLLOADTESTS_KTX2_FILE_SOURCES
+        PREPEND "${test_resources_dir}/ktx2/"
+    )
+    set( GLLOADTESTS_KTX1_FILE_SOURCES
+        conftestimage_R11_EAC.ktx
+        conftestimage_SIGNED_R11_EAC.ktx
+        conftestimage_RG11_EAC.ktx
+        conftestimage_SIGNED_RG11_EAC.ktx
+        hi_mark.ktx
+        astc_8x8_unorm_array_7.ktx
+        bc3_unorm_array_7.ktx
+        etc1.ktx
+        etc2_rgb.ktx
+        etc2_rgba1.ktx
+        etc2_rgba8.ktx
+        etc2_srgb.ktx
+        etc2_srgba1.ktx
+        etc2_srgba8.ktx
+        etc2_unorm_array_7.ktx
+        hi_mark_sq.ktx
+        metalplate_amg.ktx
+        not4_r8g8b8_srgb.ktx
+        orient_down_metadata.ktx
+        orient_up_metadata.ktx
+        pattern_02_bc2.ktx
+        r8g8b8_srgb.ktx
+        r8g8b8_srgb_mip.ktx
+        r8g8b8_unorm_amg.ktx
+        r8g8b8a8_srgb.ktx
+    )
+    list( TRANSFORM GLLOADTESTS_KTX1_FILE_SOURCES
+        PREPEND "${test_resources_dir}/ktx/"
+    )
+    set( GLLOADTESTS_KTX_FILE_SOURCES
+        ${GLLOADTESTS_KTX2_FILE_SOURCES}
+        ${GLLOADTESTS_KTX1_FILE_SOURCES}
+    )
+
+    if(IOS OR OPENGL_ES_EMULATOR)
+        set( ES1LOADTESTS_KTX_FILE_SOURCES
+             no_npot.ktx
+             hi_mark.ktx
+             l8_unorm_metadata.ktx
+             orient_up_metadata.ktx
+             orient_down_metadata.ktx
+             etc1.ktx
+             etc2_rgb.ktx
+             etc2_rgba1.ktx
+             etc2_rgba8.ktx
+             r8g8b8a8_srgb.ktx
+             r8g8b8_srgb.ktx
+             r8g8b8_unorm_amg.ktx
+             r8g8b8_srgb_mip.ktx
+             hi_mark_sq.ktx
+        )
+        list( TRANSFORM ES1LOADTESTS_KTX_FILE_SOURCES
+            PREPEND "${test_resources_dir}/ktx/"
+        )
+    endif()
+    #cmake_print_variables(VKLOADTESTS_KTX_FILE_SOURCES GLLOADTESTS_KTX_FILE_SOURCES ES1LOADTESTS_KTX_FILE_SOURCES)
+endif()
+
+source_group( "Resources/KTX Images" REGULAR_EXPRESSION "${test_resources_dir}/ktx(2?)/.*" )
 
 if(NOT APPLE AND NOT EMSCRIPTEN)
     # Arrange to copy resources next to the executable for ease of use
@@ -313,17 +406,17 @@ if(NOT APPLE AND NOT EMSCRIPTEN)
     # being created, the models and some of the KTX files are shared by
     # both gl3loadtests and vkloadtests so when building in parallel the
     # instances of the rule may conflict giving rise to races. To avoid
-    # this use custom targets that become dependencies of the apps which
+    # this we use custom targets that become dependencies of the apps which
     # imposes a strict runtime order on the builds, avoiding races.
     #
     # IMPORTANT NOTE
     # These targets and copies play no part in eventual installation of the
-    # application and are only for convenience during development. Therefore 
-    # the above mentioned error does not occur.
+    # application and are only for convenience during development. How to
+    # install the resources on Windows and Linux has yet to be determined.
 
     # The resources directory is created in the build tree next to the
-    # executable's directory. This sibling relationship will be maintained
-    # when the app and its resources are installed on a system.
+    # executable's directory. The intention is to maintain this sibling
+    # relationship when the app and its resources are installed on a system.
     set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../resources)
 
     # Each of the following custom commands includes a COMMAND to make the
@@ -332,6 +425,7 @@ if(NOT APPLE AND NOT EMSCRIPTEN)
     # will issue a warning that the command completed successfully but
     # no output was generated.
 
+    # Icons
     list(TRANSFORM KTX_ICON_SOURCES REPLACE
         "^${PROJECT_SOURCE_DIR}/icons/[a-zA-Z]+/" ${BUILDTIME_RESOURCES_DIR}/
         OUTPUT_VARIABLE ktx_icon_copies
@@ -351,6 +445,7 @@ if(NOT APPLE AND NOT EMSCRIPTEN)
     )
     unset(ktx_icon_copies)
 
+    # Models
     set(load_test_common_models_copied
         ${LOAD_TEST_COLLADA_MODELS}
         ${LOAD_TEST_OBJ_MODELS}
@@ -370,24 +465,34 @@ if(NOT APPLE AND NOT EMSCRIPTEN)
     )
     unset(load_test_common_models_copied)
 
-    list(TRANSFORM LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
-        OUTPUT_VARIABLE common_ktx_image_copies
+    # KTX files
+    set( ktx_file_sources
+        ${VKLOADTESTS_KTX_FILE_SOURCES}
+        ${GLLOADTESTS_KTX_FILE_SOURCES}
+        ${ES1LOADTESTS_KTX_FILE_SOURCES}
     )
+    list(REMOVE_DUPLICATES ktx_file_sources)
+    list(SORT ktx_file_sources)
+    # The last slash in the regex is VERY important because some of the
+    # files have names beginning with "ktx_" and we don't want to replace
+    # that part of the name.
+    list(TRANSFORM ktx_file_sources REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)/" ${BUILDTIME_RESOURCES_DIR}/
+        OUTPUT_VARIABLE ktx_file_copies
+    )
+    cmake_print_variables(ktx_file_copies)
     add_custom_command(
-        OUTPUT ${common_ktx_image_copies}
+        OUTPUT ${ktx_file_copies}
         COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy common KTX and KTX2 images to buildtime resource destination"
-        DEPENDS ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_file_sources} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Copy KTX and KTX2 images to buildtime resource destination"
+        DEPENDS ${ktx_file_sources}
         VERBATIM
     )
     add_custom_target(
-        copied_common_ktx_images
-        DEPENDS ${common_ktx_image_copies}  
+        copied_ktx_files
+        DEPENDS ${ktx_file_copies}  
     )
-    # To ensure the resources directory is created before copying KTX images.
-    #add_dependencies( copied_common_ktx_images copied_models )
-    unset( common_ktx_image_copies )
+    unset( ktx_file_copies )
 endif()
 
 if(LINUX)

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -168,10 +168,10 @@ set( LOAD_TEST_COMMON_LIBS )
 
 if(APPLE)
     set( EXE_FLAG MACOSX_BUNDLE )
-    set( KTX_APP_ICON_BASENAME ktx_app)
-    set( KTX_DOC_ICON_BASENAME ktx_document)
-    set( KTX_APP_ICON ${KTX_APP_ICON_BASENAME}.icns)
-    set( KTX_DOC_ICON ${KTX_DOC_ICON_BASENAME}.icns)
+    set( ktx_app_icon_basename ktx_app)
+    set( ktx_doc_icon_basename ktx_document)
+    set( KTX_APP_ICON ${ktx_app_icon_basename}.icns)
+    set( KTX_DOC_ICON ${ktx_doc_icon_basename}.icns)
     # On iOS an icon is a directory of images not a single file.
     # BASENAME is the name of the directory in the common .xcassets directory.
     # Assets are copied to the bundle in the build target setup.
@@ -201,11 +201,17 @@ elseif(WIN32)
     )
 endif()
 
+set( ktx_icon_sources ${KTX_APP_ICON_SOURCE} ${KTX_DOC_ICON_SOURCE} )
+source_group( "Resources" FILES
+    ${ktx_icon_sources}
+)
+
 set( LOAD_TEST_COLLADA_MODELS
      "teapot.dae"
 )
 
-list(TRANSFORM LOAD_TEST_COLLADA_MODELS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/common/models/"
+list( TRANSFORM LOAD_TEST_COLLADA_MODELS PREPEND
+    "${CMAKE_CURRENT_SOURCE_DIR}/common/models/"
     OUTPUT_VARIABLE LOAD_TEST_COLLADA_MODEL_SOURCES
 )
 # An Xcode (or possibly CMake) update in late 2024 or early 2025 started
@@ -235,16 +241,6 @@ set( LOAD_TEST_COMMON_MODEL_SOURCES
      ${LOAD_TEST_OBJ_MODEL_SOURCES}
 )
 source_group("Resources/Models" FILES ${LOAD_TEST_COMMON_MODEL_SOURCES})
-
-set( LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES
-    ${KTX_APP_ICON_SOURCE}
-    ${KTX_DOC_ICON_SOURCE}
-    ${LOAD_TEST_COMMON_MODEL_SOURCES}
-)
-source_group("Resources" FILES
-    ${KTX_APP_ICON_SOURCE} ${KTX_DOC_ICON_SOURCE}
-)
-source_group("Resources/Models" ${LOAD_TEST_COMMON_MODEL_SOURCES})
 
 set( load_test_common_ktx2_image_sources
     astc_8x8_unorm_array_7.ktx2
@@ -325,48 +321,64 @@ if(NOT APPLE)
     # application and are only for convenience during development. Therefore 
     # the above mentioned error does not occur.
 
-    set(load_test_common_resources_copied
-        ${KTX_APP_ICON}  # TODO: Is this needed on Windows?
-        ${KTX_DOC_ICON}
-        ${LOAD_TEST_COLLADA_MODELS}
-        ${LOAD_TEST_OBJ_MODELS}
-    )
     # The resources directory is created in the build tree next to the
     # executable's directory. This sibling relationship will be maintained
     # when the app and its resources are installed on a system.
     set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../resources)
-    list(TRANSFORM load_test_common_resources_copied PREPEND ${BUILDTIME_RESOURCES_DIR}/)
 
+    # Each of the following custom commands includes a COMMAND to make the
+    # directory as it is not possible to make a custom command to create an
+    # empty directory. If you try the projects created by some generators
+    # will issue a warning that the command completed successfully but
+    # no output was generated.
+
+    list(TRANSFORM ktx_icon_sources REPLACE
+        "^${PROJECT_SOURCE_DIR}/icons/[a-zA-Z]+/" ${BUILDTIME_RESOURCES_DIR}/
+        OUTPUT_VARIABLE ktx_icon_copies
+    )
     add_custom_command(
-        OUTPUT ${BUILDTIME_RESOURCES_DIR}
+        OUTPUT ${ktx_icon_copies}
+        # Make the directory
         COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMENT "Make resources directory"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_icon_sources} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Create buildtime resource destination and copy icons to it"
+        DEPENDS ${ktx_icon_sources}
         VERBATIM
     )
     add_custom_target(
-        buildtime_resources_dir
-        DEPENDS ${BUILDTIME_RESOURCES_DIR}
+        copied_ktx_icons
+        DEPENDS ${ktx_icon_copies}
     )
+    unset(ktx_icon_copies)
+    unset(ktx_icon_sources)
+
+    set(load_test_common_models_copied
+        ${LOAD_TEST_COLLADA_MODELS}
+        ${LOAD_TEST_OBJ_MODELS}
+    )
+    list(TRANSFORM load_test_common_models_copied PREPEND ${BUILDTIME_RESOURCES_DIR}/)
     add_custom_command(
-        OUTPUT ${load_test_common_resources_copied}
+        OUTPUT ${load_test_common_models_copied}
         COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy common resources (icons and models to build destination"
-        DEPENDS ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_MODEL_SOURCES} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Copy common models to buildtime resource destination"
+        DEPENDS ${LOAD_TEST_COMMON_MODEL_SOURCES}
         VERBATIM
     )
     add_custom_target(
         copied_models
-        DEPENDS ${load_test_common_resources_copied}
+        DEPENDS ${load_test_common_models_copied}
     )
-    unset(load_test_common_resources_copied)
+    unset(load_test_common_models_copied)
+
     list(TRANSFORM LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
         OUTPUT_VARIABLE common_ktx_image_copies
     )
     add_custom_command(
         OUTPUT ${common_ktx_image_copies}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy common KTX and KTX2 images to build destination"
+        COMMENT "Copy common KTX and KTX2 images to buildtime resource destination"
         DEPENDS ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
         VERBATIM
     )
@@ -375,7 +387,7 @@ if(NOT APPLE)
         DEPENDS ${common_ktx_image_copies}  
     )
     # To ensure the resources directory is created before copying KTX images.
-    add_dependencies( copied_common_ktx_images copied_models )
+    #add_dependencies( copied_common_ktx_images copied_models )
     unset( common_ktx_image_copies )
 endif()
 

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -248,7 +248,7 @@ set( LOAD_TEST_OBJ_MODELS
      "sphere.obj"
      "torusknot.obj"
 )
-list(TRANSFORM LOAD_TEST_OBJ_MODELS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/common/models/"
+list( TRANSFORM LOAD_TEST_OBJ_MODELS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/common/models/"
     OUTPUT_VARIABLE LOAD_TEST_OBJ_MODEL_SOURCES
 )
 # Hack to prevent *.obj 3D files being mistaken as linkable obj files
@@ -266,6 +266,60 @@ set( LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES
     ${LOAD_TEST_COMMON_MODEL_SOURCES}
 )
 
+
+set( load_test_common_ktx2_image_sources
+    astc_8x8_unorm_array_7.ktx2
+    bc3_unorm_array_7.ktx2
+    color_grid_uastc_zstd_5.ktx2
+    color_grid_zstd_5.ktx2
+    color_grid_blze.ktx2
+    cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
+    cubemap_yokohama_blze.ktx2
+    etc2_unorm_array_7.ktx2
+    Iron_Bars_001_normal_blze.ktx2
+    Iron_Bars_001_normal_uastc_zstd_10.ktx2
+    kodim17_blze.ktx2
+    orient_down_metadata.ktx2
+    orient_up_metadata.ktx2
+    pattern_02_bc2.ktx2
+    skybox_zstd_22.ktx2
+)
+list( TRANSFORM load_test_common_ktx2_image_sources
+    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
+)
+
+set( load_test_common_ktx_image_sources
+    astc_8x8_unorm_array_7.ktx
+    bc3_unorm_array_7.ktx
+    etc1.ktx                     # For {es1,gl3,es3}loadtests
+    etc2_rgb.ktx
+    etc2_rgba1.ktx               # For {es1,gl3,es3}loadtests
+    etc2_rgba8.ktx
+    etc2_srgb.ktx
+    etc2_srgba1.ktx              # For {gl3,es3}loadtests
+    etc2_srgba8.ktx
+    etc2_unorm_array_7.ktx
+    hi_mark_sq.ktx               # For {es1,gl3,es3}loadtests
+    metalplate_amg.ktx
+    not4_r8g8b8_srgb.ktx
+    orient_down_metadata.ktx
+    orient_up_metadata.ktx
+    pattern_02_bc2.ktx
+    r8g8b8_srgb.ktx
+    r8g8b8_srgb_mip.ktx         # For {es1,gl3,es3}loadtests
+    r8g8b8_unorm_amg.ktx
+    r8g8b8a8_srgb.ktx
+)
+list( TRANSFORM load_test_common_ktx_image_sources
+    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
+)
+set( LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES
+    ${load_test_common_ktx2_image_sources}
+    ${load_test_common_ktx_image_sources}
+)
+unset( load_test_common_ktx2_image_sources )
+unset( load_test_common_ktx_image_sources )
+
 # A custom loadtest_models target does not work as configure fails at
 # an install_target that uses this with an error "the target is not
 # an executable, library or module."
@@ -279,13 +333,13 @@ if(NOT APPLE)
     # are copied into the built bundles.
     #
     # We cannot use just custom commands because the resources directory
-    # being created and the models are shared by both gl3loadtests and
-    # vkloadtests so when building in parallel the instances of the rule may
-    # conflict giving rise to races. To avoid this use custom targets which
-    # are dependencies of the apps which imposes a strict runtime order on
-    # the builds, avoiding races.
+    # being created, the models and some of the KTX files are shared by
+    # both gl3loadtests and vkloadtests so when building in parallel the
+    # instances of the rule may conflict giving rise to races. To avoid
+    # this use custom targets that become dependencies of the apps which
+    # imposes a strict runtime order on the builds, avoiding races.
     #
-    # IMPORTANT NOTICE
+    # IMPORTANT NOTE
     # These targets and copies play no part in eventual installation of the
     # application and are only for convenience during development. Therefore 
     # the above mentioned error does not occur.
@@ -299,7 +353,6 @@ if(NOT APPLE)
     set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resources)
     list(TRANSFORM LOAD_TEST_COMMON_RESOURCES_COPIED PREPEND ${BUILDTIME_RESOURCES_DIR}/)
 
-    cmake_print_variables(BUILDTIME_RESOURCES_DIR LOAD_TEST_COMMON_RESOURCES_COPIED)
     set_source_files_properties(buildtime_resources_dir PROPERTIES SYMBOLIC 1)
     add_custom_command(
         OUTPUT ${BUILDTIME_RESOURCES_DIR}
@@ -311,7 +364,6 @@ if(NOT APPLE)
         buildtime_resources_dir
         DEPENDS ${BUILDTIME_RESOURCES_DIR}
     )
-    cmake_print_variables(BUILDTIME_RESOURCES_DIR)    
     add_custom_command(
         OUTPUT ${LOAD_TEST_COMMON_RESOURCES_COPIED}
         COMMAND ${CMAKE_COMMAND} -E echo  ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
@@ -323,8 +375,24 @@ if(NOT APPLE)
         copied_models
         DEPENDS ${LOAD_TEST_COMMON_RESOURCES_COPIED}
     )
-    add_dependencies(copied_models buildtime_resources_dir)
+    add_dependencies( copied_models buildtime_resources_dir )
     unset(LOAD_TEST_COMMON_RESOURCES_COPIED)
+    list(TRANSFORM LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
+        OUTPUT_VARIABLE common_ktx_image_copies
+    )
+    cmake_print_variables( common_ktx_image_copies )
+    add_custom_command(
+        OUTPUT ${common_ktx_image_copies}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Copy common KTX and KTX2 images to build destination"
+        VERBATIM
+    )
+    add_custom_target(
+        copied_common_ktx_images
+        DEPENDS ${common_ktx_image_copies}  
+    )
+    add_dependencies( copied_common_ktx_images buildtime_resources_dir )
+    unset( common_ktx_image_copies )
 endif()
 
 if(LINUX)

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -68,24 +68,24 @@ function( ensure_runtime_dependencies_windows target test_images )
     # Custom copy commands to ensure all dependencies (test images,
     # shaders, models) are in correct location relative to executable.
 
-    add_custom_command( TARGET ${target} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${target}>/resources"
-        COMMENT "Make resources directory"
-    )
-    if(${target} MATCHES "vkloadtests")
-        add_custom_command( TARGET ${target} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_directory  "${CMAKE_CURRENT_BINARY_DIR}/shaders" "$<TARGET_FILE_DIR:${target}>/resources"
-            COMMENT "Copy shaders to build destination"
-        )
-    endif()
-    add_custom_command( TARGET ${target} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${test_images} "$<TARGET_FILE_DIR:${target}>/resources"
-        COMMENT "Copy testimages to build destination"
-    )
-    add_custom_command( TARGET ${target} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory  "${PROJECT_SOURCE_DIR}/tests/loadtests/common/models" "$<TARGET_FILE_DIR:${target}>/resources"
-        COMMENT "Copy models to build destination"
-    )
+#    add_custom_command( TARGET ${target} POST_BUILD
+#        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${target}>/resources"
+#        COMMENT "Make resources directory"
+#    )
+#    if(${target} MATCHES "vkloadtests")
+#        add_custom_command( TARGET ${target} POST_BUILD
+#            COMMAND ${CMAKE_COMMAND} -E copy_directory  "${CMAKE_CURRENT_BINARY_DIR}/shaders" "$<TARGET_FILE_DIR:${target}>/resources"
+#            COMMENT "Copy shaders to build destination"
+#        )
+#    endif()
+#    add_custom_command( TARGET ${target} POST_BUILD
+#        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${test_images} "$<TARGET_FILE_DIR:${target}>/resources"
+#        COMMENT "Copy testimages to build destination"
+#    )
+#    add_custom_command( TARGET ${target} POST_BUILD
+#        COMMAND ${CMAKE_COMMAND} -E copy_directory  "${PROJECT_SOURCE_DIR}/tests/loadtests/common/models" "$<TARGET_FILE_DIR:${target}>/resources"
+#        COMMENT "Copy models to build destination"
+#    )
 endfunction()
 
 add_library( appfwSDL STATIC
@@ -199,8 +199,8 @@ if(APPLE)
     # On iOS an icon is a directory of images not a single file.
     # BASENAME is the name of the directory in the common .xcassets directory.
     # Assets are copied to the bundle in the build target setup.
-    set( KTX_APP_ICON_PATH ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_APP_ICON} )
-    set( KTX_DOC_ICON_PATH ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_DOC_ICON} )
+    set( KTX_APP_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_APP_ICON} )
+    set( KTX_DOC_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_DOC_ICON} )
     cmake_print_variables(assimp_LIBRARIES)
     if(IOS)
         set( LOAD_TEST_COMMON_LIBS
@@ -212,7 +212,7 @@ if(APPLE)
         )
     endif()
 elseif(LINUX)
-    set( KTX_APP_ICON_PATH ${PROJECT_SOURCE_DIR}/icons/linux/ktx_app.svg )
+    set( KTX_APP_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/linux/ktx_app.svg )
     set( LOAD_TEST_COMMON_LIBS
         assimp::assimp
         #${SDL3_LIBRARIES}
@@ -220,7 +220,7 @@ elseif(LINUX)
     )
 elseif(WIN32)
     set( EXE_FLAG WIN32 )
-    set( KTX_APP_ICON_PATH ${PROJECT_SOURCE_DIR}/icons/win/ktx_app.ico )
+    set( KTX_APP_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/win/ktx_app.ico )
     set( LOAD_TEST_COMMON_LIBS
         assimp::assimp
     )
@@ -229,13 +229,16 @@ endif()
 set( LOAD_TEST_COLLADA_MODELS
      "teapot.dae"
 )
-list(TRANSFORM LOAD_TEST_COLLADA_MODELS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/common/models/")
+
+list(TRANSFORM LOAD_TEST_COLLADA_MODELS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/common/models/"
+    OUTPUT_VARIABLE LOAD_TEST_COLLADA_MODEL_SOURCES
+)
 # An Xcode (or possibly CMake) update in late 2024 or early 2025 started
 # compressing .dae files when copying them to bundle resources. This piece
 # of undocumented magic makes it just copy. The Xcode GUI presents an option
 # menu on the file with "Copy" and "Compress" in the project settings browser.
 # This attribute sets it to "Copy."
-set_source_files_properties( ${LOAD_TEST_COLLADA_MODELS}
+set_source_files_properties( ${LOAD_TEST_COLLADA_MODEL_SOURCES}
     PROPERTIES
         XCODE_FILE_ATTRIBUTES "--decompress"
 )
@@ -245,14 +248,22 @@ set( LOAD_TEST_OBJ_MODELS
      "sphere.obj"
      "torusknot.obj"
 )
-list(TRANSFORM LOAD_TEST_OBJ_MODELS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/common/models/")
+list(TRANSFORM LOAD_TEST_OBJ_MODELS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/common/models/"
+    OUTPUT_VARIABLE LOAD_TEST_OBJ_MODEL_SOURCES
+)
 # Hack to prevent *.obj 3D files being mistaken as linkable obj files
-set_source_files_properties( ${LOAD_TEST_OBJ_MODELS}
+set_source_files_properties( ${LOAD_TEST_OBJ_MODEL_SOURCES}
     PROPERTIES HEADER_FILE_ONLY TRUE
 )
-set( LOAD_TEST_COMMON_MODELS
-     ${LOAD_TEST_COLLADA_MODELS}
-     ${LOAD_TEST_OBJ_MODELS}
+set( LOAD_TEST_COMMON_MODEL_SOURCES
+     ${LOAD_TEST_COLLADA_MODEL_SOURCES}
+     ${LOAD_TEST_OBJ_MODEL_SOURCES}
+)
+
+set( LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES
+    ${KTX_APP_ICON_SOURCE_PATH}
+    ${KTX_DOC_ICON_SOURCE_PATH}
+    ${LOAD_TEST_COMMON_MODEL_SOURCES}
 )
 
 # A custom loadtest_models target does not work as configure fails at
@@ -262,45 +273,58 @@ set( LOAD_TEST_COMMON_MODELS
 #    SOURCES ${LOAD_TEST_COMMON_MODELS}
 #)
 
-set( LOAD_TEST_COMMON_RESOURCE_FILES
-    ${KTX_APP_ICON_PATH}
-    ${KTX_DOC_ICON_PATH}
-    ${LOAD_TEST_COMMON_MODELS}
-)
+if(NOT APPLE)
+    # Arrange to copy resources next to the executable for ease of use
+    # during debugging and testing. Not needed on Apple because resources
+    # are copied into the built bundles.
+    #
+    # We cannot use just custom commands because the resources directory
+    # being created and the models are shared by both gl3loadtests and
+    # vkloadtests so when building in parallel the instances of the rule may
+    # conflict giving rise to races. To avoid this use custom targets which
+    # are dependencies of the apps which imposes a strict runtime order on
+    # the builds, avoiding races.
+    #
+    # IMPORTANT NOTICE
+    # These targets and copies play no part in eventual installation of the
+    # application and are only for convenience during development. Therefore 
+    # the above mentioned error does not occur.
 
-if(WIN32)
-    # On Windows resources for both gl3loadtests and vkloadtests go in the same resources
-    # folder therefore to support parallel builds and avoid races copying must be done via
-    # custom targets.
-#if(WIN32 AND KTX_FEATURE_LOADTEST_APPS)
-#    if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "OpenGL")
-#        set(target_dir $<TARGET_FILE_DIR:gl3loadtests>/resources)
-#    elseif(${KTX_FEATURE_LOADTEST_APPS} MATCHES "Vulkan")
-#        set(target_dir $<TARGET_FILE_DIR:vkloadtests>/resources)
-    set(resources_dir resources)
+    set(LOAD_TEST_COMMON_RESOURCES_COPIED
+        ${KTX_APP_ICON}  # TODO: Is this needed on Windows?
+    #    ${KTX_DOC_ICON} # Only needed on Apple.
+        ${LOAD_TEST_COLLADA_MODELS}
+        ${LOAD_TEST_OBJ_MODELS}
+    )
+    set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resources)
+    list(TRANSFORM LOAD_TEST_COMMON_RESOURCES_COPIED PREPEND ${BUILDTIME_RESOURCES_DIR}/)
+
+    cmake_print_variables(BUILDTIME_RESOURCES_DIR LOAD_TEST_COMMON_RESOURCES_COPIED)
+    set_source_files_properties(buildtime_resources_dir PROPERTIES SYMBOLIC 1)
     add_custom_command(
-        OUTPUT ${resources_dir}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${resources_dir}"
+        OUTPUT ${BUILDTIME_RESOURCES_DIR}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
         COMMENT "Make resources directory"
+        VERBATIM
     )
     add_custom_target(
-        resources_dir
-        DEPENDS ${resources_dir}
+        buildtime_resources_dir
+        DEPENDS ${BUILDTIME_RESOURCES_DIR}
     )
-    unset(resources_dir)
-
-    LOAD_TEST_COMMON_MODELS
-    list(TRANSFORM LOAD_TEST_COMMON_MODELS PREPEND ${resources_dir} OUTPUT_VARIABLE copied_models)
+    cmake_print_variables(BUILDTIME_RESOURCES_DIR)    
     add_custom_command(
-        OUTPUT ${copied_models}
-        COMMAND ${CMAKE_COMMAND} -E copy_directory  "${PROJECT_SOURCE_DIR}/tests/loadtests/common/models" "${resources_dir}"
+        OUTPUT ${LOAD_TEST_COMMON_RESOURCES_COPIED}
+        COMMAND ${CMAKE_COMMAND} -E echo  ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy models to build destination"
+        VERBATIM
     )
     add_custom_target(
         copied_models
-        DEPENDS ${copied_models}
+        DEPENDS ${LOAD_TEST_COMMON_RESOURCES_COPIED}
     )
-    unset(copied_models)
+    add_dependencies(copied_models buildtime_resources_dir)
+    unset(LOAD_TEST_COMMON_RESOURCES_COPIED)
 endif()
 
 if(LINUX)

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -249,251 +249,7 @@ source_group("Resources/Models" FILES ${LOAD_TEST_COMMON_MODEL_SOURCES})
 #    SOURCES ${LOAD_TEST_COMMON_MODELS}
 #)
 
-set(test_resources_dir "${PROJECT_SOURCE_DIR}/tests/resources")
-# These KTX FILES lists are needed for installations such as on iOS and macOS
-# where each app has its own resource directory.
-if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "Vulkan")
-    set( VKLOADTESTS_KTX2_FILE_SOURCES
-        alpha_complex_straight.ktx2
-        alpha_complex_premultiplied.ktx2
-        Desk_uastc_hdr4x4_zstd_15.ktx2
-        Desk_uastc_hdr6x6i.ktx2
-        ktx_document_blze.ktx2
-        ktx_document_uastc_rdo_4_zstd_5.ktx2
-        r8g8b8a8_srgb_array_7_mip.ktx2
-        astc_8x8_unorm_array_7.ktx2
-        bc3_unorm_array_7.ktx2
-        color_grid_uastc_zstd_5.ktx2
-        color_grid_zstd_5.ktx2
-        color_grid_blze.ktx2
-        cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
-        cubemap_yokohama_blze.ktx2
-        etc2_unorm_array_7.ktx2
-        Iron_Bars_001_normal_blze.ktx2
-        Iron_Bars_001_normal_uastc_zstd_10.ktx2
-        kodim17_blze.ktx2
-        orient_down_metadata.ktx2
-        orient_up_metadata.ktx2
-        pattern_02_bc2.ktx2
-        skybox_zstd_22.ktx2
-    )
-    list( TRANSFORM VKLOADTESTS_KTX2_FILE_SOURCES
-        PREPEND "${test_resources_dir}/ktx2/"
-    )
-    set( VKLOADTESTS_KTX1_FILE_SOURCES
-        astc_8x8_unorm_array_7.ktx
-        bc3_unorm_array_7.ktx
-        etc1.ktx
-        etc2_rgb.ktx
-        etc2_rgba1.ktx
-        etc2_rgba8.ktx
-        etc2_srgb.ktx
-        etc2_srgba1.ktx
-        etc2_srgba8.ktx
-        etc2_unorm_array_7.ktx
-        hi_mark_sq.ktx
-        metalplate_amg.ktx
-        not4_r8g8b8_srgb.ktx
-        orient_down_metadata.ktx
-        orient_up_metadata.ktx
-        pattern_02_bc2.ktx
-        r8g8b8_srgb.ktx
-        r8g8b8_srgb_mip.ktx
-        r8g8b8_unorm_amg.ktx
-        r8g8b8a8_srgb.ktx
-    )
-    list( TRANSFORM VKLOADTESTS_KTX1_FILE_SOURCES
-        PREPEND "${test_resources_dir}/ktx/"
-    )
-    set( VKLOADTESTS_KTX_FILE_SOURCES
-        ${VKLOADTESTS_KTX2_FILE_SOURCES}
-        ${VKLOADTESTS_KTX1_FILE_SOURCES}
-    )
-endif()
-
-if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "OpenGL")
-    set( GLLOADTESTS_KTX2_FILE_SOURCES
-        FlightHelmet_baseColor_blze.ktx2
-        r8g8b8_srgb_mip.ktx2
-        r8g8b8a8_srgb.ktx2
-        r8g8b8a8_srgb_3d_7.ktx2
-        astc_8x8_unorm_array_7.ktx2
-        bc3_unorm_array_7.ktx2
-        color_grid_uastc_zstd_5.ktx2
-        color_grid_zstd_5.ktx2
-        color_grid_blze.ktx2
-        cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
-        cubemap_yokohama_blze.ktx2
-        etc2_unorm_array_7.ktx2
-        Iron_Bars_001_normal_blze.ktx2
-        Iron_Bars_001_normal_uastc_zstd_10.ktx2
-        kodim17_blze.ktx2
-        orient_down_metadata.ktx2
-        orient_up_metadata.ktx2
-        pattern_02_bc2.ktx2
-        skybox_zstd_22.ktx2
-    )
-    list( TRANSFORM GLLOADTESTS_KTX2_FILE_SOURCES
-        PREPEND "${test_resources_dir}/ktx2/"
-    )
-    set( GLLOADTESTS_KTX1_FILE_SOURCES
-        conftestimage_R11_EAC.ktx
-        conftestimage_SIGNED_R11_EAC.ktx
-        conftestimage_RG11_EAC.ktx
-        conftestimage_SIGNED_RG11_EAC.ktx
-        hi_mark.ktx
-        astc_8x8_unorm_array_7.ktx
-        bc3_unorm_array_7.ktx
-        etc1.ktx
-        etc2_rgb.ktx
-        etc2_rgba1.ktx
-        etc2_rgba8.ktx
-        etc2_srgb.ktx
-        etc2_srgba1.ktx
-        etc2_srgba8.ktx
-        etc2_unorm_array_7.ktx
-        hi_mark_sq.ktx
-        metalplate_amg.ktx
-        not4_r8g8b8_srgb.ktx
-        orient_down_metadata.ktx
-        orient_up_metadata.ktx
-        pattern_02_bc2.ktx
-        r8g8b8_srgb.ktx
-        r8g8b8_srgb_mip.ktx
-        r8g8b8_unorm_amg.ktx
-        r8g8b8a8_srgb.ktx
-    )
-    list( TRANSFORM GLLOADTESTS_KTX1_FILE_SOURCES
-        PREPEND "${test_resources_dir}/ktx/"
-    )
-    set( GLLOADTESTS_KTX_FILE_SOURCES
-        ${GLLOADTESTS_KTX2_FILE_SOURCES}
-        ${GLLOADTESTS_KTX1_FILE_SOURCES}
-    )
-
-    if(IOS OR OPENGL_ES_EMULATOR)
-        set( ES1LOADTESTS_KTX_FILE_SOURCES
-             no_npot.ktx
-             hi_mark.ktx
-             l8_unorm_metadata.ktx
-             orient_up_metadata.ktx
-             orient_down_metadata.ktx
-             etc1.ktx
-             etc2_rgb.ktx
-             etc2_rgba1.ktx
-             etc2_rgba8.ktx
-             r8g8b8a8_srgb.ktx
-             r8g8b8_srgb.ktx
-             r8g8b8_unorm_amg.ktx
-             r8g8b8_srgb_mip.ktx
-             hi_mark_sq.ktx
-        )
-        list( TRANSFORM ES1LOADTESTS_KTX_FILE_SOURCES
-            PREPEND "${test_resources_dir}/ktx/"
-        )
-    endif()
-    #cmake_print_variables(VKLOADTESTS_KTX_FILE_SOURCES GLLOADTESTS_KTX_FILE_SOURCES ES1LOADTESTS_KTX_FILE_SOURCES)
-endif()
-
-source_group( "Resources/KTX Images" REGULAR_EXPRESSION "${test_resources_dir}/ktx(2?)/.*" )
-
-if(NOT APPLE AND NOT EMSCRIPTEN)
-    # Arrange to copy resources next to the executable for ease of use
-    # during debugging and testing. Not needed on Apple because resources
-    # are copied into the built bundles.
-    #
-    # We cannot use just custom commands because the resources directory
-    # being created, the models and some of the KTX files are shared by
-    # both gl3loadtests and vkloadtests so when building in parallel the
-    # instances of the rule may conflict giving rise to races. To avoid
-    # this we use custom targets that become dependencies of the apps which
-    # imposes a strict runtime order on the builds, avoiding races.
-    #
-    # IMPORTANT NOTE
-    # These targets and copies play no part in eventual installation of the
-    # application and are only for convenience during development. How to
-    # install the resources on Windows and Linux has yet to be determined.
-
-    # The resources directory is created in the build tree next to the
-    # executable's directory. The intention is to maintain this sibling
-    # relationship when the app and its resources are installed on a system.
-    set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../resources)
-
-    # Each of the following custom commands includes a COMMAND to make the
-    # directory as it is not possible to make a custom command to create an
-    # empty directory. If you try the projects created by some generators
-    # will issue a warning that the command completed successfully but
-    # no output was generated.
-
-    # Icons
-    list(TRANSFORM KTX_ICON_SOURCES REPLACE
-        "^${PROJECT_SOURCE_DIR}/icons/[a-zA-Z]+/" ${BUILDTIME_RESOURCES_DIR}/
-        OUTPUT_VARIABLE ktx_icon_copies
-    )
-    add_custom_command(
-        OUTPUT ${ktx_icon_copies}
-        # Make the directory
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${KTX_ICON_SOURCES} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Create buildtime resource destination and copy icons to it"
-        DEPENDS ${KTX_ICON_SOURCES}
-        VERBATIM
-    )
-    add_custom_target(
-        copied_ktx_icons
-        DEPENDS ${ktx_icon_copies}
-    )
-    unset(ktx_icon_copies)
-
-    # Models
-    set(load_test_common_models_copied
-        ${LOAD_TEST_COLLADA_MODELS}
-        ${LOAD_TEST_OBJ_MODELS}
-    )
-    list(TRANSFORM load_test_common_models_copied PREPEND ${BUILDTIME_RESOURCES_DIR}/)
-    add_custom_command(
-        OUTPUT ${load_test_common_models_copied}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_MODEL_SOURCES} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy common models to buildtime resource destination"
-        DEPENDS ${LOAD_TEST_COMMON_MODEL_SOURCES}
-        VERBATIM
-    )
-    add_custom_target(
-        copied_models
-        DEPENDS ${load_test_common_models_copied}
-    )
-    unset(load_test_common_models_copied)
-
-    # KTX files
-    set( ktx_file_sources
-        ${VKLOADTESTS_KTX_FILE_SOURCES}
-        ${GLLOADTESTS_KTX_FILE_SOURCES}
-        ${ES1LOADTESTS_KTX_FILE_SOURCES}
-    )
-    list(REMOVE_DUPLICATES ktx_file_sources)
-    list(SORT ktx_file_sources)
-    # The last slash in the regex is VERY important because some of the
-    # files have names beginning with "ktx_" and we don't want to replace
-    # that part of the name.
-    list(TRANSFORM ktx_file_sources REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)/" ${BUILDTIME_RESOURCES_DIR}/
-        OUTPUT_VARIABLE ktx_file_copies
-    )
-    cmake_print_variables(ktx_file_copies)
-    add_custom_command(
-        OUTPUT ${ktx_file_copies}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_file_sources} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy KTX and KTX2 images to buildtime resource destination"
-        DEPENDS ${ktx_file_sources}
-        VERBATIM
-    )
-    add_custom_target(
-        copied_ktx_files
-        DEPENDS ${ktx_file_copies}  
-    )
-    unset( ktx_file_copies )
-endif()
+set(TEST_RESOURCES_DIR "${PROJECT_SOURCE_DIR}/tests/resources")
 
 if(LINUX)
     set( LOAD_TEST_DESTROOT "/opt" )
@@ -506,3 +262,83 @@ endif()
 if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "Vulkan")
     include(vkloadtests.cmake)
 endif()
+
+if(NOT APPLE AND NOT EMSCRIPTEN)
+    # Arrange to copy resources next to the executable for ease of use
+    # during debugging and testing. Not needed on Apple because resources
+    # are copied into the built bundles.
+    #
+    # We cannot use just custom commands because this copy of the resources
+    # is shared by multiple targets so when building in parallel the
+    # instances of the rule may conflict giving rise to races. To avoid
+    # this we use a custom target whichh we make a dependency of the targets
+    # which imposes a strict runtime order on the builds, avoiding races.
+    #
+    # IMPORTANT NOTE
+    # This target and copy of the resources play no part in eventual
+    # installation of the application and are only for convenience during
+    # development. How to install the resources on Windows and Linux has
+    # yet to be determined.
+
+    # The resources directory is created in the build tree next to the
+    # executable's directory. The intention is to maintain this sibling
+    # relationship when the app and its resources are installed on a system.
+    set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../resources)
+
+    set( combined_resources "" )
+    if(TARGET vkloadtests)
+        get_target_property( vk_resources vkloadtests RESOURCE )
+        list(APPEND combined_resources ${vk_resources})
+    endif()
+    if(TARGET gl3loadtests)
+        get_target_property( gl3_resources gl3loadtests RESOURCE )
+        list( APPEND combined_resources ${gl3_resources} )
+    endif()
+    if(TARGET es3loadtests)
+        get_target_property( es3_resources es3loadtests RESOURCE )
+        list( APPEND combined_resources ${es3_resources} )
+    endif()
+    if(TARGET es1loadtests)
+        get_target_property( es1_resources es1loadtests RESOURCE )
+        list( APPEND combined_resources ${es1_resources} )
+    endif()
+
+    list( REMOVE_DUPLICATES combined_resources )
+    list( SORT combined_resources )
+
+    list( TRANSFORM combined_resources REPLACE "^[-a-zA-Z0-9_:/<>].*/" ${BUILDTIME_RESOURCES_DIR}/
+        OUTPUT_VARIABLE combined_resource_copies
+    )
+    cmake_print_variables(combined_resource_copies)
+    add_custom_command(
+        OUTPUT ${combined_resource_copies}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${combined_resources} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Copy KTX and KTX2 images to buildtime resource destination"
+        DEPENDS ${combined_resources}
+        VERBATIM
+    )
+    add_custom_target(
+        copied_resources
+        DEPENDS ${combined_resource_copies}  
+    )
+
+    if(TARGET vkloadtests)
+        add_dependencies( vkloadtests copied_resources )
+    endif()
+    if(TARGET gl3loadtests)
+        add_dependencies( gl3loadtests copied_resources )
+    endif()
+    if(TARGET es3loadtests)
+        add_dependencies( es3loadtests copied_resources )
+    endif()
+    if(TARGET es1loadtests)
+        add_dependencies( es1loadtests copied_resources )
+    endif()
+
+    unset( combined_resource_copies )
+    unset( combined_resources )
+
+endif()
+
+

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -168,10 +168,10 @@ set( LOAD_TEST_COMMON_LIBS )
 
 if(APPLE)
     set( EXE_FLAG MACOSX_BUNDLE )
-    set( ktx_app_icon_basename ktx_app)
-    set( ktx_doc_icon_basename ktx_document)
-    set( KTX_APP_ICON ${ktx_app_icon_basename}.icns)
-    set( KTX_DOC_ICON ${ktx_doc_icon_basename}.icns)
+    set( KTX_APP_ICON_BASENAME ktx_app)
+    set( KTX_DOC_ICON_BASENAME ktx_document)
+    set( KTX_APP_ICON ${KTX_APP_ICON_BASENAME}.icns)
+    set( KTX_DOC_ICON ${KTX_DOC_ICON_BASENAME}.icns)
     # On iOS an icon is a directory of images not a single file.
     # BASENAME is the name of the directory in the common .xcassets directory.
     # Assets are copied to the bundle in the build target setup.

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -246,7 +246,7 @@ source_group("Resources/Models" FILES ${LOAD_TEST_COMMON_MODEL_SOURCES})
 # an install_target that uses this with an error "the target is not
 # an executable, library or module."
 #add_custom_target( loadtest_models
-#    SOURCES ${LOAD_TEST_COMMON_MODELS}
+#    SOURCES ${LOAD_TEST_COMMON_MODEL_SOURCES}
 #)
 
 set(TEST_RESOURCES_DIR "${PROJECT_SOURCE_DIR}/tests/resources")

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -64,30 +64,6 @@ if(APPLE AND IOS)
     find_library(UIKit_LIBRARY UIKit)
 endif()
 
-function( ensure_runtime_dependencies_windows target test_images )
-    # Custom copy commands to ensure all dependencies (test images,
-    # shaders, models) are in correct location relative to executable.
-
-#    add_custom_command( TARGET ${target} POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${target}>/resources"
-#        COMMENT "Make resources directory"
-#    )
-#    if(${target} MATCHES "vkloadtests")
-#        add_custom_command( TARGET ${target} POST_BUILD
-#            COMMAND ${CMAKE_COMMAND} -E copy_directory  "${CMAKE_CURRENT_BINARY_DIR}/shaders" "$<TARGET_FILE_DIR:${target}>/resources"
-#            COMMENT "Copy shaders to build destination"
-#        )
-#    endif()
-#    add_custom_command( TARGET ${target} POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${test_images} "$<TARGET_FILE_DIR:${target}>/resources"
-#        COMMENT "Copy testimages to build destination"
-#    )
-#    add_custom_command( TARGET ${target} POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E copy_directory  "${PROJECT_SOURCE_DIR}/tests/loadtests/common/models" "$<TARGET_FILE_DIR:${target}>/resources"
-#        COMMENT "Copy models to build destination"
-#    )
-endfunction()
-
 add_library( appfwSDL STATIC
     appfwSDL/AppBaseSDL.cpp
     appfwSDL/AppBaseSDL.h

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -28,6 +28,10 @@ if(NOT EMSCRIPTEN)
     # no time to experiment, so tests that use assimp are omitted from
     # loadtests when building for the web.
     find_package(assimp REQUIRED CONFIG REQUIRED)
+    #cmake_print_variables(assimp_LIBRARIES)
+    set( LOAD_TEST_COMMON_LIBS assimp::assimp)
+else()
+    set( LOAD_TEST_COMMON_LIBS )
 endif()
 
 # We use our own local copy of GL headers to ensure we have glcorearb.h.
@@ -164,8 +168,6 @@ if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "OpenGL")
   )
 endif()
 
-set( LOAD_TEST_COMMON_LIBS )
-
 if(APPLE)
     set( EXE_FLAG MACOSX_BUNDLE )
     set( KTX_APP_ICON_BASENAME ktx_app)
@@ -177,27 +179,11 @@ if(APPLE)
     # Assets are copied to the bundle in the build target setup.
     set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_APP_ICON} )
     set( KTX_DOC_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_DOC_ICON} )
-    #cmake_print_variables(assimp_LIBRARIES)
-    if(IOS)
-        set( LOAD_TEST_COMMON_LIBS
-            assimp::assimp
-        )
-    else()
-        set( LOAD_TEST_COMMON_LIBS
-            assimp::assimp
-        )
-    endif()
 elseif(LINUX)
     set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/linux/ktx_app.svg )
-    set( LOAD_TEST_COMMON_LIBS
-        assimp::assimp
-    )
 elseif(WIN32)
     set( EXE_FLAG WIN32 )
     set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/win/ktx_app.ico )
-    set( LOAD_TEST_COMMON_LIBS
-        assimp::assimp
-    )
 endif()
 
 set( KTX_ICON_SOURCES ${KTX_APP_ICON_SOURCE} ${KTX_DOC_ICON_SOURCE} )

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -325,9 +325,9 @@ if(NOT APPLE)
     # application and are only for convenience during development. Therefore 
     # the above mentioned error does not occur.
 
-    set(LOAD_TEST_COMMON_RESOURCES_COPIED
+    set(load_test_common_resources_copied
         ${KTX_APP_ICON}  # TODO: Is this needed on Windows?
-    #    ${KTX_DOC_ICON} # Only needed on Apple.
+        ${KTX_DOC_ICON}
         ${LOAD_TEST_COLLADA_MODELS}
         ${LOAD_TEST_OBJ_MODELS}
     )
@@ -335,9 +335,8 @@ if(NOT APPLE)
     # executable's directory. This sibling relationship will be maintained
     # when the app and its resources are installed on a system.
     set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../resources)
-    list(TRANSFORM LOAD_TEST_COMMON_RESOURCES_COPIED PREPEND ${BUILDTIME_RESOURCES_DIR}/)
+    list(TRANSFORM load_test_common_resources_copied PREPEND ${BUILDTIME_RESOURCES_DIR}/)
 
-    set_source_files_properties(buildtime_resources_dir PROPERTIES SYMBOLIC 1)
     add_custom_command(
         OUTPUT ${BUILDTIME_RESOURCES_DIR}
         COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
@@ -349,17 +348,18 @@ if(NOT APPLE)
         DEPENDS ${BUILDTIME_RESOURCES_DIR}
     )
     add_custom_command(
-        OUTPUT ${LOAD_TEST_COMMON_RESOURCES_COPIED}
+        OUTPUT ${load_test_common_resources_copied}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy models to build destination"
+        COMMENT "Copy common resources (icons and models to build destination"
+        DEPENDS ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
         VERBATIM
     )
     add_custom_target(
         copied_models
-        DEPENDS ${LOAD_TEST_COMMON_RESOURCES_COPIED}
+        DEPENDS ${load_test_common_resources_copied}
     )
-    add_dependencies( copied_models buildtime_resources_dir )
-    unset(LOAD_TEST_COMMON_RESOURCES_COPIED)
+    unset(load_test_common_resources_copied)
     list(TRANSFORM LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
         OUTPUT_VARIABLE common_ktx_image_copies
     )
@@ -367,13 +367,15 @@ if(NOT APPLE)
         OUTPUT ${common_ktx_image_copies}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy common KTX and KTX2 images to build destination"
+        DEPENDS ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
         VERBATIM
     )
     add_custom_target(
         copied_common_ktx_images
         DEPENDS ${common_ktx_image_copies}  
     )
-    add_dependencies( copied_common_ktx_images buildtime_resources_dir )
+    # To ensure the resources directory is created before copying KTX images.
+    add_dependencies( copied_common_ktx_images copied_models )
     unset( common_ktx_image_copies )
 endif()
 

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -268,6 +268,41 @@ set( LOAD_TEST_COMMON_RESOURCE_FILES
     ${LOAD_TEST_COMMON_MODELS}
 )
 
+if(WIN32)
+    # On Windows resources for both gl3loadtests and vkloadtests go in the same resources
+    # folder therefore to support parallel builds and avoid races copying must be done via
+    # custom targets.
+#if(WIN32 AND KTX_FEATURE_LOADTEST_APPS)
+#    if(${KTX_FEATURE_LOADTEST_APPS} MATCHES "OpenGL")
+#        set(target_dir $<TARGET_FILE_DIR:gl3loadtests>/resources)
+#    elseif(${KTX_FEATURE_LOADTEST_APPS} MATCHES "Vulkan")
+#        set(target_dir $<TARGET_FILE_DIR:vkloadtests>/resources)
+    set(resources_dir resources)
+    add_custom_command(
+        OUTPUT ${resources_dir}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${resources_dir}"
+        COMMENT "Make resources directory"
+    )
+    add_custom_target(
+        resources_dir
+        DEPENDS ${resources_dir}
+    )
+    unset(resources_dir)
+
+    LOAD_TEST_COMMON_MODELS
+    list(TRANSFORM LOAD_TEST_COMMON_MODELS PREPEND ${resources_dir} OUTPUT_VARIABLE copied_models)
+    add_custom_command(
+        OUTPUT ${copied_models}
+        COMMAND ${CMAKE_COMMAND} -E copy_directory  "${PROJECT_SOURCE_DIR}/tests/loadtests/common/models" "${resources_dir}"
+        COMMENT "Copy models to build destination"
+    )
+    add_custom_target(
+        copied_models
+        DEPENDS ${copied_models}
+    )
+    unset(copied_models)
+endif()
+
 if(LINUX)
     set( LOAD_TEST_DESTROOT "/opt" )
 endif()

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -191,7 +191,6 @@ elseif(LINUX)
     set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/linux/ktx_app.svg )
     set( LOAD_TEST_COMMON_LIBS
         assimp::assimp
-        SDL3::SDL3
     )
 elseif(WIN32)
     set( EXE_FLAG WIN32 )

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -325,7 +325,10 @@ if(NOT APPLE)
         ${LOAD_TEST_COLLADA_MODELS}
         ${LOAD_TEST_OBJ_MODELS}
     )
-    set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/resources)
+    # The resources directory is created in the build tree next to the
+    # executable's directory. This sibling relationship will be maintained
+    # when the app and its resources are installed on a system.
+    set(BUILDTIME_RESOURCES_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../resources)
     list(TRANSFORM LOAD_TEST_COMMON_RESOURCES_COPIED PREPEND ${BUILDTIME_RESOURCES_DIR}/)
 
     set_source_files_properties(buildtime_resources_dir PROPERTIES SYMBOLIC 1)
@@ -341,7 +344,6 @@ if(NOT APPLE)
     )
     add_custom_command(
         OUTPUT ${LOAD_TEST_COMMON_RESOURCES_COPIED}
-        COMMAND ${CMAKE_COMMAND} -E echo  ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy models to build destination"
         VERBATIM

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -177,7 +177,7 @@ if(APPLE)
     # Assets are copied to the bundle in the build target setup.
     set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_APP_ICON} )
     set( KTX_DOC_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_DOC_ICON} )
-    cmake_print_variables(assimp_LIBRARIES)
+    #cmake_print_variables(assimp_LIBRARIES)
     if(IOS)
         set( LOAD_TEST_COMMON_LIBS
             assimp::assimp
@@ -191,7 +191,6 @@ elseif(LINUX)
     set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/linux/ktx_app.svg )
     set( LOAD_TEST_COMMON_LIBS
         assimp::assimp
-        #${SDL3_LIBRARIES}
         SDL3::SDL3
     )
 elseif(WIN32)
@@ -356,7 +355,6 @@ if(NOT APPLE)
     list(TRANSFORM LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
         OUTPUT_VARIABLE common_ktx_image_copies
     )
-    cmake_print_variables( common_ktx_image_copies )
     add_custom_command(
         OUTPUT ${common_ktx_image_copies}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES} ${BUILDTIME_RESOURCES_DIR}

--- a/tests/loadtests/CMakeLists.txt
+++ b/tests/loadtests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Khronos Group Inc.
+# Copyright 2017-2026 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #if(WIN32)
@@ -175,8 +175,8 @@ if(APPLE)
     # On iOS an icon is a directory of images not a single file.
     # BASENAME is the name of the directory in the common .xcassets directory.
     # Assets are copied to the bundle in the build target setup.
-    set( KTX_APP_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_APP_ICON} )
-    set( KTX_DOC_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_DOC_ICON} )
+    set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_APP_ICON} )
+    set( KTX_DOC_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/mac/${KTX_DOC_ICON} )
     cmake_print_variables(assimp_LIBRARIES)
     if(IOS)
         set( LOAD_TEST_COMMON_LIBS
@@ -188,7 +188,7 @@ if(APPLE)
         )
     endif()
 elseif(LINUX)
-    set( KTX_APP_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/linux/ktx_app.svg )
+    set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/linux/ktx_app.svg )
     set( LOAD_TEST_COMMON_LIBS
         assimp::assimp
         #${SDL3_LIBRARIES}
@@ -196,7 +196,7 @@ elseif(LINUX)
     )
 elseif(WIN32)
     set( EXE_FLAG WIN32 )
-    set( KTX_APP_ICON_SOURCE_PATH ${PROJECT_SOURCE_DIR}/icons/win/ktx_app.ico )
+    set( KTX_APP_ICON_SOURCE ${PROJECT_SOURCE_DIR}/icons/win/ktx_app.ico )
     set( LOAD_TEST_COMMON_LIBS
         assimp::assimp
     )
@@ -237,8 +237,8 @@ set( LOAD_TEST_COMMON_MODEL_SOURCES
 )
 
 set( LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES
-    ${KTX_APP_ICON_SOURCE_PATH}
-    ${KTX_DOC_ICON_SOURCE_PATH}
+    ${KTX_APP_ICON_SOURCE}
+    ${KTX_DOC_ICON_SOURCE}
     ${LOAD_TEST_COMMON_MODEL_SOURCES}
 )
 

--- a/tests/loadtests/appfwSDL/AppBaseSDL.cpp
+++ b/tests/loadtests/appfwSDL/AppBaseSDL.cpp
@@ -31,13 +31,9 @@ AppBaseSDL::initialize(Args& /*args*/)
     if (basePath == NULL)
         basePath = SDL_strdup("./");
     sBasePath = basePath;
-#if SDL_PLATFORM_LINUX
-    // TODO figure out best way to handle these resources
+#if SDL_PLATFORM_LINUX || SDL_PLATFORM_WINDOWS
+    // We put the resources in a sibling directory to the executable.
     sBasePath += "../resources/";
-#endif
-#if SDL_PLATFORM_WINDOWS
-    // Ditto
-    sBasePath += "resources/";
 #endif
     return true;
 }

--- a/tests/loadtests/compile_shader.cmake
+++ b/tests/loadtests/compile_shader.cmake
@@ -55,18 +55,18 @@ function(compile_shader_list shader_target shader_src_path shader_path)
         set(spirv_out "${CMAKE_CURRENT_BINARY_DIR}/${shader_path}/${shader}.spv")
 
         add_custom_command(OUTPUT
-        ${spirv_out}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
-        COMMAND glslc -o "${spirv_out}" "${spirv_in}"
-        DEPENDS ${spirv_in}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-        COMMENT "Compiling ${shader}."
-        VERBATIM
+            ${spirv_out}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
+            COMMAND glslc -o "${spirv_out}" "${spirv_in}"
+            DEPENDS ${spirv_in}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            COMMENT "Compiling ${shader}."
+            VERBATIM
         )
 
         list(APPEND inputs ${spirv_in})
         list(APPEND outputs ${spirv_out})
-     endforeach()
+    endforeach()
 
     add_custom_target(
         ${shader_target}

--- a/tests/loadtests/compile_shader.cmake
+++ b/tests/loadtests/compile_shader.cmake
@@ -8,13 +8,13 @@ function(compile_shader shader_target shader_name shader_src_path shader_path)
     set(vert2spirv_out "${CMAKE_CURRENT_BINARY_DIR}/${shader_path}/${vert_name}.spv")
 
     add_custom_command(OUTPUT
-    ${vert2spirv_out}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
-    COMMAND glslc "-fshader-stage=vertex" -o "${vert2spirv_out}" "${vert2spirv_in}"
-    DEPENDS ${vert2spirv_in}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    COMMENT "Compiling ${vert_name}."
-    VERBATIM
+        ${vert2spirv_out}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
+        COMMAND glslc "-fshader-stage=vertex" -o "${vert2spirv_out}" "${vert2spirv_in}"
+        DEPENDS ${vert2spirv_in}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        COMMENT "Compiling ${vert_name}."
+        VERBATIM
     )
 
     set(frag_name "${shader_name}.frag")
@@ -22,13 +22,13 @@ function(compile_shader shader_target shader_name shader_src_path shader_path)
     set(frag2spirv_out "${CMAKE_CURRENT_BINARY_DIR}/${shader_path}/${frag_name}.spv")
 
     add_custom_command(OUTPUT
-    ${frag2spirv_out}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
-    COMMAND glslc "-fshader-stage=fragment" -o "${frag2spirv_out}" "${frag2spirv_in}"
-    DEPENDS ${frag2spirv_in}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    COMMENT "Compiling ${frag_name}."
-    VERBATIM
+        ${frag2spirv_out}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
+        COMMAND glslc "-fshader-stage=fragment" -o "${frag2spirv_out}" "${frag2spirv_in}"
+        DEPENDS ${frag2spirv_in}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        COMMENT "Compiling ${frag_name}."
+        VERBATIM
     )
 
     add_custom_target(
@@ -43,7 +43,8 @@ function(compile_shader shader_target shader_name shader_src_path shader_path)
 
     set_target_properties(${shader_target} PROPERTIES EXCLUDE_FROM_ALL "FALSE")
 
-    set(SHADER_SOURCES ${SHADER_SOURCES} ${frag2spirv_out} ${vert2spirv_out} PARENT_SCOPE)
+    set(SHADER_SOURCES ${SHADER_SOURCES} ${frag2spirv_in} ${vert2spirv_in} PARENT_SCOPE)
+    set(SHADER_SPVS ${SHADER_SPVS} ${frag2spirv_out} ${vert2spirv_out} PARENT_SCOPE)
 
 endfunction(compile_shader)
 
@@ -75,6 +76,7 @@ function(compile_shader_list shader_target shader_src_path shader_path)
 
     set_target_properties(${shader_target} PROPERTIES EXCLUDE_FROM_ALL "FALSE")
 
-    set(SHADER_SOURCES ${SHADER_SOURCES} ${outputs} PARENT_SCOPE)
+    set(SHADER_SOURCES ${SHADER_SOURCES} ${inputs} PARENT_SCOPE)
+    set(SHADER_SPVS ${SHADER_SPVS} ${outputs} PARENT_SCOPE)
 
 endfunction()

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -10,12 +10,14 @@ if(WIN32)
     find_package(GLEW REQUIRED)
 endif()
 
-function( create_gl_target target version sources common_resources test_image_sources
+function( create_gl_target target version sources common_resources ktx_image_sources
           KTX_GL_CONTEXT_PROFILE
           KTX_GL_CONTEXT_MAJOR_VERSION KTX_GL_CONTEXT_MINOR_VERSION
           EMULATE_GLES)
 
-    set( resources ${common_resources};${test_image_sources} )
+    set( resources
+       ${common_resources};${ktx_image_sources};${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
+    )
 
     add_executable( ${target}
         ${EXE_FLAG}
@@ -110,7 +112,7 @@ function( create_gl_target target version sources common_resources test_image_so
         # Beware of de-duplication in list expansion for commands and options.
         # SHELL: prevents it but if they are separate items in the list they
         # be de-duplicated.
-        list( TRANSFORM test_image_sources REPLACE
+        list( TRANSFORM ktx_image_sources REPLACE
             "(${PROJECT_SOURCE_DIR}/tests/resources/(ktx|ktx2)/([a-zA-Z0-9_].*$))"
             "SHELL:--preload-file \\1@\\3"
             OUTPUT_VARIABLE preloads
@@ -261,27 +263,29 @@ function( create_gl_target target version sources common_resources test_image_so
 #              ${resources}
 #              $<TARGET_FILE_DIR:${target}>/../resources
 #        )
-        list(TRANSFORM test_image_sources REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
-            OUTPUT_VARIABLE test_image_copies
+        # Copy the KTX images specific to the current target.
+        list(TRANSFORM ktx_image_sources REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
+            OUTPUT_VARIABLE ktx_image_copies
         )
-        cmake_print_variables( test_image_copies )
-#        add_custom_command(
-#            OUTPUT ${test_image_copies}
-#           COMMAND ${CMAKE_COMMAND} -E copy_if_different ${test_image_sources} ${BUILDTIME_RESOURCES_DIR}
-#            COMMENT "Copy test images to build destination"
-#            VERBATIM
-#        )
-#        add_custom_target(
-#            copied_${target}_test_images
-#            DEPENDS ${test_image_copies}
-#        )
-#        add_dependencies(
-#            copied_${target}_test_images
-#            buildtime_resources_dir
-#        )
+        cmake_print_variables( ktx_image_copies )
+        add_custom_command(
+            OUTPUT ${ktx_image_copies}
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_image_sources} ${BUILDTIME_RESOURCES_DIR}
+            COMMENT "Copy ${target}'s ktx images to build destination"
+            VERBATIM
+        )
+        add_custom_target(
+            copied_${target}_ktx_images
+            DEPENDS ${ktx_image_copies}
+        )
+        add_dependencies(
+            copied_${target}_ktx_images
+            buildtime_resources_dir
+        )
         add_dependencies( ${target}
             copied_models
-#            copied_${target}_test_images
+            copied_common_ktx_images
+            copied_${target}_ktx_images
         )
 
         # See important comment and TODO:s starting at line 365
@@ -334,24 +338,12 @@ function( create_gl_target target version sources common_resources test_image_so
     endif()
 endfunction( create_gl_target target )
 
-
-set( es1_test_image_sources
+set( es1_ktx_image_sources
     no_npot.ktx
     hi_mark.ktx
     l8_unorm_metadata.ktx
-    orient_up_metadata.ktx
-    orient_down_metadata.ktx
-    etc1.ktx
-    etc2_rgb.ktx
-    etc2_rgba1.ktx
-    etc2_rgba8.ktx
-    r8g8b8a8_srgb.ktx
-    r8g8b8_srgb.ktx
-    r8g8b8_unorm_amg.ktx
-    r8g8b8_srgb_mip.ktx
-    hi_mark_sq.ktx
 )
-list( TRANSFORM es1_test_image_sources
+list( TRANSFORM es1_ktx_image_sources
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
 )
 
@@ -363,64 +355,30 @@ set( es1_sources
     glloadtests/gles1/TexturedCube.h
 )
 
-set( gl3_ktx2_test_image_sources
-    astc_8x8_unorm_array_7.ktx2
-    bc3_unorm_array_7.ktx2
-    color_grid_uastc_zstd_5.ktx2
-    color_grid_zstd_5.ktx2
-    color_grid_blze.ktx2
-    cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
-    cubemap_yokohama_blze.ktx2
-    etc2_unorm_array_7.ktx2
+set( gl3_ktx2_image_sources
     FlightHelmet_baseColor_blze.ktx2
-    Iron_Bars_001_normal_blze.ktx2
-    Iron_Bars_001_normal_uastc_zstd_10.ktx2
-    kodim17_blze.ktx2
-    orient_down_metadata.ktx2
-    orient_up_metadata.ktx2
-    pattern_02_bc2.ktx2
     r8g8b8a8_srgb.ktx2
     r8g8b8a8_srgb_3d_7.ktx2
-    r8g8b8_srgb_mip.ktx2
 )
-set( gl3_ktx_test_image_sources
-    astc_8x8_unorm_array_7.ktx
-    bc3_unorm_array_7.ktx
+
+set( gl3_ktx_image_sources
     conftestimage_R11_EAC.ktx
     conftestimage_SIGNED_R11_EAC.ktx
     conftestimage_RG11_EAC.ktx
     conftestimage_SIGNED_RG11_EAC.ktx
-    etc1.ktx
-    etc2_rgb.ktx
-    etc2_rgba1.ktx
-    etc2_rgba8.ktx
-    etc2_srgb.ktx
-    etc2_srgba1.ktx
-    etc2_srgba8.ktx
-    etc2_unorm_array_7.ktx
     hi_mark.ktx
-    hi_mark_sq.ktx
-    metalplate_amg.ktx
-    not4_r8g8b8_srgb.ktx
-    orient_down_metadata.ktx
-    orient_up_metadata.ktx
-    pattern_02_bc2.ktx
-    r8g8b8a8_srgb.ktx
-    r8g8b8_srgb.ktx
-    r8g8b8_unorm_amg.ktx
-    r8g8b8_srgb_mip.ktx
 )
-list( TRANSFORM gl3_ktx_test_image_sources
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
-)
-list( TRANSFORM gl3_ktx2_test_image_sources
+list( TRANSFORM gl3_ktx2_image_sources
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
 )
-set( gl3_test_image_sources ${gl3_ktx2_test_image_sources} ${gl3_ktx_test_image_sources} )
-#set( gl3_resource_files ${LOAD_TEST_COMMON_RESOURCE_FILES} ${gl3_test_image_sources} )
+list( TRANSFORM gl3_ktx_image_sources
+    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
+)
+
+set( gl3_ktx12_image_sources ${gl3_ktx2_image_sources} ${gl3_ktx_image_sources} )
 
 
-set( GL3_SOURCES
+set( gl3_sources
     common/TranscodeTargetStrToFmt.cpp
     common/TranscodeTargetStrToFmt.h
     common/disable_glm_warnings.h
@@ -451,7 +409,6 @@ set( GL3_SOURCES
     glloadtests/utils/GLTextureTranscoder.hpp
 )
 
-
 if(WIN32)
     if(NOT OPENGL_ES_EMULATOR)
         message("OPENGL_ES_EMULATOR not set. Will not build OpenGL ES load tests applications.")
@@ -462,22 +419,22 @@ endif()
 
 if(IOS OR EMULATE_GLES)
     # OpenGL ES 1.0
-    create_gl_target( es1loadtests "ES1" "${es1_sources}" "${KTX_APP_ICON_SOURCE_PATH}" "${es1_test_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 1 0 ON)
+    create_gl_target( es1loadtests "ES1" "${es1_sources}" "${KTX_APP_ICON_SOURCE_PATH}" "${es1_ktx_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 1 0 ON)
 endif()
 
 if(IOS OR EMSCRIPTEN OR EMULATE_GLES)
     # OpenGL ES 3.0
-    create_gl_target( es3loadtests "ES3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_test_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES)
+    create_gl_target( es3loadtests "ES3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_ktx12_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES)
 endif()
 
 if( (APPLE AND NOT IOS) OR LINUX OR WIN32 )
     # OpenGL 3.3
-    create_gl_target( gl3loadtests "GL3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_test_image_sources}" SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES)
+    create_gl_target( gl3loadtests "GL3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_ktx12_image_sources}" SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES)
 endif()
 
 unset( es1_sources )
 unset( gl3_sources )
-unset( es1_test_image_sources )
-unset( gl3_ktx2_test_image_sources )
-unset( gl3_ktx_test_image_sources )
-unset( gl3_test_image_sources )
+unset( es1_ktx_image_sources )
+unset( gl3_ktx2_image_sources )
+unset( gl3_ktx_image_sources )
+unset( gl3_ktx12_image_sources )

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -315,13 +315,110 @@ function( create_gl_target target version sources common_resources ktx_file_sour
     endif()
 endfunction( create_gl_target target )
 
-set( es1_sources
-    glloadtests/gles1/ES1LoadTests.cpp
-    glloadtests/gles1/DrawTexture.cpp
-    glloadtests/gles1/DrawTexture.h
-    glloadtests/gles1/TexturedCube.cpp
-    glloadtests/gles1/TexturedCube.h
+if(WIN32)
+    if(NOT OPENGL_ES_EMULATOR)
+        message("OPENGL_ES_EMULATOR not set. Will not build OpenGL ES load tests applications.")
+    else()
+        set(EMULATE_GLES ON)
+    endif()
+endif()
+
+if(IOS OR EMULATE_GLES)
+    # OpenGL ES 1.0
+    set( es1_ktx_file_sources
+            no_npot.ktx
+            hi_mark.ktx
+            l8_unorm_metadata.ktx
+            orient_up_metadata.ktx
+            orient_down_metadata.ktx
+            etc1.ktx
+            etc2_rgb.ktx
+            etc2_rgba1.ktx
+            etc2_rgba8.ktx
+            r8g8b8a8_srgb.ktx
+            r8g8b8_srgb.ktx
+            r8g8b8_unorm_amg.ktx
+            r8g8b8_srgb_mip.ktx
+            hi_mark_sq.ktx
+    )
+    list( TRANSFORM es1_ktx_file_sources
+        PREPEND "${TEST_RESOURCES_DIR}/ktx/"
+    )
+
+    set( es1_sources
+        glloadtests/gles1/ES1LoadTests.cpp
+        glloadtests/gles1/DrawTexture.cpp
+        glloadtests/gles1/DrawTexture.h
+        glloadtests/gles1/TexturedCube.cpp
+        glloadtests/gles1/TexturedCube.h
+    )
+
+    create_gl_target( es1loadtests "ES1" "${es1_sources}"
+        "${KTX_ICON_SOURCES}"                     # common_resources
+        "${es1_ktx_file_sources}"                 # ktx_file_sources
+        SDL_GL_CONTEXT_PROFILE_ES 1 0 ON
+    )
+endif()
+
+set( gl_ktx2_file_sources
+    FlightHelmet_baseColor_blze.ktx2
+    r8g8b8_srgb_mip.ktx2
+    r8g8b8a8_srgb.ktx2
+    r8g8b8a8_srgb_3d_7.ktx2
+    astc_8x8_unorm_array_7.ktx2
+    bc3_unorm_array_7.ktx2
+    color_grid_uastc_zstd_5.ktx2
+    color_grid_zstd_5.ktx2
+    color_grid_blze.ktx2
+    cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
+    cubemap_yokohama_blze.ktx2
+    etc2_unorm_array_7.ktx2
+    Iron_Bars_001_normal_blze.ktx2
+    Iron_Bars_001_normal_uastc_zstd_10.ktx2
+    kodim17_blze.ktx2
+    orient_down_metadata.ktx2
+    orient_up_metadata.ktx2
+    pattern_02_bc2.ktx2
+    skybox_zstd_22.ktx2
 )
+list( TRANSFORM gl_ktx2_file_sources
+    PREPEND "${TEST_RESOURCES_DIR}/ktx2/"
+)
+set( gl_ktx1_file_sources
+    conftestimage_R11_EAC.ktx
+    conftestimage_SIGNED_R11_EAC.ktx
+    conftestimage_RG11_EAC.ktx
+    conftestimage_SIGNED_RG11_EAC.ktx
+    hi_mark.ktx
+    astc_8x8_unorm_array_7.ktx
+    bc3_unorm_array_7.ktx
+    etc1.ktx
+    etc2_rgb.ktx
+    etc2_rgba1.ktx
+    etc2_rgba8.ktx
+    etc2_srgb.ktx
+    etc2_srgba1.ktx
+    etc2_srgba8.ktx
+    etc2_unorm_array_7.ktx
+    hi_mark_sq.ktx
+    metalplate_amg.ktx
+    not4_r8g8b8_srgb.ktx
+    orient_down_metadata.ktx
+    orient_up_metadata.ktx
+    pattern_02_bc2.ktx
+    r8g8b8_srgb.ktx
+    r8g8b8_srgb_mip.ktx
+    r8g8b8_unorm_amg.ktx
+    r8g8b8a8_srgb.ktx
+)
+list( TRANSFORM gl_ktx1_file_sources
+    PREPEND "${TEST_RESOURCES_DIR}/ktx/"
+)
+set( gl_ktx_file_sources
+    ${gl_ktx2_file_sources}
+    ${gl_ktx1_file_sources}
+)
+source_group( "Resources/KTX Images" REGULAR_EXPRESSION "${TEST_RESOURCES_DIR}/ktx(2?)/.*" )
 
 set( gl3_sources
     common/TranscodeTargetStrToFmt.cpp
@@ -354,28 +451,11 @@ set( gl3_sources
     glloadtests/utils/GLTextureTranscoder.hpp
 )
 
-if(WIN32)
-    if(NOT OPENGL_ES_EMULATOR)
-        message("OPENGL_ES_EMULATOR not set. Will not build OpenGL ES load tests applications.")
-    else()
-        set(EMULATE_GLES ON)
-    endif()
-endif()
-
-if(IOS OR EMULATE_GLES)
-    # OpenGL ES 1.0
-    create_gl_target( es1loadtests "ES1" "${es1_sources}"
-        "${KTX_ICON_SOURCES}"                                   # common_resources
-        "${ES1LOADTESTS_KTX_FILE_SOURCES}"                             # ktx_file_sources
-        SDL_GL_CONTEXT_PROFILE_ES 1 0 ON
-    )
-endif()
-
 if(IOS OR EMSCRIPTEN OR EMULATE_GLES)
     # OpenGL ES 3.0
     create_gl_target( es3loadtests "ES3" "${gl3_sources}"
         "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}" # common_resources
-        "${GLLOADTESTS_KTX_FILE_SOURCES}"                              # ktx_file_sources
+        "${gl_ktx_file_sources}"                                # ktx_file_sources
         SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES
     )
 endif()
@@ -384,10 +464,14 @@ if( (APPLE AND NOT IOS) OR LINUX OR WIN32 )
     # OpenGL 3.3
     create_gl_target( gl3loadtests "GL3" "${gl3_sources}"
         "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}" # common_resources
-        "${GLLOADTESTS_KTX_FILE_SOURCES}"                              # ktx_file_sources
+        "${gl_ktx_file_sources}"                                # ktx_file_sources
         SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES
     )
 endif()
 
 unset( es1_sources )
+unset( es1_ktx_file_sources )
 unset( gl3_sources )
+unset( gl_ktx_file_sources )
+unset( gl_ktx1_file_sources )
+unset( gl_ktx2_file_sources )

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -250,17 +250,6 @@ function( create_gl_target target version sources common_resources ktx_file_sour
         endif()
 
     else()
-        if(WINDOWS OR LINUX)
-            # These copy the resources to a shared resource directory next to
-            # the executables for ease of use during debugging and testing.
-            # They have no effect on the install targets.
-            add_dependencies( ${target}
-                copied_ktx_icons
-                copied_models
-                copied_ktx_files # Installs KTX files for configured targets.
-            )
-        endif()
-
         if(EMSCRIPTEN)
             set_target_properties(${target} PROPERTIES SUFFIX ".html")
         endif()

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -264,6 +264,7 @@ function( create_gl_target target version sources common_resources ktx_image_sou
         )
         add_custom_command(
             OUTPUT ${ktx_image_copies}
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
             COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_image_sources} ${BUILDTIME_RESOURCES_DIR}
             COMMENT "Copy ${target}'s ktx images to build destination"
             DEPENDS ${ktx_image_sources}
@@ -278,6 +279,7 @@ function( create_gl_target target version sources common_resources ktx_image_sou
             copied_common_ktx_images
         )
         add_dependencies( ${target}
+            copied_ktx_icons
             copied_models
             copied_${target}_ktx_images
         )

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -315,20 +315,20 @@ endif()
 if(IOS OR EMULATE_GLES)
     # OpenGL ES 1.0
     set( es1_ktx_file_sources
-            no_npot.ktx
-            hi_mark.ktx
-            l8_unorm_metadata.ktx
-            orient_up_metadata.ktx
-            orient_down_metadata.ktx
             etc1.ktx
             etc2_rgb.ktx
             etc2_rgba1.ktx
             etc2_rgba8.ktx
+            hi_mark.ktx
+            hi_mark_sq.ktx
+            l8_unorm_metadata.ktx
+            no_npot.ktx
+            orient_up_metadata.ktx
+            orient_down_metadata.ktx
             r8g8b8a8_srgb.ktx
             r8g8b8_srgb.ktx
             r8g8b8_unorm_amg.ktx
             r8g8b8_srgb_mip.ktx
-            hi_mark_sq.ktx
     )
     list( TRANSFORM es1_ktx_file_sources
         PREPEND "${TEST_RESOURCES_DIR}/ktx/"
@@ -350,10 +350,6 @@ if(IOS OR EMULATE_GLES)
 endif()
 
 set( gl_ktx2_file_sources
-    FlightHelmet_baseColor_blze.ktx2
-    r8g8b8_srgb_mip.ktx2
-    r8g8b8a8_srgb.ktx2
-    r8g8b8a8_srgb_3d_7.ktx2
     astc_8x8_unorm_array_7.ktx2
     bc3_unorm_array_7.ktx2
     color_grid_uastc_zstd_5.ktx2
@@ -362,25 +358,28 @@ set( gl_ktx2_file_sources
     cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
     cubemap_yokohama_blze.ktx2
     etc2_unorm_array_7.ktx2
+    FlightHelmet_baseColor_blze.ktx2
     Iron_Bars_001_normal_blze.ktx2
     Iron_Bars_001_normal_uastc_zstd_10.ktx2
     kodim17_blze.ktx2
     orient_down_metadata.ktx2
     orient_up_metadata.ktx2
     pattern_02_bc2.ktx2
+    r8g8b8_srgb_mip.ktx2
+    r8g8b8a8_srgb.ktx2
+    r8g8b8a8_srgb_3d_7.ktx2
     skybox_zstd_22.ktx2
 )
 list( TRANSFORM gl_ktx2_file_sources
     PREPEND "${TEST_RESOURCES_DIR}/ktx2/"
 )
 set( gl_ktx1_file_sources
+    astc_8x8_unorm_array_7.ktx
+    bc3_unorm_array_7.ktx
     conftestimage_R11_EAC.ktx
     conftestimage_SIGNED_R11_EAC.ktx
     conftestimage_RG11_EAC.ktx
     conftestimage_SIGNED_RG11_EAC.ktx
-    hi_mark.ktx
-    astc_8x8_unorm_array_7.ktx
-    bc3_unorm_array_7.ktx
     etc1.ktx
     etc2_rgb.ktx
     etc2_rgba1.ktx
@@ -389,6 +388,7 @@ set( gl_ktx1_file_sources
     etc2_srgba1.ktx
     etc2_srgba8.ktx
     etc2_unorm_array_7.ktx
+    hi_mark.ktx
     hi_mark_sq.ktx
     metalplate_amg.ktx
     not4_r8g8b8_srgb.ktx

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020 Andreas Atteneder
+# Copyright 2020-2026 Andreas Atteneder, Mark Callow
 # SPDX-License-Identifier: Apache-2.0
 
 set(OPENGL_ES_EMULATOR "" CACHE PATH "Path to OpenGL ES emulation libraries")
@@ -413,7 +413,7 @@ endif()
 
 if(IOS OR EMULATE_GLES)
     # OpenGL ES 1.0
-    create_gl_target( es1loadtests "ES1" "${es1_sources}" "${KTX_APP_ICON_SOURCE_PATH}" "${es1_ktx_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 1 0 ON)
+    create_gl_target( es1loadtests "ES1" "${es1_sources}" "${KTX_APP_ICON_SOURCE}" "${es1_ktx_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 1 0 ON)
 endif()
 
 if(IOS OR EMSCRIPTEN OR EMULATE_GLES)

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -371,6 +371,7 @@ list( TRANSFORM gl3_ktx_image_sources
 )
 
 set( gl3_ktx12_image_sources ${gl3_ktx2_image_sources} ${gl3_ktx_image_sources} )
+source_group("Resources/KTX Images" FILES ${gl3_ktx12_image_sources})
 
 set( gl3_sources
     common/TranscodeTargetStrToFmt.cpp

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -254,20 +254,14 @@ function( create_gl_target target version sources common_resources ktx_image_sou
             set_target_properties(${target} PROPERTIES SUFFIX ".html")
         endif()
 
-        # This copies the resources next to the executable for ease
-        # of use during debugging and testing.
-#        add_custom_command( TARGET ${target} POST_BUILD
-#            COMMAND ${CMAKE_COMMAND} -E make_directory
-#              $<TARGET_FILE_DIR:${target}>/../resources
-#            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-#              ${resources}
-#              $<TARGET_FILE_DIR:${target}>/../resources
-#        )
+        # These custom targets, custom commands and dependencies copy
+        # the resources next to the executable for ease of use during
+        # debugging and testing. They have no effect on the install target.
+
         # Copy the KTX images specific to the current target.
         list(TRANSFORM ktx_image_sources REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
             OUTPUT_VARIABLE ktx_image_copies
         )
-        cmake_print_variables( ktx_image_copies )
         add_custom_command(
             OUTPUT ${ktx_image_copies}
             COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_image_sources} ${BUILDTIME_RESOURCES_DIR}
@@ -357,6 +351,7 @@ set( es1_sources
 
 set( gl3_ktx2_image_sources
     FlightHelmet_baseColor_blze.ktx2
+    r8g8b8_srgb_mip.ktx2
     r8g8b8a8_srgb.ktx2
     r8g8b8a8_srgb_3d_7.ktx2
 )
@@ -376,7 +371,6 @@ list( TRANSFORM gl3_ktx_image_sources
 )
 
 set( gl3_ktx12_image_sources ${gl3_ktx2_image_sources} ${gl3_ktx_image_sources} )
-
 
 set( gl3_sources
     common/TranscodeTargetStrToFmt.cpp

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -368,7 +368,6 @@ set( gl_ktx2_file_sources
     r8g8b8_srgb_mip.ktx2
     r8g8b8a8_srgb.ktx2
     r8g8b8a8_srgb_3d_7.ktx2
-    skybox_zstd_22.ktx2
 )
 list( TRANSFORM gl_ktx2_file_sources
     PREPEND "${TEST_RESOURCES_DIR}/ktx2/"

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -266,6 +266,7 @@ function( create_gl_target target version sources common_resources ktx_image_sou
             OUTPUT ${ktx_image_copies}
             COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_image_sources} ${BUILDTIME_RESOURCES_DIR}
             COMMENT "Copy ${target}'s ktx images to build destination"
+            DEPENDS ${ktx_image_sources}
             VERBATIM
         )
         add_custom_target(
@@ -274,11 +275,10 @@ function( create_gl_target target version sources common_resources ktx_image_sou
         )
         add_dependencies(
             copied_${target}_ktx_images
-            buildtime_resources_dir
+            copied_common_ktx_images
         )
         add_dependencies( ${target}
             copied_models
-            copied_common_ktx_images
             copied_${target}_ktx_images
         )
 

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -16,7 +16,7 @@ function( create_gl_target target version sources common_resources ktx_image_sou
           EMULATE_GLES)
 
     set( resources
-       ${common_resources};${ktx_image_sources};${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
+       ${common_resources};${ktx_image_sources};
     )
 
     add_executable( ${target}
@@ -250,39 +250,42 @@ function( create_gl_target target version sources common_resources ktx_image_sou
         endif()
 
     else()
+        if(WINDOWS OR LINUX)
+            # These custom targets, custom commands and dependencies copy
+            # the resources next to the executable for ease of use during
+            # debugging and testing. They have no effect on the install target.
+
+            # Copy the KTX images specific to the current target.
+            list(TRANSFORM ktx_image_sources
+                REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
+                OUTPUT_VARIABLE ktx_image_copies
+            )
+            add_custom_command(
+                OUTPUT ${ktx_image_copies}
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_image_sources} ${BUILDTIME_RESOURCES_DIR}
+                COMMENT "Copy ${target}'s ktx images to build destination"
+                DEPENDS ${ktx_image_sources}
+                VERBATIM
+            )
+            add_custom_target(
+                copied_${target}_ktx_images
+                DEPENDS ${ktx_image_copies}
+            )
+            add_dependencies(
+                copied_${target}_ktx_images
+                copied_common_ktx_images
+            )
+            add_dependencies( ${target}
+                copied_ktx_icons
+                copied_models
+                copied_${target}_ktx_images
+            )
+        endif()
+
         if(EMSCRIPTEN)
             set_target_properties(${target} PROPERTIES SUFFIX ".html")
         endif()
-
-        # These custom targets, custom commands and dependencies copy
-        # the resources next to the executable for ease of use during
-        # debugging and testing. They have no effect on the install target.
-
-        # Copy the KTX images specific to the current target.
-        list(TRANSFORM ktx_image_sources REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
-            OUTPUT_VARIABLE ktx_image_copies
-        )
-        add_custom_command(
-            OUTPUT ${ktx_image_copies}
-            COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_image_sources} ${BUILDTIME_RESOURCES_DIR}
-            COMMENT "Copy ${target}'s ktx images to build destination"
-            DEPENDS ${ktx_image_sources}
-            VERBATIM
-        )
-        add_custom_target(
-            copied_${target}_ktx_images
-            DEPENDS ${ktx_image_copies}
-        )
-        add_dependencies(
-            copied_${target}_ktx_images
-            copied_common_ktx_images
-        )
-        add_dependencies( ${target}
-            copied_ktx_icons
-            copied_models
-            copied_${target}_ktx_images
-        )
 
         # See important comment and TODO:s starting at line 365
         # in ./vkloadtests.cmake regarding installation of these
@@ -416,17 +419,29 @@ endif()
 
 if(IOS OR EMULATE_GLES)
     # OpenGL ES 1.0
-    create_gl_target( es1loadtests "ES1" "${es1_sources}" "${KTX_APP_ICON_SOURCE}" "${es1_ktx_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 1 0 ON)
+    create_gl_target( es1loadtests "ES1" "${es1_sources}"
+        "${KTX_ICON_SOURCES}"                                   # common_resources
+        "${es1_ktx_image_sources}"                              # ktx_image_sources
+        SDL_GL_CONTEXT_PROFILE_ES 1 0 ON
+    )
 endif()
 
 if(IOS OR EMSCRIPTEN OR EMULATE_GLES)
     # OpenGL ES 3.0
-    create_gl_target( es3loadtests "ES3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_ktx12_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES)
+    create_gl_target( es3loadtests "ES3" "${gl3_sources}"
+        "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}"             # common_resources
+        "${gl3_ktx12_image_sources};${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}" # ktx_image_sources
+        SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES
+    )
 endif()
 
 if( (APPLE AND NOT IOS) OR LINUX OR WIN32 )
     # OpenGL 3.3
-    create_gl_target( gl3loadtests "GL3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_ktx12_image_sources}" SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES)
+    create_gl_target( gl3loadtests "GL3" "${gl3_sources}"
+        "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}"              # common_resources
+        "${gl3_ktx12_image_sources};${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}" # ktx_image_sources
+        SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES
+    )
 endif()
 
 unset( es1_sources )

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -10,13 +10,13 @@ if(WIN32)
     find_package(GLEW REQUIRED)
 endif()
 
-function( create_gl_target target version sources common_resources ktx_image_sources
+function( create_gl_target target version sources common_resources ktx_file_sources
           KTX_GL_CONTEXT_PROFILE
           KTX_GL_CONTEXT_MAJOR_VERSION KTX_GL_CONTEXT_MINOR_VERSION
           EMULATE_GLES)
 
     set( resources
-       ${common_resources};${ktx_image_sources};
+       ${common_resources};${ktx_file_sources};
     )
 
     add_executable( ${target}
@@ -112,7 +112,7 @@ function( create_gl_target target version sources common_resources ktx_image_sou
         # Beware of de-duplication in list expansion for commands and options.
         # SHELL: prevents it but if they are separate items in the list they
         # be de-duplicated.
-        list( TRANSFORM ktx_image_sources REPLACE
+        list( TRANSFORM ktx_file_sources REPLACE
             "(${PROJECT_SOURCE_DIR}/tests/resources/(ktx|ktx2)/([a-zA-Z0-9_].*$))"
             "SHELL:--preload-file \\1@\\3"
             OUTPUT_VARIABLE preloads
@@ -251,35 +251,13 @@ function( create_gl_target target version sources common_resources ktx_image_sou
 
     else()
         if(WINDOWS OR LINUX)
-            # These custom targets, custom commands and dependencies copy
-            # the resources next to the executable for ease of use during
-            # debugging and testing. They have no effect on the install target.
-
-            # Copy the KTX images specific to the current target.
-            list(TRANSFORM ktx_image_sources
-                REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
-                OUTPUT_VARIABLE ktx_image_copies
-            )
-            add_custom_command(
-                OUTPUT ${ktx_image_copies}
-                COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ktx_image_sources} ${BUILDTIME_RESOURCES_DIR}
-                COMMENT "Copy ${target}'s ktx images to build destination"
-                DEPENDS ${ktx_image_sources}
-                VERBATIM
-            )
-            add_custom_target(
-                copied_${target}_ktx_images
-                DEPENDS ${ktx_image_copies}
-            )
-            add_dependencies(
-                copied_${target}_ktx_images
-                copied_common_ktx_images
-            )
+            # These copy the resources to a shared resource directory next to
+            # the executables for ease of use during debugging and testing.
+            # They have no effect on the install targets.
             add_dependencies( ${target}
                 copied_ktx_icons
                 copied_models
-                copied_${target}_ktx_images
+                copied_ktx_files # Installs KTX files for configured targets.
             )
         endif()
 
@@ -337,15 +315,6 @@ function( create_gl_target target version sources common_resources ktx_image_sou
     endif()
 endfunction( create_gl_target target )
 
-set( es1_ktx_image_sources
-    no_npot.ktx
-    hi_mark.ktx
-    l8_unorm_metadata.ktx
-)
-list( TRANSFORM es1_ktx_image_sources
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
-)
-
 set( es1_sources
     glloadtests/gles1/ES1LoadTests.cpp
     glloadtests/gles1/DrawTexture.cpp
@@ -353,30 +322,6 @@ set( es1_sources
     glloadtests/gles1/TexturedCube.cpp
     glloadtests/gles1/TexturedCube.h
 )
-
-set( gl3_ktx2_image_sources
-    FlightHelmet_baseColor_blze.ktx2
-    r8g8b8_srgb_mip.ktx2
-    r8g8b8a8_srgb.ktx2
-    r8g8b8a8_srgb_3d_7.ktx2
-)
-
-set( gl3_ktx_image_sources
-    conftestimage_R11_EAC.ktx
-    conftestimage_SIGNED_R11_EAC.ktx
-    conftestimage_RG11_EAC.ktx
-    conftestimage_SIGNED_RG11_EAC.ktx
-    hi_mark.ktx
-)
-list( TRANSFORM gl3_ktx2_image_sources
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
-)
-list( TRANSFORM gl3_ktx_image_sources
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
-)
-
-set( gl3_ktx12_image_sources ${gl3_ktx2_image_sources} ${gl3_ktx_image_sources} )
-source_group("Resources/KTX Images" FILES ${gl3_ktx12_image_sources})
 
 set( gl3_sources
     common/TranscodeTargetStrToFmt.cpp
@@ -421,7 +366,7 @@ if(IOS OR EMULATE_GLES)
     # OpenGL ES 1.0
     create_gl_target( es1loadtests "ES1" "${es1_sources}"
         "${KTX_ICON_SOURCES}"                                   # common_resources
-        "${es1_ktx_image_sources}"                              # ktx_image_sources
+        "${ES1LOADTESTS_KTX_FILE_SOURCES}"                             # ktx_file_sources
         SDL_GL_CONTEXT_PROFILE_ES 1 0 ON
     )
 endif()
@@ -429,8 +374,8 @@ endif()
 if(IOS OR EMSCRIPTEN OR EMULATE_GLES)
     # OpenGL ES 3.0
     create_gl_target( es3loadtests "ES3" "${gl3_sources}"
-        "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}"             # common_resources
-        "${gl3_ktx12_image_sources};${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}" # ktx_image_sources
+        "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}" # common_resources
+        "${GLLOADTESTS_KTX_FILE_SOURCES}"                              # ktx_file_sources
         SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES
     )
 endif()
@@ -438,15 +383,11 @@ endif()
 if( (APPLE AND NOT IOS) OR LINUX OR WIN32 )
     # OpenGL 3.3
     create_gl_target( gl3loadtests "GL3" "${gl3_sources}"
-        "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}"              # common_resources
-        "${gl3_ktx12_image_sources};${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}" # ktx_image_sources
+        "${KTX_ICON_SOURCES};${LOAD_TEST_COMMON_MODEL_SOURCES}" # common_resources
+        "${GLLOADTESTS_KTX_FILE_SOURCES}"                              # ktx_file_sources
         SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES
     )
 endif()
 
 unset( es1_sources )
 unset( gl3_sources )
-unset( es1_ktx_image_sources )
-unset( gl3_ktx2_image_sources )
-unset( gl3_ktx_image_sources )
-unset( gl3_ktx12_image_sources )

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -10,12 +10,12 @@ if(WIN32)
     find_package(GLEW REQUIRED)
 endif()
 
-function( create_gl_target target version sources common_resources test_images
+function( create_gl_target target version sources common_resources test_image_sources
           KTX_GL_CONTEXT_PROFILE
           KTX_GL_CONTEXT_MAJOR_VERSION KTX_GL_CONTEXT_MINOR_VERSION
           EMULATE_GLES)
 
-    set( resources ${common_resources};${test_images} )
+    set( resources ${common_resources};${test_image_sources} )
 
     add_executable( ${target}
         ${EXE_FLAG}
@@ -110,7 +110,7 @@ function( create_gl_target target version sources common_resources test_images
         # Beware of de-duplication in list expansion for commands and options.
         # SHELL: prevents it but if they are separate items in the list they
         # be de-duplicated.
-        list( TRANSFORM test_images REPLACE
+        list( TRANSFORM test_image_sources REPLACE
             "(${PROJECT_SOURCE_DIR}/tests/resources/(ktx|ktx2)/([a-zA-Z0-9_].*$))"
             "SHELL:--preload-file \\1@\\3"
             OUTPUT_VARIABLE preloads
@@ -153,7 +153,6 @@ function( create_gl_target target version sources common_resources test_images
                 ${GLEW_LIBRARIES}
             )
         endif()
-        ensure_runtime_dependencies_windows(${target} "${test_images}")
     elseif(LINUX)
         # The output file is configured at CMake config time.
         configure_file(glloadtests/resources/linux/glloadtests.desktop.in
@@ -255,12 +254,34 @@ function( create_gl_target target version sources common_resources test_images
 
         # This copies the resources next to the executable for ease
         # of use during debugging and testing.
-        add_custom_command( TARGET ${target} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E make_directory
-              $<TARGET_FILE_DIR:${target}>/../resources
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-              ${resources}
-              $<TARGET_FILE_DIR:${target}>/../resources
+#        add_custom_command( TARGET ${target} POST_BUILD
+#            COMMAND ${CMAKE_COMMAND} -E make_directory
+#              $<TARGET_FILE_DIR:${target}>/../resources
+#            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+#              ${resources}
+#              $<TARGET_FILE_DIR:${target}>/../resources
+#        )
+        list(TRANSFORM test_image_sources REPLACE "^[a-zA-Z0-9:/<>].*/ktx(2?)" ${BUILDTIME_RESOURCES_DIR}
+            OUTPUT_VARIABLE test_image_copies
+        )
+        cmake_print_variables( test_image_copies )
+#        add_custom_command(
+#            OUTPUT ${test_image_copies}
+#           COMMAND ${CMAKE_COMMAND} -E copy_if_different ${test_image_sources} ${BUILDTIME_RESOURCES_DIR}
+#            COMMENT "Copy test images to build destination"
+#            VERBATIM
+#        )
+#        add_custom_target(
+#            copied_${target}_test_images
+#            DEPENDS ${test_image_copies}
+#        )
+#        add_dependencies(
+#            copied_${target}_test_images
+#            buildtime_resources_dir
+#        )
+        add_dependencies( ${target}
+            copied_models
+#            copied_${target}_test_images
         )
 
         # See important comment and TODO:s starting at line 365
@@ -314,7 +335,7 @@ function( create_gl_target target version sources common_resources test_images
 endfunction( create_gl_target target )
 
 
-set( ES1_TEST_IMAGES
+set( es1_test_image_sources
     no_npot.ktx
     hi_mark.ktx
     l8_unorm_metadata.ktx
@@ -330,11 +351,11 @@ set( ES1_TEST_IMAGES
     r8g8b8_srgb_mip.ktx
     hi_mark_sq.ktx
 )
-list( TRANSFORM ES1_TEST_IMAGES
+list( TRANSFORM es1_test_image_sources
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
 )
 
-set( ES1_SOURCES
+set( es1_sources
     glloadtests/gles1/ES1LoadTests.cpp
     glloadtests/gles1/DrawTexture.cpp
     glloadtests/gles1/DrawTexture.h
@@ -342,7 +363,7 @@ set( ES1_SOURCES
     glloadtests/gles1/TexturedCube.h
 )
 
-set( gl3_ktx2_test_images
+set( gl3_ktx2_test_image_sources
     astc_8x8_unorm_array_7.ktx2
     bc3_unorm_array_7.ktx2
     color_grid_uastc_zstd_5.ktx2
@@ -362,7 +383,7 @@ set( gl3_ktx2_test_images
     r8g8b8a8_srgb_3d_7.ktx2
     r8g8b8_srgb_mip.ktx2
 )
-set( gl3_ktx_test_images
+set( gl3_ktx_test_image_sources
     astc_8x8_unorm_array_7.ktx
     bc3_unorm_array_7.ktx
     conftestimage_R11_EAC.ktx
@@ -389,16 +410,15 @@ set( gl3_ktx_test_images
     r8g8b8_unorm_amg.ktx
     r8g8b8_srgb_mip.ktx
 )
-list( TRANSFORM gl3_ktx_test_images
+list( TRANSFORM gl3_ktx_test_image_sources
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
 )
-list( TRANSFORM gl3_ktx2_test_images
+list( TRANSFORM gl3_ktx2_test_image_sources
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
 )
-set( GL3_TEST_IMAGES ${gl3_ktx2_test_images} ${gl3_ktx_test_images} )
-set( GL3_RESOURCE_FILES ${LOAD_TEST_COMMON_RESOURCE_FILES} ${GL3_TEST_IMAGES} )
-unset( gl3_ktx2_test_images )
-unset( gl3_ktx_test_images )
+set( gl3_test_image_sources ${gl3_ktx2_test_image_sources} ${gl3_ktx_test_image_sources} )
+#set( gl3_resource_files ${LOAD_TEST_COMMON_RESOURCE_FILES} ${gl3_test_image_sources} )
+
 
 set( GL3_SOURCES
     common/TranscodeTargetStrToFmt.cpp
@@ -442,16 +462,22 @@ endif()
 
 if(IOS OR EMULATE_GLES)
     # OpenGL ES 1.0
-    create_gl_target( es1loadtests "ES1" "${ES1_SOURCES}" "${KTX_APP_ICON_PATH}" "${ES1_TEST_IMAGES}" SDL_GL_CONTEXT_PROFILE_ES 1 0 ON)
+    create_gl_target( es1loadtests "ES1" "${es1_sources}" "${KTX_APP_ICON_SOURCE_PATH}" "${es1_test_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 1 0 ON)
 endif()
 
 if(IOS OR EMSCRIPTEN OR EMULATE_GLES)
     # OpenGL ES 3.0
-    create_gl_target( es3loadtests "ES3" "${GL3_SOURCES}" "${LOAD_TEST_COMMON_RESOURCE_FILES}" "${GL3_TEST_IMAGES}" SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES)
+    create_gl_target( es3loadtests "ES3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_test_image_sources}" SDL_GL_CONTEXT_PROFILE_ES 3 0 ON YES)
 endif()
 
 if( (APPLE AND NOT IOS) OR LINUX OR WIN32 )
     # OpenGL 3.3
-    create_gl_target( gl3loadtests "GL3" "${GL3_SOURCES}" "${LOAD_TEST_COMMON_RESOURCE_FILES}" "${GL3_TEST_IMAGES}" SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES)
+    create_gl_target( gl3loadtests "GL3" "${gl3_sources}" "${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}" "${gl3_test_image_sources}" SDL_GL_CONTEXT_PROFILE_CORE 3 3 OFF YES)
 endif()
 
+unset( es1_sources )
+unset( gl3_sources )
+unset( es1_test_image_sources )
+unset( gl3_ktx2_test_image_sources )
+unset( gl3_ktx_test_image_sources )
+unset( gl3_test_image_sources )

--- a/tests/loadtests/glloadtests/gles1/DrawTexture.cpp
+++ b/tests/loadtests/glloadtests/gles1/DrawTexture.cpp
@@ -113,7 +113,7 @@ DrawTexture::DrawTexture(uint32_t width, uint32_t height,
 
     if (npotTexture  && !bNpotSupported) {
         /* Load error texture. */
-        filename = "no-npot.ktx";
+        filename = "no_npot.ktx";
     }
     
     pathname = getAssetPath() + filename;

--- a/tests/loadtests/glloadtests/gles1/TexturedCube.cpp
+++ b/tests/loadtests/glloadtests/gles1/TexturedCube.cpp
@@ -80,7 +80,7 @@ TexturedCube::TexturedCube(uint32_t width, uint32_t height,
     
     if (npotTexture  && !npotSupported) {
         /* Load error texture. */
-        filename = "no-npot.ktx";
+        filename = "no_npot.ktx";
     }
     pathname = getAssetPath() + filename;
 

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -408,17 +408,16 @@ else()
     )
     add_dependencies(
         copied_shaders
-        buildtime_resources_dir
+        copied_models   # To ensure the output directory exists before copying
     )
     add_dependencies(
         copied_vkloadtests_ktx2_images
-        buildtime_resources_dir
+        copied_common_ktx_images
     )
     add_dependencies(   
         vkloadtests
         copied_models
         copied_shaders
-        copied_common_ktx_images
         copied_vkloadtests_ktx2_images
     )
 

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020 Andreas Atteneder
+# Copyright 2020-2026 Andreas Atteneder, Mark Callow
 # SPDX-License-Identifier: Apache-2.0
 
 # Find Vulkan package

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -386,7 +386,7 @@ else()
         copied_shaders
         DEPENDS ${copied_shaders}
     )
-    cmake_print_variables( BUILDTIME_RESOURCES_DIR )
+    
     list(TRANSFORM vkloadtests_ktx2_image_sources REPLACE ^[a-zA-Z0-9:/<>].*/ktx2 ${BUILDTIME_RESOURCES_DIR}
         OUTPUT_VARIABLE copied_vkloadtests_ktx2_images
     )

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -85,10 +85,10 @@ set( ktx2_file_sources
     Desk_uastc_hdr4x4_zstd_15.ktx2
     Desk_uastc_hdr6x6i.ktx2
     etc2_unorm_array_7.ktx2
-    ktx_document_blze.ktx2
-    ktx_document_uastc_rdo_4_zstd_5.ktx2
     Iron_Bars_001_normal_blze.ktx2
     Iron_Bars_001_normal_uastc_zstd_10.ktx2
+    ktx_document_blze.ktx2
+    ktx_document_uastc_rdo_4_zstd_5.ktx2
     kodim17_blze.ktx2
     orient_down_metadata.ktx2
     orient_up_metadata.ktx2
@@ -110,7 +110,6 @@ set( ktx1_file_sources
     etc2_srgb.ktx
     etc2_srgba8.ktx
     etc2_unorm_array_7.ktx
-    hi_mark_sq.ktx
     metalplate_amg.ktx
     not4_r8g8b8_srgb.ktx
     orient_down_metadata.ktx

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -383,6 +383,7 @@ else()
     )
     add_custom_command(
         OUTPUT ${copied_shaders}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SPVS} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy shaders to build destination"
         VERBATIM
@@ -398,6 +399,7 @@ else()
 
     add_custom_command(
         OUTPUT ${copied_vkloadtests_ktx2_images}
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${vkloadtests_ktx2_image_sources} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy vkloadtests ktx2 images to build destination"
         VERBATIM
@@ -407,15 +409,12 @@ else()
         DEPENDS ${copied_vkloadtests_ktx2_images}
     )
     add_dependencies(
-        copied_shaders
-        copied_models   # To ensure the output directory exists before copying
-    )
-    add_dependencies(
         copied_vkloadtests_ktx2_images
         copied_common_ktx_images
     )
     add_dependencies(   
         vkloadtests
+        copied_ktx_icons
         copied_models
         copied_shaders
         copied_vkloadtests_ktx2_images

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -117,12 +117,22 @@ set( vk_ktx_test_images
 )
 list( TRANSFORM vk_ktx2_test_images
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
+    OUTPUT_VARIABLE vk_ktx2_test_image_sources
 )
 list( TRANSFORM vk_ktx_test_images
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
+    OUTPUT_VARIABLE vk_ktx_test_image_sources
 )
-set( VK_TEST_IMAGES ${vk_ktx2_test_images} ${vk_ktx_test_images} )
-set( KTX_RESOURCES ${LOAD_TEST_COMMON_RESOURCE_FILES} ${VK_TEST_IMAGES} )
+list( TRANSFORM vk_ktx2_test_images
+    PREPEND "${BUILDTIME_RESOURCES_DIR}/"
+    OUTPUT_VARIABLE vk_ktx2_test_image_copies
+)
+list( TRANSFORM vk_ktx_test_images
+    PREPEND "${BUILDTIME_RESOURCES_DIR}/"
+    OUTPUT_VARIABLE vk_ktx_test_image_copies
+)
+set( VK_TEST_IMAGE_SOURCES ${vk_ktx2_test_image_sources} ${vk_ktx_test_image_sources} )
+set( KTX_RESOURCES ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${VK_TEST_IMAGE_SOURCES} )
 unset( vk_ktx2_test_images )
 unset( vk_ktx_test_images )
 
@@ -174,10 +184,10 @@ add_executable( vkloadtests
     vkloadtests/VulkanLoadTests.h
     vkloadtests/VulkanLoadTestSample.cpp
     vkloadtests/VulkanLoadTestSample.h
-    ${LOAD_TEST_COMMON_RESOURCE_FILES}
+    ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
     ${Vulkan_SHARE_VULKAN}
     ${SHADER_SOURCES}
-    ${VK_TEST_IMAGES}
+    ${VK_TEST_IMAGE_SOURCES}
     vkloadtests.cmake
 )
 
@@ -273,8 +283,6 @@ if(APPLE)
     else()
         set( INFO_PLIST_IN "${PROJECT_SOURCE_DIR}/tests/loadtests/vkloadtests/resources/mac/Info.plist.in" )
     endif()
-elseif(WIN32)
-    ensure_runtime_dependencies_windows(vkloadtests ${VK_TEST_IMAGES})
 elseif(LINUX)
         target_sources(
             vkloadtests
@@ -392,16 +400,60 @@ if(APPLE)
         #     #fixup_bundle($<TARGET_BUNDLE_DIR:vkloadtests> \"\" \"\")"
         # )
     endif()
+    add_dependencies(
+        vkloadtests
+        spirv_shaders
+    )
 else()
     # This is for other platforms.
     # This copies the resources next to the executable for ease
     # of use during debugging and testing.
-    add_custom_command( TARGET vkloadtests POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory
-          $<TARGET_FILE_DIR:vkloadtests>/../resources
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-          ${KTX_RESOURCES} ${SHADER_SOURCES}
-          $<TARGET_FILE_DIR:vkloadtests>/../resources
+#    add_custom_command( TARGET vkloadtests POST_BUILD
+#        COMMAND ${CMAKE_COMMAND} -E make_directory
+#          $<TARGET_FILE_DIR:vkloadtests>/../resources
+#        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+#          ${KTX_RESOURCES} ${SHADER_SOURCES}
+#          $<TARGET_FILE_DIR:vkloadtests>/../resources
+#    )
+
+    # TODO: SHADER_SOURCES appears misnamed. It iis actually the list of .spv files.
+    list(TRANSFORM SHADER_SOURCES REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
+        OUTPUT_VARIABLE COPIED_SHADERS
+    )
+    add_custom_command(
+        OUTPUT ${COPIED_SHADERS}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SOURCES} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Copy shaders to build destination"
+        VERBATIM
+    )
+    add_custom_target(
+        copied_shaders
+        DEPENDS ${COPIED_SHADERS}
+    )
+    set(vkloadtests_test_image_copies ${vk_ktx2_test_image_copies} ${vk_ktx_test_image_copies})
+    add_custom_command(
+        OUTPUT ${vkloadtests_test_image_copies}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VK_TEST_IMAGE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Copy test images to build destination"
+        VERBATIM
+    )
+    add_custom_target(
+        copied_vkloadtests_test_images
+        DEPENDS ${vk_ktx2_test_image_copies} ${vk_ktx_test_image_copies}
+    )
+    add_dependencies(
+        copied_shaders
+        buildtime_resources_dir
+    )
+    add_dependencies(
+        copied_vkloadtests_test_images
+        buildtime_resources_dir
+    )
+    add_dependencies(
+        vkloadtests
+        copied_shaders
+        copied_vkloadtests_test_images
+        copied_models
     )
 
     # To keep the resources (test images and models) close to the
@@ -458,8 +510,4 @@ else()
 #    endif()
 endif()
 
-add_dependencies(
-    vkloadtests
-    spirv_shaders
-)
 

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -75,11 +75,6 @@ add_custom_target(
 set( ktx2_file_sources
     alpha_complex_straight.ktx2
     alpha_complex_premultiplied.ktx2
-    Desk_uastc_hdr4x4_zstd_15.ktx2
-    Desk_uastc_hdr6x6i.ktx2
-    ktx_document_blze.ktx2
-    ktx_document_uastc_rdo_4_zstd_5.ktx2
-    r8g8b8a8_srgb_array_7_mip.ktx2
     astc_8x8_unorm_array_7.ktx2
     bc3_unorm_array_7.ktx2
     color_grid_uastc_zstd_5.ktx2
@@ -87,13 +82,21 @@ set( ktx2_file_sources
     color_grid_blze.ktx2
     cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
     cubemap_yokohama_blze.ktx2
+    Desk_uastc_hdr4x4_zstd_15.ktx2
+    Desk_uastc_hdr6x6i.ktx2
     etc2_unorm_array_7.ktx2
+    ktx_document_blze.ktx2
+    ktx_document_uastc_rdo_4_zstd_5.ktx2
     Iron_Bars_001_normal_blze.ktx2
     Iron_Bars_001_normal_uastc_zstd_10.ktx2
     kodim17_blze.ktx2
     orient_down_metadata.ktx2
     orient_up_metadata.ktx2
     pattern_02_bc2.ktx2
+    r8g8b8a8_srgb.ktx2
+    r8g8b8a8_srgb_3d_7.ktx2
+    r8g8b8a8_srgb_array_7_mip.ktx2
+    r8g8b8a8_srgb_mip_blze.ktx2
     skybox_zstd_22.ktx2
 )
 list( TRANSFORM ktx2_file_sources
@@ -102,12 +105,9 @@ list( TRANSFORM ktx2_file_sources
 set( ktx1_file_sources
     astc_8x8_unorm_array_7.ktx
     bc3_unorm_array_7.ktx
-    etc1.ktx
     etc2_rgb.ktx
-    etc2_rgba1.ktx
     etc2_rgba8.ktx
     etc2_srgb.ktx
-    etc2_srgba1.ktx
     etc2_srgba8.ktx
     etc2_unorm_array_7.ktx
     hi_mark_sq.ktx
@@ -116,8 +116,6 @@ set( ktx1_file_sources
     orient_down_metadata.ktx
     orient_up_metadata.ktx
     pattern_02_bc2.ktx
-    r8g8b8_srgb.ktx
-    r8g8b8_srgb_mip.ktx
     r8g8b8_unorm_amg.ktx
     r8g8b8a8_srgb.ktx
 )
@@ -412,40 +410,8 @@ else()
     # resources next to the built executable for ease of use during
     # debugging and testing. They have no effect on the install target.
 
-    # These custom targets, custom commands and dependencies copy
-    # the resources next to the executable for ease of use during
-    # debugging and testing. They have no effect on the install target.
-
-    # As these custom commands and targets are only referenced by vkloadtests
-    # we could use just custom commands without fear of races but for
-    # consistency we handle these resources in the same way as the shared
-    # resources.
-
-    #list(TRANSFORM SHADER_SPVS REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
-    #    OUTPUT_VARIABLE copied_shaders
-    #)
-    #add_custom_command(
-    #    OUTPUT ${copied_shaders}
-    #    COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-    #    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SPVS} ${BUILDTIME_RESOURCES_DIR}
-    #    COMMENT "Copy shaders to build destination"
-    #    VERBATIM
-    #)
-    #add_custom_target(
-    #    copied_shaders
-    #    DEPENDS ${copied_shaders}
-    #)
-    
-    #add_dependencies(   
-    #    vkloadtests
-    #    copied_ktx_icons
-    #    copied_models
-    #    copied_shaders
-    #    copied_ktx_files
-    #)
-
-    #unset( copied_shaders )
- 
+    # Installation
+    #
     # To keep the resources (test images and models) close to the
     # executable and to be compliant with the Filesystem Hierarchy
     # Standard https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -35,7 +35,7 @@ if(APPLE)
         set( Vulkan_SHARE_VULKAN appfwSDL/VulkanAppSDL/mac/vulkan )
     endif()
 else()
-    find_package(Vulkan REQUIRED)
+    find_package( Vulkan REQUIRED )
 endif()
 
 #cmake_print_variables(
@@ -47,8 +47,8 @@ endif()
 
 include(compile_shader.cmake)
 
-set(SHADER_SOURCES "")
-set(SHADER_SPVS "")
+set( SHADER_SOURCES "" )
+set( SHADER_SPVS "" )
 
 compile_shader(shader_textoverlay textoverlay appfwSDL/VulkanAppSDL/shaders shaders )
 compile_shader(shader_cube cube vkloadtests/shaders/cube shaders )
@@ -72,9 +72,64 @@ add_custom_target(
     shader_texturemipmap
 )
 
+set( ktx2_file_sources
+    alpha_complex_straight.ktx2
+    alpha_complex_premultiplied.ktx2
+    Desk_uastc_hdr4x4_zstd_15.ktx2
+    Desk_uastc_hdr6x6i.ktx2
+    ktx_document_blze.ktx2
+    ktx_document_uastc_rdo_4_zstd_5.ktx2
+    r8g8b8a8_srgb_array_7_mip.ktx2
+    astc_8x8_unorm_array_7.ktx2
+    bc3_unorm_array_7.ktx2
+    color_grid_uastc_zstd_5.ktx2
+    color_grid_zstd_5.ktx2
+    color_grid_blze.ktx2
+    cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
+    cubemap_yokohama_blze.ktx2
+    etc2_unorm_array_7.ktx2
+    Iron_Bars_001_normal_blze.ktx2
+    Iron_Bars_001_normal_uastc_zstd_10.ktx2
+    kodim17_blze.ktx2
+    orient_down_metadata.ktx2
+    orient_up_metadata.ktx2
+    pattern_02_bc2.ktx2
+    skybox_zstd_22.ktx2
+)
+list( TRANSFORM ktx2_file_sources
+    PREPEND "${TEST_RESOURCES_DIR}/ktx2/"
+)
+set( ktx1_file_sources
+    astc_8x8_unorm_array_7.ktx
+    bc3_unorm_array_7.ktx
+    etc1.ktx
+    etc2_rgb.ktx
+    etc2_rgba1.ktx
+    etc2_rgba8.ktx
+    etc2_srgb.ktx
+    etc2_srgba1.ktx
+    etc2_srgba8.ktx
+    etc2_unorm_array_7.ktx
+    hi_mark_sq.ktx
+    metalplate_amg.ktx
+    not4_r8g8b8_srgb.ktx
+    orient_down_metadata.ktx
+    orient_up_metadata.ktx
+    pattern_02_bc2.ktx
+    r8g8b8_srgb.ktx
+    r8g8b8_srgb_mip.ktx
+    r8g8b8_unorm_amg.ktx
+    r8g8b8a8_srgb.ktx
+)
+list( TRANSFORM ktx1_file_sources
+    PREPEND "${TEST_RESOURCES_DIR}/ktx/"
+)
+
 set( KTX_RESOURCES
     ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
-    ${VKLOADTESTS_KTX_FILE_SOURCES}
+    ${ktx2_file_sources}
+    ${ktx1_file_sources}
+    ${SHADER_SPVS}
 )
 
 if(APPLE)
@@ -130,11 +185,13 @@ add_executable( vkloadtests
     ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
     ${LOAD_TEST_COMMON_MODEL_SOURCES}
     ${SHADER_SOURCES}
-    ${VKLOADTESTS_KTX_FILE_SOURCES}
+    ${ktx2_file_sources}
+    ${ktx1_file_sources}
     ${Vulkan_SHARE_VULKAN}
 )
 
-source_group("Resources/Shaders" FILES ${SHADER_SOURCES})
+source_group( "Resources/Shaders" FILES ${SHADER_SOURCES})
+source_group( "Resources/KTX Images" REGULAR_EXPRESSION "${TEST_RESOURCES_DIR}/ktx(2?)/.*" )
 
 # Keep this in case something changes in the Vulkan implementation and we need to
 # explicitly set wantsExtendedDynamicRangeContent as we must on locked OSes.
@@ -152,7 +209,6 @@ if(APPLE_LOCKED_OS)
         appfwSDL/uikitSetEDR.mm
     )
 endif()
-
 
 set_code_sign(vkloadtests)
 
@@ -246,7 +302,7 @@ PRIVATE
     $<$<PLATFORM_ID:Windows>:NOMINMAX>
 )
 
-set_target_properties( vkloadtests PROPERTIES RESOURCE "${KTX_RESOURCES};${SHADER_SPVS}" )
+set_target_properties( vkloadtests PROPERTIES RESOURCE "${KTX_RESOURCES}" )
 
 if(APPLE)
     set( product_name vkloadtests )
@@ -352,6 +408,10 @@ if(APPLE)
 else()
     # This is for other platforms.
 
+    # See parent CMakeLists.txt for custom target and command to copy
+    # resources next to the built executable for ease of use during
+    # debugging and testing. They have no effect on the install target.
+
     # These custom targets, custom commands and dependencies copy
     # the resources next to the executable for ease of use during
     # debugging and testing. They have no effect on the install target.
@@ -361,30 +421,30 @@ else()
     # consistency we handle these resources in the same way as the shared
     # resources.
 
-    list(TRANSFORM SHADER_SPVS REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
-        OUTPUT_VARIABLE copied_shaders
-    )
-    add_custom_command(
-        OUTPUT ${copied_shaders}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SPVS} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy shaders to build destination"
-        VERBATIM
-    )
-    add_custom_target(
-        copied_shaders
-        DEPENDS ${copied_shaders}
-    )
+    #list(TRANSFORM SHADER_SPVS REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
+    #    OUTPUT_VARIABLE copied_shaders
+    #)
+    #add_custom_command(
+    #    OUTPUT ${copied_shaders}
+    #    COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
+    #    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SPVS} ${BUILDTIME_RESOURCES_DIR}
+    #    COMMENT "Copy shaders to build destination"
+    #    VERBATIM
+    #)
+    #add_custom_target(
+    #    copied_shaders
+    #    DEPENDS ${copied_shaders}
+    #)
     
-    add_dependencies(   
-        vkloadtests
-        copied_ktx_icons
-        copied_models
-        copied_shaders
-        copied_ktx_files
-    )
+    #add_dependencies(   
+    #    vkloadtests
+    #    copied_ktx_icons
+    #    copied_models
+    #    copied_shaders
+    #    copied_ktx_files
+    #)
 
-    unset( copied_shaders )
+    #unset( copied_shaders )
  
     # To keep the resources (test images and models) close to the
     # executable and to be compliant with the Filesystem Hierarchy

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -382,8 +382,8 @@ if(APPLE)
             COMMAND ${CMAKE_COMMAND} -E create_symlink "${Vulkan_LIBRARY_REAL_FILE_NAME}" "$<TARGET_BUNDLE_CONTENT_DIR:vkloadtests>/Frameworks/${Vulkan_LIBRARY_SONAME_FILE_NAME}"
             COMMENT "Create symlink for Vulkan library (ld name to real name)"
         )
-        # Re. SDL3 & assimp: no copy required.: vcpkg libs are static or else
-        # vcpkg arranges copy. Brew libs cannot be bundled.
+        # Re. SDL3 & assimp: no copy required.: vcpkg libs are static. Brew libs
+        # cannot be bundled.
 
         # Specify destination for cmake --install.
         install(TARGETS vkloadtests

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -362,8 +362,11 @@ if(APPLE)
     )
 else()
     # This is for other platforms.
-    # This copies the resources next to the executable for ease
-    # of use during debugging and testing.
+
+    # These custom targets, custom commands and dependencies copy
+    # the resources next to the executable for ease of use during
+    # debugging and testing. They have no effect on the install target.
+
     # As these custom commands and targets are only referenced by vkloadtests
     # we could use just custom commands without fear of races but for
     # consistency we handle these resources in the same way as the shared
@@ -371,32 +374,32 @@ else()
 
     # TODO: SHADER_SOURCES appears misnamed. It iis actually the list of .spv files.
     list(TRANSFORM SHADER_SOURCES REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
-        OUTPUT_VARIABLE COPIED_SHADERS
+        OUTPUT_VARIABLE copied_shaders
     )
     add_custom_command(
-        OUTPUT ${COPIED_SHADERS}
+        OUTPUT ${copied_shaders}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SOURCES} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy shaders to build destination"
         VERBATIM
     )
     add_custom_target(
         copied_shaders
-        DEPENDS ${COPIED_SHADERS}
+        DEPENDS ${copied_shaders}
     )
     cmake_print_variables( BUILDTIME_RESOURCES_DIR )
     list(TRANSFORM vkloadtests_ktx2_image_sources REPLACE ^[a-zA-Z0-9:/<>].*/ktx2 ${BUILDTIME_RESOURCES_DIR}
-        OUTPUT_VARIABLE vkloadtests_ktx2_image_copies
+        OUTPUT_VARIABLE copied_vkloadtests_ktx2_images
     )
 
     add_custom_command(
-        OUTPUT ${vkloadtests_ktx2_image_copies}
+        OUTPUT ${copied_vkloadtests_ktx2_images}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${vkloadtests_ktx2_image_sources} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy vkloadtests ktx2 images to build destination"
         VERBATIM
     )
     add_custom_target(
         copied_vkloadtests_ktx2_images
-        DEPENDS ${vkloadtests_ktx2_image_copies}
+        DEPENDS ${copied_vkloadtests_ktx2_images}
     )
     add_dependencies(
         copied_shaders
@@ -413,6 +416,9 @@ else()
         copied_common_ktx_images
         copied_vkloadtests_ktx2_images
     )
+
+    unset( copied_shaders )
+    unset( copied_vkloadtests_ktx2_images )
 
     # To keep the resources (test images and models) close to the
     # executable and to be compliant with the Filesystem Hierarchy

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -71,70 +71,25 @@ add_custom_target(
     shader_texturemipmap
 )
 
-set( vk_ktx2_test_images
-    astc_8x8_unorm_array_7.ktx2
-    bc3_unorm_array_7.ktx2
+set( vkloadtests_ktx2_image_sources
     alpha_complex_straight.ktx2
     alpha_complex_premultiplied.ktx2
-    color_grid_uastc_zstd_5.ktx2
-    color_grid_zstd_5.ktx2
-    color_grid_blze.ktx2
-    cubemap_goldengate_uastc_rdo_4_zstd_5.ktx2
-    cubemap_yokohama_blze.ktx2
     Desk_uastc_hdr4x4_zstd_15.ktx2
     Desk_uastc_hdr6x6i.ktx2
-    etc2_unorm_array_7.ktx2
-    Iron_Bars_001_normal_blze.ktx2
-    Iron_Bars_001_normal_uastc_zstd_10.ktx2
     ktx_document_blze.ktx2
     ktx_document_uastc_rdo_4_zstd_5.ktx2
-    kodim17_blze.ktx2
-    orient_down_metadata.ktx2
-    orient_up_metadata.ktx2
-    pattern_02_bc2.ktx2
-    r8g8b8a8_srgb.ktx2
-    r8g8b8a8_srgb_mip_blze.ktx2
-    r8g8b8a8_srgb_3d_7.ktx2
     r8g8b8a8_srgb_array_7_mip.ktx2
-    skybox_zstd_22.ktx2
 )
-set( vk_ktx_test_images
-    astc_8x8_unorm_array_7.ktx
-    bc3_unorm_array_7.ktx
-    etc2_rgb.ktx
-    etc2_rgba8.ktx
-    etc2_srgb.ktx
-    #etc2_srgba1.ktx
-    etc2_srgba8.ktx
-    etc2_unorm_array_7.ktx
-    metalplate_amg.ktx
-    not4_r8g8b8_srgb.ktx
-    orient_down_metadata.ktx
-    orient_up_metadata.ktx
-    pattern_02_bc2.ktx
-    r8g8b8_unorm_amg.ktx
-    r8g8b8a8_srgb.ktx
-)
-list( TRANSFORM vk_ktx2_test_images
+list( TRANSFORM vkloadtests_ktx2_image_sources
     PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
-    OUTPUT_VARIABLE vk_ktx2_test_image_sources
 )
-list( TRANSFORM vk_ktx_test_images
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx/"
-    OUTPUT_VARIABLE vk_ktx_test_image_sources
+# All the ktx1 images used are shared with the other apps.
+
+set( KTX_RESOURCES
+    ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
+    ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
+    ${vkloadtests_ktx2_image_sources}
 )
-list( TRANSFORM vk_ktx2_test_images
-    PREPEND "${BUILDTIME_RESOURCES_DIR}/"
-    OUTPUT_VARIABLE vk_ktx2_test_image_copies
-)
-list( TRANSFORM vk_ktx_test_images
-    PREPEND "${BUILDTIME_RESOURCES_DIR}/"
-    OUTPUT_VARIABLE vk_ktx_test_image_copies
-)
-set( VK_TEST_IMAGE_SOURCES ${vk_ktx2_test_image_sources} ${vk_ktx_test_image_sources} )
-set( KTX_RESOURCES ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES} ${VK_TEST_IMAGE_SOURCES} )
-unset( vk_ktx2_test_images )
-unset( vk_ktx_test_images )
 
 if(APPLE)
     # Adding this directory to KTX_RESOURCES and ultimately vkloadtests's
@@ -187,7 +142,8 @@ add_executable( vkloadtests
     ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
     ${Vulkan_SHARE_VULKAN}
     ${SHADER_SOURCES}
-    ${VK_TEST_IMAGE_SOURCES}
+    ${vkloadtests_ktx2_image_sources}
+    ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
     vkloadtests.cmake
 )
 
@@ -408,13 +364,10 @@ else()
     # This is for other platforms.
     # This copies the resources next to the executable for ease
     # of use during debugging and testing.
-#    add_custom_command( TARGET vkloadtests POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E make_directory
-#          $<TARGET_FILE_DIR:vkloadtests>/../resources
-#        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-#          ${KTX_RESOURCES} ${SHADER_SOURCES}
-#          $<TARGET_FILE_DIR:vkloadtests>/../resources
-#    )
+    # As these custom commands and targets are only referenced by vkloadtests
+    # we could use just custom commands without fear of races but for
+    # consistency we handle these resources in the same way as the shared
+    # resources.
 
     # TODO: SHADER_SOURCES appears misnamed. It iis actually the list of .spv files.
     list(TRANSFORM SHADER_SOURCES REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
@@ -430,30 +383,35 @@ else()
         copied_shaders
         DEPENDS ${COPIED_SHADERS}
     )
-    set(vkloadtests_test_image_copies ${vk_ktx2_test_image_copies} ${vk_ktx_test_image_copies})
+    cmake_print_variables( BUILDTIME_RESOURCES_DIR )
+    list(TRANSFORM vkloadtests_ktx2_image_sources REPLACE ^[a-zA-Z0-9:/<>].*/ktx2 ${BUILDTIME_RESOURCES_DIR}
+        OUTPUT_VARIABLE vkloadtests_ktx2_image_copies
+    )
+
     add_custom_command(
-        OUTPUT ${vkloadtests_test_image_copies}
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VK_TEST_IMAGE_SOURCES} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy test images to build destination"
+        OUTPUT ${vkloadtests_ktx2_image_copies}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${vkloadtests_ktx2_image_sources} ${BUILDTIME_RESOURCES_DIR}
+        COMMENT "Copy vkloadtests ktx2 images to build destination"
         VERBATIM
     )
     add_custom_target(
-        copied_vkloadtests_test_images
-        DEPENDS ${vk_ktx2_test_image_copies} ${vk_ktx_test_image_copies}
+        copied_vkloadtests_ktx2_images
+        DEPENDS ${vkloadtests_ktx2_image_copies}
     )
     add_dependencies(
         copied_shaders
         buildtime_resources_dir
     )
     add_dependencies(
-        copied_vkloadtests_test_images
+        copied_vkloadtests_ktx2_images
         buildtime_resources_dir
     )
-    add_dependencies(
+    add_dependencies(   
         vkloadtests
-        copied_shaders
-        copied_vkloadtests_test_images
         copied_models
+        copied_shaders
+        copied_common_ktx_images
+        copied_vkloadtests_ktx2_images
     )
 
     # To keep the resources (test images and models) close to the

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -143,11 +143,15 @@ add_executable( vkloadtests
     vkloadtests/VulkanLoadTestSample.h
     vkloadtests.cmake
     ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
+    ${LOAD_TEST_COMMON_MODEL_SOURCES}
     ${SHADER_SOURCES}
     ${vkloadtests_ktx2_image_sources}
     ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
     ${Vulkan_SHARE_VULKAN}
 )
+
+source_group("Resources/Shaders" FILES ${SHADER_SOURCES})
+source_group("Resources/KTX Images" FILES ${vkloadtests_ktx2_image_sources})
 
 # Keep this in case something changes in the Vulkan implementation and we need to
 # explicitly set wantsExtendedDynamicRangeContent as we must on locked OSes.

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -48,6 +48,7 @@ endif()
 include(compile_shader.cmake)
 
 set(SHADER_SOURCES "")
+set(SHADER_SPVS "")
 
 compile_shader(shader_textoverlay textoverlay appfwSDL/VulkanAppSDL/shaders shaders )
 compile_shader(shader_cube cube vkloadtests/shaders/cube shaders )
@@ -119,6 +120,7 @@ add_executable( vkloadtests
     common/disable_glm_warnings.h
     common/ltexceptions.h
     common/reenable_warnings.h
+    compile_shader.cmake
     vkloadtests/InstancedSampleBase.cpp
     vkloadtests/InstancedSampleBase.h
     vkloadtests/Texture.cpp
@@ -139,12 +141,12 @@ add_executable( vkloadtests
     vkloadtests/VulkanLoadTests.h
     vkloadtests/VulkanLoadTestSample.cpp
     vkloadtests/VulkanLoadTestSample.h
+    vkloadtests.cmake
     ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
-    ${Vulkan_SHARE_VULKAN}
     ${SHADER_SOURCES}
     ${vkloadtests_ktx2_image_sources}
     ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
-    vkloadtests.cmake
+    ${Vulkan_SHARE_VULKAN}
 )
 
 # Keep this in case something changes in the Vulkan implementation and we need to
@@ -257,7 +259,7 @@ PRIVATE
     $<$<PLATFORM_ID:Windows>:NOMINMAX>
 )
 
-set_target_properties( vkloadtests PROPERTIES RESOURCE "${KTX_RESOURCES};${SHADER_SOURCES}" )
+set_target_properties( vkloadtests PROPERTIES RESOURCE "${KTX_RESOURCES};${SHADER_SPVS}" )
 
 if(APPLE)
     set( product_name vkloadtests )
@@ -372,13 +374,12 @@ else()
     # consistency we handle these resources in the same way as the shared
     # resources.
 
-    # TODO: SHADER_SOURCES appears misnamed. It iis actually the list of .spv files.
-    list(TRANSFORM SHADER_SOURCES REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
+    list(TRANSFORM SHADER_SPVS REPLACE ^[a-zA-Z0-9:/<>].*/shaders ${BUILDTIME_RESOURCES_DIR}
         OUTPUT_VARIABLE copied_shaders
     )
     add_custom_command(
         OUTPUT ${copied_shaders}
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SOURCES} ${BUILDTIME_RESOURCES_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SHADER_SPVS} ${BUILDTIME_RESOURCES_DIR}
         COMMENT "Copy shaders to build destination"
         VERBATIM
     )

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -72,24 +72,9 @@ add_custom_target(
     shader_texturemipmap
 )
 
-set( vkloadtests_ktx2_image_sources
-    alpha_complex_straight.ktx2
-    alpha_complex_premultiplied.ktx2
-    Desk_uastc_hdr4x4_zstd_15.ktx2
-    Desk_uastc_hdr6x6i.ktx2
-    ktx_document_blze.ktx2
-    ktx_document_uastc_rdo_4_zstd_5.ktx2
-    r8g8b8a8_srgb_array_7_mip.ktx2
-)
-list( TRANSFORM vkloadtests_ktx2_image_sources
-    PREPEND "${PROJECT_SOURCE_DIR}/tests/resources/ktx2/"
-)
-# All the ktx1 images used are shared with the other apps.
-
 set( KTX_RESOURCES
     ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
-    ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
-    ${vkloadtests_ktx2_image_sources}
+    ${VKLOADTESTS_KTX_FILE_SOURCES}
 )
 
 if(APPLE)
@@ -145,13 +130,11 @@ add_executable( vkloadtests
     ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
     ${LOAD_TEST_COMMON_MODEL_SOURCES}
     ${SHADER_SOURCES}
-    ${vkloadtests_ktx2_image_sources}
-    ${LOAD_TEST_COMMON_KTX12_IMAGE_SOURCES}
+    ${VKLOADTESTS_KTX_FILE_SOURCES}
     ${Vulkan_SHARE_VULKAN}
 )
 
 source_group("Resources/Shaders" FILES ${SHADER_SOURCES})
-source_group("Resources/KTX Images" FILES ${vkloadtests_ktx2_image_sources})
 
 # Keep this in case something changes in the Vulkan implementation and we need to
 # explicitly set wantsExtendedDynamicRangeContent as we must on locked OSes.
@@ -393,36 +376,16 @@ else()
         DEPENDS ${copied_shaders}
     )
     
-    list(TRANSFORM vkloadtests_ktx2_image_sources REPLACE ^[a-zA-Z0-9:/<>].*/ktx2 ${BUILDTIME_RESOURCES_DIR}
-        OUTPUT_VARIABLE copied_vkloadtests_ktx2_images
-    )
-
-    add_custom_command(
-        OUTPUT ${copied_vkloadtests_ktx2_images}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILDTIME_RESOURCES_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${vkloadtests_ktx2_image_sources} ${BUILDTIME_RESOURCES_DIR}
-        COMMENT "Copy vkloadtests ktx2 images to build destination"
-        VERBATIM
-    )
-    add_custom_target(
-        copied_vkloadtests_ktx2_images
-        DEPENDS ${copied_vkloadtests_ktx2_images}
-    )
-    add_dependencies(
-        copied_vkloadtests_ktx2_images
-        copied_common_ktx_images
-    )
     add_dependencies(   
         vkloadtests
         copied_ktx_icons
         copied_models
         copied_shaders
-        copied_vkloadtests_ktx2_images
+        copied_ktx_files
     )
 
     unset( copied_shaders )
-    unset( copied_vkloadtests_ktx2_images )
-
+ 
     # To keep the resources (test images and models) close to the
     # executable and to be compliant with the Filesystem Hierarchy
     # Standard https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -123,9 +123,10 @@ list( TRANSFORM ktx1_file_sources
 )
 
 set( KTX_RESOURCES
-    ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
     ${ktx2_file_sources}
     ${ktx1_file_sources}
+    ${KTX_ICON_SOURCES}
+    ${LOAD_TEST_COMMON_MODEL_SOURCES} 
     ${SHADER_SPVS}
 )
 
@@ -179,11 +180,11 @@ add_executable( vkloadtests
     vkloadtests/VulkanLoadTestSample.cpp
     vkloadtests/VulkanLoadTestSample.h
     vkloadtests.cmake
-    ${LOAD_TEST_COMMON_RESOURCE_FILE_SOURCES}
-    ${LOAD_TEST_COMMON_MODEL_SOURCES}
-    ${SHADER_SOURCES}
     ${ktx2_file_sources}
     ${ktx1_file_sources}
+    ${KTX_ICON_SOURCES}
+    ${LOAD_TEST_COMMON_MODEL_SOURCES}
+    ${SHADER_SOURCES}
     ${Vulkan_SHARE_VULKAN}
 )
 


### PR DESCRIPTION
Reinstate previously disabled parallel builds.

The issue was use of custom commands (add_custom_command) to copy resource files to a directory near the just-built executable, which is done for ease of testing and debugging. These commands were used by both the vkloadtests and gl3loadtests targets which meant races were possible.

This changes the copying to be done via custom targets which have a defined ordering and will only be built once. These target invoke very similar custom commands to do the actual work.

Only Windows and Linux builds are affected. The resource copying is not needed on macOS because the apps are built as bundles including all the resource files.

Other included changes are:
- resources directory for Windows has been moved to a sibling of the directory containing the executable. This is the same as Linux;
- the hierarchy of the vkloadtests and {gl3,es1,es3} targets as presented in an IDE GUI has been reworked for simpler navigation, using CMake's source_group command;
- setting of link libraries for the load test apps has been simplified.

Fixes #1229.