### PR TITLE
fix: minor memory leak with invalid ktxTexture2CreateInfo dimensions

### DIFF
--- a/lib/src/texture.c
+++ b/lib/src/texture.c
@@ -178,10 +178,12 @@ ktxTexture_construct(ktxTexture* This,
 
 error_invalid_value:
     free(This->_protected);
+    This->_protected = NULL;
     return KTX_INVALID_VALUE;
 
 error_invalid_operation:
     free(This->_protected);
+    This->_protected = NULL;
     return KTX_INVALID_OPERATION;
 }
 
@@ -234,19 +236,22 @@ ktxTexture_constructFromStream(ktxTexture* This, ktxStream* pStream,
 void
 ktxTexture_destruct(ktxTexture* This)
 {
-    ktxStream stream = *(ktxTexture_getStream(This));
-
-    if (stream.data.file != NULL) {
-        stream.destruct(&stream);
-        stream.data.file = NULL;
+    if (This->_protected != NULL) {
+        ktxStream stream = *(ktxTexture_getStream(This));
+        if (stream.data.file != NULL) {
+            stream.destruct(&stream);
+            stream.data.file = NULL;
+        }
     }
+
     if (This->kvDataHead != NULL)
         ktxHashList_Destruct(&This->kvDataHead);
     if (This->kvData != NULL)
         free(This->kvData);
     if (This->pData != NULL)
         free(This->pData);
-    free(This->_protected);
+    if (This->_protected != NULL)
+        free(This->_protected);
 }
 
 

--- a/lib/src/texture.c
+++ b/lib/src/texture.c
@@ -16,6 +16,7 @@
  * @author Mark Callow, github.com/MarkCallow
  */
 
+#include <stdatomic.h>
 #if defined(_WIN32)
   #define _CRT_SECURE_NO_WARNINGS
   #ifndef __cplusplus
@@ -85,12 +86,15 @@ ktxTexture_construct(ktxTexture* This,
                      const ktxTextureCreateInfo* const createInfo,
                      ktxFormatSize* formatSize)
 {
+    KTX_error_code result;
     DECLARE_PROTECTED(ktxTexture);
 
     memset(This, 0, sizeof(*This));
     This->_protected = (struct ktxTexture_protected*)malloc(sizeof(*prtctd));
-    if (!This->_protected)
-        return KTX_OUT_OF_MEMORY;
+    if (!This->_protected) {
+        result = KTX_OUT_OF_MEMORY;
+        goto cleanup;
+    }
     prtctd = This->_protected;
     memset(prtctd, 0, sizeof(*prtctd));
     memcpy(&prtctd->_formatSize, formatSize, sizeof(prtctd->_formatSize));
@@ -104,22 +108,30 @@ ktxTexture_construct(ktxTexture* This,
     /* Check texture dimensions. KTX files can store 8 types of textures:
      * 1D, 2D, 3D, cube, and array variants of these.
      */
-    if (createInfo->numDimensions < 1 || createInfo->numDimensions > 3)
-        goto error_invalid_value;
+    if (createInfo->numDimensions < 1 || createInfo->numDimensions > 3) {
+        result = KTX_INVALID_VALUE;
+        goto cleanup;
+    }
 
     if (createInfo->baseWidth == 0 || createInfo->baseHeight == 0
-        || createInfo->baseDepth == 0)
-        goto error_invalid_value;
+        || createInfo->baseDepth == 0) {
+        result = KTX_INVALID_VALUE;
+        goto cleanup;
+    }
 
     switch (createInfo->numDimensions) {
       case 1:
-        if (createInfo->baseHeight > 1 || createInfo->baseDepth > 1)
-            goto error_invalid_operation;
+        if (createInfo->baseHeight > 1 || createInfo->baseDepth > 1) {
+            result = KTX_INVALID_OPERATION;
+            goto cleanup;
+        }
         break;
 
       case 2:
-        if (createInfo->baseDepth > 1)
-            goto error_invalid_operation;
+        if (createInfo->baseDepth > 1) {
+            result = KTX_INVALID_OPERATION;
+            goto cleanup;
+        }
         break;
 
       case 3:
@@ -127,8 +139,10 @@ ktxTexture_construct(ktxTexture* This,
          * OpenGL or Vulkan.
          */
         if (createInfo->isArray || createInfo->numFaces != 1
-            || createInfo->numLayers != 1)
-            goto error_invalid_operation;
+            || createInfo->numLayers != 1) {
+            result = KTX_INVALID_OPERATION;
+            goto cleanup;
+        }
         break;
     }
     This->numDimensions = createInfo->numDimensions;
@@ -136,30 +150,37 @@ ktxTexture_construct(ktxTexture* This,
     This->baseDepth = createInfo->baseDepth;
     This->baseHeight = createInfo->baseHeight;
 
-    if (createInfo->numLayers == 0)
-        goto error_invalid_value;
+    if (createInfo->numLayers == 0) {
+        result = KTX_INVALID_VALUE;
+        goto cleanup;
+    }
     This->numLayers = createInfo->numLayers;
     This->isArray = createInfo->isArray;
 
     if (createInfo->numFaces == 6) {
         if (This->numDimensions != 2) {
             /* cube map needs 2D faces */
-            goto error_invalid_operation;
+            result = KTX_INVALID_OPERATION;
+            goto cleanup;
         }
         if (createInfo->baseWidth != createInfo->baseHeight) {
             /* cube maps require square images */
-            goto error_invalid_operation;
+            result = KTX_INVALID_OPERATION;
+            goto cleanup;
         }
         This->isCubemap = KTX_TRUE;
     } else if (createInfo->numFaces != 1) {
         /* numFaces must be either 1 or 6 */
-        goto error_invalid_value;
+        result = KTX_INVALID_VALUE;
+        goto cleanup;
     }
     This->numFaces = createInfo->numFaces;
 
     /* Check number of mipmap levels */
-    if (createInfo->numLevels == 0)
-        goto error_invalid_value;
+    if (createInfo->numLevels == 0) {
+        result = KTX_INVALID_VALUE;
+        goto cleanup;
+    }
     This->numLevels = createInfo->numLevels;
     This->generateMipmaps = createInfo->generateMipmaps;
 
@@ -169,22 +190,17 @@ ktxTexture_construct(ktxTexture* This,
         if (max_dim < ((GLuint)1 << (This->numLevels - 1)))
         {
             /* Can't have more mip levels than 1 + log2(max(width, height, depth)) */
-            goto error_invalid_operation;
+            result = KTX_INVALID_OPERATION;
+            goto cleanup;
         }
     }
 
     ktxHashList_Construct(&This->kvDataHead);
     return KTX_SUCCESS;
 
-error_invalid_value:
-    free(This->_protected);
-    This->_protected = NULL;
-    return KTX_INVALID_VALUE;
-
-error_invalid_operation:
-    free(This->_protected);
-    This->_protected = NULL;
-    return KTX_INVALID_OPERATION;
+cleanup:
+    ktxTexture_destruct(This);
+    return result;
 }
 
 /**
@@ -230,8 +246,8 @@ ktxTexture_constructFromStream(ktxTexture* This, ktxStream* pStream,
  * @~English
  * @brief Free the memory associated with the texture contents
  *
- * @param[in] This pointer to the ktxTextureInt whose texture contents are
- *                 to be freed.
+ * @param[in] This pointer to the ktxTexture whose texture contents are to be
+ *                 freed.
  */
 void
 ktxTexture_destruct(ktxTexture* This)
@@ -242,16 +258,21 @@ ktxTexture_destruct(ktxTexture* This)
             stream.destruct(&stream);
             stream.data.file = NULL;
         }
-    }
-
-    if (This->kvDataHead != NULL)
-        ktxHashList_Destruct(&This->kvDataHead);
-    if (This->kvData != NULL)
-        free(This->kvData);
-    if (This->pData != NULL)
-        free(This->pData);
-    if (This->_protected != NULL)
         free(This->_protected);
+        This->_protected = NULL;
+    }
+    if (This->kvDataHead != NULL) {
+        ktxHashList_Destruct(&This->kvDataHead);
+        This->kvDataHead = NULL;
+    }
+    if (This->kvData != NULL) {
+        free(This->kvData);
+        This->kvData = NULL;
+    }
+    if (This->pData != NULL) {
+        free(This->pData);
+        This->pData = NULL;
+    }
 }
 
 

