### PR TITLE
git subrepo pull external/basis_universal for updated CMakeLists.txt

### DIFF
--- a/external/basis_universal/.gitrepo
+++ b/external/basis_universal/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/KhronosGroup/basis_universal.git
 	branch = fixes_for_ktx
-	commit = a660e7be16d667a2569890430e630ce66d31ac59
-	parent = b0e5077581382bd6e92c191a5082ce7822acb2f9
+	commit = 9bba38d6337096719895ff55d4534050e7a9f574
+	parent = 9c357f2a59362ec84942bb97a0bea7fc624712c3
 	method = merge
 	cmdver = 0.4.9

--- a/external/basis_universal/CMakeLists.txt
+++ b/external/basis_universal/CMakeLists.txt
@@ -25,6 +25,10 @@
 #     a link-time warning about setting of an rpath, something done when BASISU_STATIC is FALSE.
 #   - The libraries added when `BASISU_STATIC` is TRUE are only needed for MinGW and are now added
 #     only for MinGW.
+#   - Setting of soon to be removed policy CMP0148 to OLD has been removed and the way of
+#     finding python11 has been updated. N.B I do not understand the reason for separate
+#     if(BASISU_BUILD_PYTHON) and find_package() for the encoder and transcoder builds so
+#     I have left them as is.
 #
 # * Known Issues (also in upstream)
 #   - BASISU_SSE is set `if (MSVC)` so it is incorrectly set on Windows ARM and not set when
@@ -46,11 +50,6 @@ if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
 endif()
 
 project(basisu C CXX)
-
-# pybind11: allow old Python finder modules without complaining
-if (POLICY CMP0148)
-    cmake_policy(SET CMP0148 OLD)
-endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "WASI")
     set(BASISU_BUILD_WASM TRUE)
@@ -521,6 +520,7 @@ endif()
 # Optional: Build native Python modules (pybind11)
 # ------------------------------------------------------------
 if (BASISU_BUILD_PYTHON AND NOT BASISU_BUILD_WASM)
+    find_package(Python COMPONENTS Interpreter Development)
     find_package(pybind11 CONFIG REQUIRED)
 
     message(STATUS "Building pybind11 Python extension: basisu_python")
@@ -548,6 +548,7 @@ if (BASISU_BUILD_PYTHON AND NOT BASISU_BUILD_WASM)
 endif()
 
 if (BASISU_BUILD_PYTHON AND NOT BASISU_BUILD_WASM)
+    find_package(Python COMPONENTS Interpreter Development)
     find_package(pybind11 CONFIG REQUIRED)
 
     message(STATUS "Building pybind11 Python extension: basisu_transcoder_python")


### PR DESCRIPTION
This updates the way of finding the python11 package to remove the need for soon to be removed OLD CMP0148 policy, quieting warnings from CMake >= 4.1.0.

subrepo:
  subdir:   "external/basis_universal"
  merged:   "9bba38d63"
upstream:
  origin:   "https://github.com/KhronosGroup/basis_universal.git"
  branch:   "fixes_for_ktx"
  commit:   "9bba38d63"
git-subrepo:
  version:  "0.4.9"
  origin:   "https://github.com/MarkCallow/git-subrepo.git"
  commit:   "4f60dd7"