--- a/lib/src/texture.c
+++ b/lib/src/texture.c
@@ -16,7 +16,6 @@
  * @author Mark Callow, github.com/MarkCallow
  */
 
-#include <stdatomic.h>
 #if defined(_WIN32)
   #define _CRT_SECURE_NO_WARNINGS
   #ifndef __cplusplus

--- a/lib/src/texture2.c
+++ b/lib/src/texture2.c
@@ -1264,19 +1264,26 @@ ktxTexture2_constructFromMemory(ktxTexture2* This,
 /**
  * @memberof ktxTexture2 @private
  * @~English
- * @brief Destruct a ktxTexture2, freeing and internal memory.
+ * @brief Free the memory associated with the ktxTexture2 contents
  *
- * @param[in] This pointer to a ktxTexture2-sized block of memory to
- *                 initialize.
+ * @param[in] This pointer to the ktxTexture2 whose texture contents are to be
+ *                 freed.
  */
 void
 ktxTexture2_destruct(ktxTexture2* This)
 {
-    if (This->pDfd) free(This->pDfd);
+    if (This->pDfd) {
+      free(This->pDfd);
+      This->pDfd = NULL;
+    }
     if (This->_private) {
       ktx_uint8_t* sgd = This->_private->_supercompressionGlobalData;
-      if (sgd) free(sgd);
+      if (sgd) {
+        free(sgd);
+        This->_private->_supercompressionGlobalData = NULL;
+      }
       free(This->_private);
+      This->_private = NULL;
     }
     ktxTexture_destruct(ktxTexture(This));
 }

--- a/lib/src/texture2.c
+++ b/lib/src/texture2.c
@@ -492,12 +492,11 @@ ktxTexture2_construct(ktxTexture2* This,
     }
 
     result =  ktxTexture_construct(ktxTexture(This), createInfo, &formatSize);
-
     if (result != KTX_SUCCESS)
-        return result;
+        goto cleanup;
     result = ktxTexture2_constructCommon(This, createInfo->numLevels);
     if (result != KTX_SUCCESS)
-        goto cleanup;;
+        goto cleanup;
 
     This->vkFormat = createInfo->vkFormat;
 

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -1176,6 +1176,35 @@ TEST_F(ktxTexture2_LoadImageDataTest, LoadImageDataExternal) {
     }
 }
 
+/////////////////////////////////////////
+// ktxTexture2 invalid creation params tests.
+////////////////////////////////////////
+
+TEST(ktxTexture2_invalidCreateInfoParams, InvalidWidth) {
+    ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
+    ktxTexture2* texture;
+    KTX_error_code result;
+    ktxTextureCreateInfo createInfo;
+    createInfo.glInternalformat = 0;
+    createInfo.vkFormat = VK_FORMAT_R8G8B8A8_SRGB;
+    createInfo.pDfd = nullptr;
+    createInfo.baseWidth = 0;  //< Invalid width
+    createInfo.baseHeight = 1;
+    createInfo.baseDepth = 1;
+    createInfo.numDimensions = 2;
+    createInfo.numLevels = 1;
+    createInfo.numLayers = 1;
+    createInfo.numFaces = 1;
+    createInfo.isArray = KTX_FALSE;
+    createInfo.generateMipmaps = KTX_FALSE;
+    // This will fail but should never leak resources when failing because it
+    // will return a nullptr and is expected to cleanup its resources upon
+    // failure.
+    result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE, &texture);
+    texture_raii.reset(ktxTexture(texture));
+    EXPECT_EQ(result, KTX_INVALID_VALUE);
+}
+
 /////////////////////////////////////////////
 // ktxTexture2_CreateCopyTest
 ////////////////////////////////////////////

--- a/tests/texturetests/texturetests.cc
+++ b/tests/texturetests/texturetests.cc
@@ -475,7 +475,7 @@ class ktxTexture2_CreateTest : public ::testing::Test {
             createInfo.isArray = isArray;
             createInfo.generateMipmaps = generateMipmaps;
 
-        ktxTexture2* pTexture;
+        ktxTexture2* pTexture = nullptr;
         auto result = ktxTexture2_Create(&createInfo,
                                   KTX_TEXTURE_CREATE_ALLOC_STORAGE,
                                   &pTexture);
@@ -504,7 +504,7 @@ class ktxTexture1WriteTestBase : public ::testing::Test {
         ktx_size_t ktxMemFileLen;
         ktx_uint8_t* filePtr;
 
-        ktxTexture1* texture = 0;
+        ktxTexture1* texture = nullptr;
         result = ktxTexture1_Create(&helper.createInfo,
                                    KTX_TEXTURE_CREATE_ALLOC_STORAGE,
                                    &texture);
@@ -572,7 +572,7 @@ class ktxTexture2_CreateCopyTest: public ktxTexture2TestBase<GLubyte, 4, GL_RGBA
 ////////////////////////////////////////
 
 TEST_F(ktxTexture1_CreateTest, InvalidValueOnNullParams) {
-    ktxTexture* texture = 0;
+    ktxTexture* texture = nullptr;
 
     EXPECT_EQ(ktxTexture_CreateFromStdioStream(0, 0, &texture),
               KTX_INVALID_VALUE);
@@ -614,7 +614,7 @@ TEST_F(ktxTexture1_CreateTest, ConstructFromMemory) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
+    if (ktxMemFile != nullptr) {
         ktxTexture1* texture = nullptr;
         result = ktxTexture1_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0, &texture);
@@ -635,7 +635,7 @@ TEST_F(ktxTexture1_CreateTest, CreateEmpty) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    ktxTexture1* texture = 0;
+    ktxTexture1* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 &texture);
     texture_raii.reset((ktxTexture*)texture);
@@ -660,7 +660,7 @@ TEST_F(ktxTexture1_CreateTest, InvalidOpOnSetImagesNoStorage) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    ktxTexture1* texture = 0;
+    ktxTexture1* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                &texture);
     texture_raii.reset((ktxTexture*)texture);
@@ -683,7 +683,7 @@ TEST_F(ktxTexture1_CreateTest, CreateEmptyAndSetImages) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    ktxTexture1* texture = 0;
+    ktxTexture1* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_ALLOC_STORAGE,
                                 &texture);
     texture_raii.reset((ktxTexture*)texture);
@@ -705,7 +705,7 @@ TEST_F(ktxTexture1_CreateTest, CreateEmptySetImagesWriteToMemory) {
     ktx_size_t testMemFileLen;
     char orientation[10];
 
-    ktxTexture1* texture = 0;
+    ktxTexture1* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_ALLOC_STORAGE,
                                 &texture);
     texture_raii.reset((ktxTexture*)texture);
@@ -748,7 +748,7 @@ TEST_F(ktxTexture_KVDataTest, KVDataDeserialized) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0,
                                              &texture);
@@ -777,7 +777,7 @@ TEST_F(ktxTexture_KVDataTest, LoadRawKVData) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_RAW_KVDATA_BIT,
                                              &texture);
@@ -797,7 +797,7 @@ TEST_F(ktxTexture_KVDataTest, SkipKVData) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_SKIP_KVDATA_BIT,
                                              &texture);
@@ -820,7 +820,7 @@ TEST_F(ktxTexture1_IterateLoadLevelFacesTest, InvalidValueOnNullCallback) {
     ktxTexture1_IterateLoadLevelFacesTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0, &texture);
         texture_raii.reset(texture);
@@ -839,7 +839,7 @@ TEST_F(ktxTexture1_IterateLoadLevelFacesTest, InvalidOpWhenDataAlreadyLoaded) {
     ktxTexture1_IterateLoadLevelFacesTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -859,7 +859,7 @@ TEST_F(ktxTexture1_IterateLoadLevelFacesTest, IterateImages) {
     ktxTexture1_IterateLoadLevelFacesTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0, &texture);
         texture_raii.reset(texture);
@@ -884,7 +884,7 @@ TEST_F(ktxTexture1_IterateLevelFacesTest, InvalidValueOnNullCallback) {
     ktxTexture1_IterateLevelFacesTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -904,7 +904,7 @@ TEST_F(ktxTexture1_IterateLevelFacesTest, IterateImages) {
     ktxTexture1_IterateLevelFacesTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -926,7 +926,7 @@ TEST_F(ktxTexture2_IterateLevelFacesTest, InvalidValueOnNullCallback) {
     ktxTexture2_IterateLevelFacesTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -946,7 +946,7 @@ TEST_F(ktxTexture2_IterateLevelFacesTest, IterateImages) {
     ktxTexture2_IterateLevelFacesTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -972,7 +972,7 @@ TEST_F(ktxTexture2_IterateLevelsTest, InvalidValueOnNullCallback) {
     ktxTexture2_IterateLevelsTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -992,7 +992,7 @@ TEST_F(ktxTexture2_IterateLevelsTest, IterateLevels) {
     ktxTexture2_IterateLevelsTest* fixture = this;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -1017,7 +1017,7 @@ TEST_F(ktxTexture1_LoadImageDataTest, InvalidOpWhenDataAlreadyLoaded) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -1037,7 +1037,7 @@ TEST_F(ktxTexture1_LoadImageDataTest, InvalidOpWhenDataAlreadyLoadedToExternal) 
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0,
                                              &texture);
@@ -1059,7 +1059,7 @@ TEST_F(ktxTexture1_LoadImageDataTest, LoadImageDataInternal) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -1078,7 +1078,7 @@ TEST_F(ktxTexture1_LoadImageDataTest, LoadImageDataExternal) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0,
                                              &texture);
@@ -1099,7 +1099,7 @@ TEST_F(ktxTexture2_LoadImageDataTest, InvalidOpWhenDataAlreadyLoaded) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -1119,7 +1119,7 @@ TEST_F(ktxTexture2_LoadImageDataTest, InvalidOpWhenDataAlreadyLoadedToExternal) 
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0,
                                              &texture);
@@ -1141,7 +1141,7 @@ TEST_F(ktxTexture2_LoadImageDataTest, LoadImageDataInternal) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                              &texture);
@@ -1160,7 +1160,7 @@ TEST_F(ktxTexture2_LoadImageDataTest, LoadImageDataExternal) {
     KTX_error_code result;
 
     if (ktxMemFile != NULL) {
-        ktxTexture* texture = 0;
+        ktxTexture* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0,
                                              &texture);
@@ -1182,7 +1182,10 @@ TEST_F(ktxTexture2_LoadImageDataTest, LoadImageDataExternal) {
 
 TEST(ktxTexture2_invalidCreateInfoParams, InvalidWidth) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
-    ktxTexture2* texture;
+    // If you don't initialize this to nullptr/0/NULL, you will (probably) get
+    // segfault when you enable optimizations (i.e., Release build). For Debug
+    // builds, leaving this uninitialized doesn't seem to cause any issues.
+    ktxTexture2* texture = nullptr;
     KTX_error_code result;
     ktxTextureCreateInfo createInfo;
     createInfo.glInternalformat = 0;
@@ -1198,7 +1201,8 @@ TEST(ktxTexture2_invalidCreateInfoParams, InvalidWidth) {
     createInfo.isArray = KTX_FALSE;
     createInfo.generateMipmaps = KTX_FALSE;
     // This will fail but should never leak resources when failing because it
-    // will return a nullptr and is expected to cleanup its resources upon
+    // will NOT set the provided pointer to anything. All libktx functions that
+    // allocate resources on success are expected to cleanup said resources on
     // failure.
     result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE, &texture);
     texture_raii.reset(ktxTexture(texture));
@@ -1214,8 +1218,8 @@ TEST_F(ktxTexture2_CreateCopyTest, CreateCopy) {
     ktxTexture_unique_ptr copyTexture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture = 0;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                              0,
                                              (ktxTexture**)&texture);
@@ -1223,7 +1227,7 @@ TEST_F(ktxTexture2_CreateCopyTest, CreateCopy) {
         EXPECT_EQ(result, KTX_SUCCESS);
         ASSERT_TRUE(texture != NULL) << "ktxTexture_CreateFromMemory failed: "
                                      << ktxErrorString(result);
-        ktxTexture2* copyTexture = 0;
+        ktxTexture2* copyTexture = nullptr;
         result = ktxTexture2_CreateCopy(texture, &copyTexture);
         copyTexture_raii.reset((ktxTexture*)copyTexture);
         EXPECT_EQ(result, KTX_SUCCESS);
@@ -1298,7 +1302,7 @@ TEST(ktxTexture_calcImageSize, ImageSizeAtEachLevelRGBA2D) {
     ktx_uint32_t ktx2sizes[] = {1024, 256, 64, 16, 4};
 
 
-    ktxTexture* texture;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE, (ktxTexture1**)&texture);
     texture_raii.reset(texture);
     EXPECT_EQ(result, KTX_SUCCESS);
@@ -1325,7 +1329,7 @@ TEST(ktxTexture_calcImageSize, ImageSizeAtEachLevelRGB2D) {
     ktx_uint32_t ktx1sizes[] = {28*9, 12*4, 8*2, 4*1};
     ktx_uint32_t ktx2sizes[] = {27*9, 12*4, 6*2, 3*1};
 
-    ktxTexture* texture;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset(texture);
@@ -1356,7 +1360,7 @@ TEST(ktxTexture_calcLevelSize, SizeOfEachLevelRGBA2D) {
     ktx_uint32_t ktx1sizes[] = {1024, 256, 64, 16, 4};
     ktx_uint32_t ktx2sizes[] = {1024, 256, 64, 16, 4};
 
-    ktxTexture* texture;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset(texture);
@@ -1384,7 +1388,7 @@ TEST(ktxTexture_calcLevelSize, SizeOfEachLevelRGB2D) {
     ktx_uint32_t ktx1sizes[] = {28*9, 12*4, 8*2, 4*1};
     ktx_uint32_t ktx2sizes[] = {27*9, 12*4, 6*2, 3*1};
 
-    ktxTexture* texture;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset((ktxTexture*)texture);
@@ -1417,7 +1421,7 @@ TEST(ktxTexture_calcLevelOffset, OffsetOfEachLevelRGBA2D) {
     // KTX 2: level 0 ... level 4 with mip padding to a 4 byte alignment.
     ktx_uint32_t ktx2offsets[] = {4+16+64+256, 4+16+64, 4+16, 4, 0};
 
-    ktxTexture1* ktx1texture = 0;
+    ktxTexture1* ktx1texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 &ktx1texture);
     ktx1texture_raii.reset((ktxTexture*)ktx1texture);
@@ -1425,7 +1429,7 @@ TEST(ktxTexture_calcLevelOffset, OffsetOfEachLevelRGBA2D) {
     ASSERT_TRUE(ktx1texture != NULL) << "ktxTexture1_Create failed: "
                                  << ktxErrorString(result);
 
-    ktxTexture2* ktx2texture = 0;
+    ktxTexture2* ktx2texture = nullptr;
     result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 &ktx2texture);
     ktx2texture_raii.reset((ktxTexture*)ktx2texture);
@@ -1453,14 +1457,14 @@ TEST(ktxTexture_calcLevelOffset, OffsetOfEachLevelRGB2D) {
     // KTX 2: level 0 ... level 4 with mip padding to a 12 byte alignment.
     ktx_uint32_t ktx2offsets[] = {12*4+24, 6*2+12, 3*1+9, 0};
 
-    ktxTexture1* ktx1texture = 0;
+    ktxTexture1* ktx1texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 &ktx1texture);
     ktx1texture_raii.reset((ktxTexture*)ktx1texture);
     EXPECT_EQ(result, KTX_SUCCESS);
     ASSERT_TRUE(ktx1texture != NULL) << "ktxTexture1_Create failed: "
                                  << ktxErrorString(result);
-    ktxTexture2* ktx2texture = 0;
+    ktxTexture2* ktx2texture = nullptr;
     result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 &ktx2texture);
     ktx2texture_raii.reset((ktxTexture*)ktx2texture);
@@ -1486,7 +1490,7 @@ TEST(ktxTexture_calcLevelOffset, OffsetOfEachLevelD16_UNORM_S8_UINT) {
     // KTX 2: level 0 ... level 4 with mip padding to a 4 byte alignment.
     ktx_uint32_t ktx2offsets[] = {4+16+64, 4+16, 4, 0};
 
-    ktxTexture2* ktx2texture = 0;
+    ktxTexture2* ktx2texture = nullptr;
     result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 &ktx2texture);
     ktx2texture_raii.reset((ktxTexture*)ktx2texture);
@@ -1510,7 +1514,7 @@ TEST(ktxTexture_calcLevelOffset, OffsetOfEachLevelD32_SFLOAT_S8_UINT) {
     // KTX 2: level 0 ... level 4 with mip padding to an 8 byte alignment.
     ktx_uint32_t ktx2offsets[] = {8+32+128, 8+32, 8, 0};
 
-    ktxTexture2* ktx2texture = 0;
+    ktxTexture2* ktx2texture = nullptr;
     result = ktxTexture2_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 &ktx2texture);
     ktx2texture_raii.reset((ktxTexture*)ktx2texture);
@@ -1535,7 +1539,7 @@ TEST(ktxTexture_GetImageOffsetTest, InvalidOpOnLevelFaceLayerTooBig) {
     KTX_error_code result;
     ktx_size_t offset;
 
-    ktxTexture* texture = 0;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset(texture);
@@ -1559,7 +1563,7 @@ TEST(ktxTexture_GetImageOffsetTest, ImageOffsetLevel) {
     KTX_error_code result;
     ktx_size_t expectedOffset, imageSize, offset;
 
-    ktxTexture* texture = 0;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&helper.createInfo,
                                KTX_TEXTURE_CREATE_NO_STORAGE,
                                (ktxTexture1**)&texture);
@@ -1595,7 +1599,7 @@ TEST(ktxTexture_GetImageOffsetTest, ImageOffsetWithRowPadding) {
     // Pick type and size that requires row padding for KTX_GL_UNPACK_ALIGNMENT.
     createInfo.glInternalformat = GL_RGB8;
     createInfo.baseWidth = 9;
-    ktxTexture* texture = 0;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset(texture);
@@ -1637,7 +1641,7 @@ TEST(ktxTexture_GetImageOffsetTest, ImageOffsetArray) {
     createInfo.glInternalformat = GL_RGB8;
     createInfo.baseWidth = 9;
     createInfo.numLayers = 3;
-    ktxTexture* texture = 0;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset(texture);
@@ -1679,7 +1683,7 @@ TEST(ktxTexture_GetImageOffsetTest, ImageOffsetFace) {
     createInfo.numLayers = 1;
     createInfo.numFaces = 6;
 
-    ktxTexture* texture = 0;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset(texture);
@@ -1722,7 +1726,7 @@ TEST(ktxTexture_GetImageOffsetTest, ImageOffsetArrayFace) {
     createInfo.numLayers = 3;
     createInfo.numFaces = 6;
 
-    ktxTexture* texture = 0;
+    ktxTexture* texture = nullptr;
     result = ktxTexture1_Create(&createInfo, KTX_TEXTURE_CREATE_NO_STORAGE,
                                 (ktxTexture1**)&texture);
     texture_raii.reset(texture);
@@ -1871,7 +1875,7 @@ class ktxTexture1WriteKTX2TestBase
         std::unique_ptr<ktx_uint8_t, decltype(std::free)*> kvData{nullptr, std::free};
         ktx_uint32_t kvDataLen;
 
-        ktxTexture1* texture = 0;
+        ktxTexture1* texture = nullptr;
         result = ktxTexture1_Create(&helper.createInfo,
                                    KTX_TEXTURE_CREATE_ALLOC_STORAGE,
                                    &texture);
@@ -1992,7 +1996,7 @@ class ktxTexture1WriteKTX2TestBase
         ktx_uint8_t* filePtr;
         ktx_uint32_t kvDataLen;
 
-        ktxTexture1* texture = 0;
+        ktxTexture1* texture = nullptr;
         result = ktxTexture1_Create(&helper.createInfo,
                                    KTX_TEXTURE_CREATE_ALLOC_STORAGE,
                                    &texture);
@@ -2231,7 +2235,7 @@ class ktxTexture2ReadTestBase
         helper.resize(flags, numLayers, numFaces, numDimensions,
                       width, height, depth);
 
-        ktxTexture1* texture = 0;
+        ktxTexture1* texture = nullptr;
         result = ktxTexture1_Create(&helper.createInfo,
                                     KTX_TEXTURE_CREATE_ALLOC_STORAGE,
                                     &texture);
@@ -2270,7 +2274,7 @@ class ktxTexture2ReadTestBase
         ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
         KTX_error_code result;
 
-        ktxTexture2* texture2 = 0;
+        ktxTexture2* texture2 = nullptr;
         result = ktxTexture2_CreateFromMemory(ktx2MemFile.get(), ktx2MemFileLen,
                                         KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                         &texture2);
@@ -2350,8 +2354,8 @@ TEST_F(ktxTexture2_BasisCompressTest, Compress) {
     ktx_uint64_t dataSize;
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2390,8 +2394,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestR8, Uncompressed) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2411,8 +2415,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestR8, BasisLZ) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2435,8 +2439,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestR8, UASTC) {
     KTX_error_code result;
     ktxBasisParams cparams = { };
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2459,8 +2463,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRG8, Uncompressed) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2480,8 +2484,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRG8, BasisLZ) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile.get() != nullptr) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2504,8 +2508,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRG8, UASTC) {
     KTX_error_code result;
     ktxBasisParams cparams = { };
 
-    if (ktxMemFile.get() != nullptr) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2528,8 +2532,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGB8, Uncompressed) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2549,8 +2553,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGB8, BasisLZ) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2573,8 +2577,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGB8, UASTC) {
     KTX_error_code result;
     ktxBasisParams cparams = { };
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2597,8 +2601,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, Uncompressed) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2618,8 +2622,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, BasisLZ) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2642,8 +2646,8 @@ TEST_F(ktxTexture2_GetNumComponentsTestRGBA8, UASTC) {
     KTX_error_code result;
     ktxBasisParams cparams = { };
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2668,8 +2672,8 @@ TEST_F(ktxTexture2_MetadataTest, EmptyValue) {
 
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2719,8 +2723,8 @@ TEST_F(ktxTexture2_MetadataTest, NoMetadata) {
     std::unique_ptr<ktx_uint8_t, decltype(std::free)*> newMemFile_raii{nullptr, std::free};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2768,8 +2772,8 @@ TEST_F(ktxTexture2_MetadataTest, NoLibVersionDupOnMultipleWrites) {
     ktxTexture_unique_ptr texture_raii{nullptr, ktxTexture_Deleter};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -2836,8 +2840,8 @@ TEST_F(ktxTexture2_MetadataTest, LibVersionUpdatedCorrectly) {
     std::unique_ptr<ktx_uint8_t, decltype(std::free)*> newMemFile_raii{nullptr, std::free};
     KTX_error_code result;
 
-    if (ktxMemFile != NULL) {
-        ktxTexture2* texture;
+    if (ktxMemFile != nullptr) {
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                               KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                               &texture);
@@ -3012,8 +3016,8 @@ class ktxTexture2AstcLdrEncodeDecodeTestBase
         fs::path decoded = tmpDir / format("{}_decoded.ktx2", testname);
         fs::path ktxdiffOut = tmpDir / format("{}_ktxdiff.txt", testname);
 
-        if (ktxMemFile.get() != nullptr) {
-            ktxTexture2* texture;
+        if (ktxMemFile != nullptr) {
+            ktxTexture2* texture = nullptr;
             result = ktxTexture2_CreateFromMemory(ktxMemFile.get(), ktxMemFileLen,
                                                   KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,
                                                   &texture);
@@ -3252,7 +3256,7 @@ class ktxTexture2AstcDecodeTestBase : public ::testing::Test {
         fs::path astcPath = ktx2Path;
         astcPath.replace_filename(astcFileName);
 
-        ktxTexture2* texture;
+        ktxTexture2* texture = nullptr;
         result = ktxTexture2_CreateFromNamedFile(
             reinterpret_cast<const char*>(astcPath.u8string().c_str()),
             KTX_TEXTURE_CREATE_LOAD_IMAGE_DATA_BIT,


### PR DESCRIPTION
Fixes #1222.

The test I added fails, prior to this commit, when ran through ASan:

```
90/233 Testing: texturetest.ktxTexture2_invalidCreateInfoParams.InvalidWidth
90/233 Test: texturetest.ktxTexture2_invalidCreateInfoParams.InvalidWidth
Command: "/home/walcht/KTX-Software/build/Debug/texturetests" "--gtest_filter=ktxTexture2_invalidCreateInfoParams.InvalidWidth" "--gtest_also_run_disabled_tests" "/home/walcht/KTX-Software/tests/resources/" "/home/walcht/KTX-Software/build/Debug/ktxdiff"
Directory: /home/walcht/KTX-Software/build/tests
"texturetest.ktxTexture2_invalidCreateInfoParams.InvalidWidth" start time: Jul 26 08:24 CEST
Output:
----------------------------------------------------------
Note: Google Test filter = ktxTexture2_invalidCreateInfoParams.InvalidWidth
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ktxTexture2_invalidCreateInfoParams
[ RUN      ] ktxTexture2_invalidCreateInfoParams.InvalidWidth
[       OK ] ktxTexture2_invalidCreateInfoParams.InvalidWidth (0 ms)
[----------] 1 test from ktxTexture2_invalidCreateInfoParams (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

=================================================================
==51590==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 92 byte(s) in 1 object(s) allocated from:
    #0 0x70e5338fd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x70e532857a90 in writeHeader /home/walcht/KTX-Software/external/dfdutils/createdfd.c:30
    #2 0x70e532858498 in createDFDUnpacked /home/walcht/KTX-Software/external/dfdutils/createdfd.c:222
    #3 0x70e532863ecd in vk2dfd /home/walcht/KTX-Software/external/dfdutils/vk2dfd.inl:74
    #4 0x70e5327f8302 in ktxVk2dfd /home/walcht/KTX-Software/lib/src/texture2.c:393
    #5 0x70e5327f86aa in ktxTexture2_construct /home/walcht/KTX-Software/lib/src/texture2.c:465
    #6 0x70e5327fd38c in ktxTexture2_Create /home/walcht/KTX-Software/lib/src/texture2.c:1346
    #7 0x5e67f7524770 in TestBody /home/walcht/KTX-Software/tests/texturetests/texturetests.cc:1203
    #8 0x5e67f76daeb1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:2607
    #9 0x5e67f76c6c87 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:2643
    #10 0x5e67f765df13 in testing::Test::Run() /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:2682
    #11 0x5e67f765f547 in testing::TestInfo::Run() /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:2861
    #12 0x5e67f7660780 in testing::TestSuite::Run() /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:3015
    #13 0x5e67f7686ab0 in testing::internal::UnitTestImpl::RunAllTests() /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:5855
    #14 0x5e67f76de4f1 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:2607
    #15 0x5e67f76c9ef2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:2643
    #16 0x5e67f7683391 in testing::UnitTest::Run() /home/walcht/KTX-Software/tests/gtest/./src/gtest.cc:5438
    #17 0x5e67f75d7913 in RUN_ALL_TESTS() (/home/walcht/KTX-Software/build/Debug/texturetests+0x135913) (BuildId: 846250dfedc5954aa8d5f7a548abc8c1e7ab8e7f)
    #18 0x5e67f7564cff in main /home/walcht/KTX-Software/tests/texturetests/texturetests.cc:3383
    #19 0x70e531e2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #20 0x70e531e2a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #21 0x5e67f74fc774 in _start (/home/walcht/KTX-Software/build/Debug/texturetests+0x5a774) (BuildId: 846250dfedc5954aa8d5f7a548abc8c1e7ab8e7f)

SUMMARY: AddressSanitizer: 92 byte(s) leaked in 1 allocation(s).
<end of output>
Test time =   0.15 sec
----------------------------------------------------------
Test Failed.
"texturetest.ktxTexture2_invalidCreateInfoParams.InvalidWidth" end time: Jul 26 08:24 CEST
"texturetest.ktxTexture2_invalidCreateInfoParams.InvalidWidth" time elapsed: 00:00:00
----------------------------------------------------------
```

I have to figure out why CIs segfault...