### PR TITLE
Expose more transcode formats and flags.

### DIFF
--- a/interface/java_binding/src/main/java/org/khronos/ktx/KtxTranscodeFlagBits.java
+++ b/interface/java_binding/src/main/java/org/khronos/ktx/KtxTranscodeFlagBits.java
@@ -14,8 +14,8 @@ public class KtxTranscodeFlagBits {
 
 	/**
 	 * PVRTC1: decode non-pow2 ETC1S texture level to the next larger
-	 * power of 2 (not implemented yet, but we're going to support it).
-	 * Ignored if the slice's dimensions are already a power of 2.
+	 * power of 2 (not implemented yet). Ignored if the slice's
+	 * dimensions are already a power of 2.
 	 */
 	public static final int PVRTC_DECODE_TO_NEXT_POW2 = 2;
 
@@ -25,6 +25,12 @@ public class KtxTranscodeFlagBits {
 	 * output texture format. Has no effect if there is no alpha data.
 	 */
 	public static final int TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS = 4;
+
+	/**
+	 * Disable ETC1S to BC7 adaptive chroma filtering, for much faster
+	 * transcoding to BC7. This flag is unused by other ETC1S transcoders.
+	 */
+    public static final int NO_ETC1S_CHROMA_FILTERING = 64;
 
 	/**
 	 * Request higher quality transcode of UASTC to BC1, BC3, ETC2_EAC_R11 and
@@ -55,6 +61,12 @@ public class KtxTranscodeFlagBits {
 				sb.append("|");
 			}
 			sb.append("TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS");
+		}
+		if ((n & NO_ETC1S_CHROMA_FILTERING) != 0) {
+			if (sb.length() != 0) {
+				sb.append("|");
+			}
+			sb.append("NO_ETC1S_CHROMA_FILTERING");
 		}
 		if ((n & HIGH_QUALITY) != 0) {
 			if (sb.length() != 0) {

--- a/interface/java_binding/src/main/java/org/khronos/ktx/KtxTranscodeFormat.java
+++ b/interface/java_binding/src/main/java/org/khronos/ktx/KtxTranscodeFormat.java
@@ -150,26 +150,44 @@ public class KtxTranscodeFormat {
 	/**
 	 * 48bpp RGB half (16-bits/component, 3 components) 
 	 */
-        public static final int RGBA_HALF = 25; 
+    public static final int RGB_HALF = 24;
 
 	/**
-	 * HDR, RGBA (currently UASTC HDR 4x4 encoders are only RGB), unsigned
+	 * 64bpp RGBA half (16-bits/component, 4 components).
+	 * A will always 1.0 as UASTC_HDR does not support alpha.
 	 */
-        public static final int ASTC_HDR_4x4_RGBA = 29;
-        
+    public static final int RGBA_HALF = 25;
+
 	/**
-	 * HDR, RGBA (currently UASTC HDR 4x4 encoders are only RGB), unsigned
+	 * 32bpp RGB9E5 (shared exponent, positive only).
 	 */
-        public static final int ASTC_HDR_6x6_RGBA = 30;
-        
+    public static final int RGB_9E5 = 26;
+
+	/**
+	 * HDR, RGBA (currently UASTC HDR 4x4 encoders are only RGB), unsigned.
+	 * A will always 1.0 as UASTC_HDR does not support alpha.
+	 */
+    public static final int ASTC_HDR_4x4_RGBA = 29;
+
+	/**
+	 * HDR, RGBA (currently UASTC HDR 4x4 encoders are only RGB), unsigned.
+	 * A will always 1.0 as UASTC_HDR does not support alpha.
+	 */
+    public static final int ASTC_HDR_6x6_RGBA = 30;
+
 	/**
 	 * HDR, RGB only, unsigned
 	 */
-        public static final int BC6HU = 31;
-	
-        /**
-         * No selection
-         */
+    public static final int BC6HU_RGB = 31;
+
+    /**
+     * @deprecated Use BC6HU_RGB
+     */
+    public static final int BC6HU = BC6HU_RGB;
+
+    /**
+     * No selection
+     */
 	public static final int NOSELECTION = 0x7fffffff;
 
 	/**
@@ -200,10 +218,12 @@ public class KtxTranscodeFormat {
 		case RGBA4444: return "RGBA4444";
 		case ETC: return "ETC";
 		case BC1_OR_3: return "BC1_OR_3";
+		case RGB_HALF: return "RGB_HALF"; 
 		case RGBA_HALF: return "RGBA_HALF"; 
+		case RGB_9E5: return "RGB_9E5"; 
 		case ASTC_HDR_4x4_RGBA: return "ASTC_HDR_4x4_RGBA";
 		case ASTC_HDR_6x6_RGBA: return "ASTC_HDR_6x6_RGBA";
-		case BC6HU: return "BC6HU";
+		case BC6HU_RGB: return "BC6HU_RGB";
 		case NOSELECTION: return "NOSELECTION";
 		}
 		return "[Unknown KtxTranscodeFormat]";

--- a/interface/js_binding/ktx_wrapper.cpp
+++ b/interface/js_binding/ktx_wrapper.cpp
@@ -748,16 +748,19 @@ enum transcode_fmt = {
     "BC1_OR_3",
     "PVRTC1_4_RGB",
     "PVRTC1_4_RGBA",
-    "BC6HU",
+    "BC6HU_RGB",
     "BC7_RGBA",
     "ETC2_RGBA",
     "ASTC_4x4_RGBA",
+    "ASTC_LDR_4x4_RGBA",
     "ASTC_HDR_4x4_RGBA",
     "ASTC_HDR_6x6_RGBA",
     "RGBA32",
     "RGB565",
     "BGR565",
     "RGBA4444",
+    "RGB16F",
+    "RGB9E5",
     "RGBA16F",
     "PVRTC2_4_RGB",
     "PVRTC2_4_RGBA",
@@ -1242,10 +1245,11 @@ EMSCRIPTEN_BINDINGS(ktx)
         .value("BC1_OR_3", KTX_TTF_BC1_OR_3)
         .value("PVRTC1_4_RGB", KTX_TTF_PVRTC1_4_RGB)
         .value("PVRTC1_4_RGBA", KTX_TTF_PVRTC1_4_RGBA)
-        .value("BC6HU", KTX_TTF_BC6HU)
+        .value("BC6HU_RGB", KTX_TTF_BC6HU_RGB)
         .value("BC7_RGBA", KTX_TTF_BC7_RGBA)
         .value("ETC2_RGBA", KTX_TTF_ETC2_RGBA)
-        .value("ASTC_4x4_RGBA", KTX_TTF_ASTC_4x4_RGBA)
+        .value("ASTC_4x4_RGBA", KTX_TTF_ASTC_LDR_4x4_RGBA)
+        .value("ASTC_LDR_4x4_RGBA", KTX_TTF_ASTC_LDR_4x4_RGBA)
         .value("ASTC_HDR_4x4_RGBA", KTX_TTF_ASTC_HDR_4x4_RGBA)
         .value("ASTC_HDR_6x6_RGBA", KTX_TTF_ASTC_HDR_6x6_RGBA)
         .value("RGBA32", KTX_TTF_RGBA32)
@@ -1253,6 +1257,8 @@ EMSCRIPTEN_BINDINGS(ktx)
         .value("BGR565", KTX_TTF_BGR565)
         .value("RGBA4444", KTX_TTF_RGBA4444)
         .value("RGBA8888", KTX_TTF_RGBA32)
+        .value("RGB16F", KTX_TTF_RGB_HALF)
+        .value("RGB9E5", KTX_TTF_RGB_9E5)
         .value("RGBA16F", KTX_TTF_RGBA_HALF)
         .value("PVRTC2_4_RGB", KTX_TTF_PVRTC2_4_RGB)
         .value("PVRTC2_4_RGBA", KTX_TTF_PVRTC2_4_RGBA)

--- a/interface/js_binding/transcoder_wrapper.cpp
+++ b/interface/js_binding/transcoder_wrapper.cpp
@@ -448,15 +448,22 @@ enum TranscodeTarget = {
     "BC3_RGBA",
     "PVRTC1_4_RGB",
     "PVRTC1_4_RGBA",
+    "BC6HU_RGB",
     "BC7_RGBA",
     "BC7_M6_RGB",   //Deprecated. Use BC7_RGBA.
     "BC7_M5_RGBA",  //Deprecated. Use BC7_RGBA.
     "ETC2_RGBA",
     "ASTC_4x4_RGBA",
+    "ASTC_LDR_4x4_RGBA",
+    "ASTC_HDR_4x4_RGBA",
+    "ASTC_HDR_6x6_RGBA",
     "RGBA32",
     "RGB565",
     "BGR565",
     "RGBA4444",
+    "RGB16F",
+    "RGBA16F",
+    "RGB9E5",
     "PVRTC2_4_RGB",
     "PVRTC2_4_RGBA",
     "EAC_R11",
@@ -727,17 +734,24 @@ EMSCRIPTEN_BINDINGS(ktx_wrappers)
         .value("BC3_RGBA", transcoder_texture_format::cTFBC3_RGBA)
         .value("PVRTC1_4_RGB", transcoder_texture_format::cTFPVRTC1_4_RGB)
         .value("PVRTC1_4_RGBA", transcoder_texture_format::cTFPVRTC1_4_RGBA)
+        .value("BC6HU_RGB", transcoder_texture_format::cTFBC6H)
         .value("BC7_RGBA", transcoder_texture_format::cTFBC7_RGBA)
         // Deprecated. Use BC7_RGBA.
         .value("BC7_M6_RGB", transcoder_texture_format::cTFBC7_M6_RGB)
         // Deprecated. Use BC7_RGBA.
         .value("BC7_M5_RGBA", transcoder_texture_format::cTFBC7_M5_RGBA)
         .value("ETC2_RGBA", transcoder_texture_format::cTFETC2_RGBA)
-        .value("ASTC_4x4_RGBA", transcoder_texture_format::cTFASTC_4x4_RGBA)
+        .value("ASTC_4x4_RGBA", transcoder_texture_format::cTFASTC_LDR_4x4_RGBA)
+        .value("ASTC_LDR_4x4_RGBA", transcoder_texture_format::cTFASTC_LDR_4x4_RGBA)
+        .value("ASTC_HDR_4x4_RGBA", transcoder_texture_format::cTFASTC_HDR_4x4_RGBA)
+        .value("ASTC_HDR_6x6_RGBA", transcoder_texture_format::cTFASTC_HDR_6x6_RGBA)
         .value("RGBA32", transcoder_texture_format::cTFRGBA32)
         .value("RGB565", transcoder_texture_format::cTFRGB565)
         .value("BGR565", transcoder_texture_format::cTFBGR565)
         .value("RGBA4444", transcoder_texture_format::cTFRGBA4444)
+        .value("RGB16F", transcoder_texture_format::cTFRGB_HALF)
+        .value("RGBA16F", transcoder_texture_format::cTFRGBA_HALF)
+        .value("RGB9E5", transcoder_texture_format::cTFRGB_9E5)
         .value("PVRTC2_4_RGB", transcoder_texture_format::cTFPVRTC2_4_RGB)
         .value("PVRTC2_4_RGBA", transcoder_texture_format::cTFPVRTC2_4_RGBA)
         .value("EAC_R11", transcoder_texture_format::cTFETC2_EAC_R11)

--- a/interface/python_binding/pyktx/ktx_transcode_flag_bits.py
+++ b/interface/python_binding/pyktx/ktx_transcode_flag_bits.py
@@ -21,6 +21,13 @@ class KtxTranscodeFlagBits(IntEnum):
     output texture format. Has no effect if there is no alpha data.
     """
 
+    NO_ETC1S_CHROMA_FILTERING = 64
+    """
+    Disable ETC1S to BC7 adaptive chroma filtering, for much faster
+    transcoding to BC7.  This flag is unused by other ETC1S
+    transcoders.
+    """
+
     HIGH_QUALITY = 32
     """
     Request higher quality transcode of UASTC to BC1, BC3, ETC2_EAC_R11 and

--- a/interface/python_binding/pyktx/ktx_transcode_fmt.py
+++ b/interface/python_binding/pyktx/ktx_transcode_fmt.py
@@ -16,7 +16,8 @@ class KtxTranscodeFmt(IntEnum):
     BC7_RGBA = 6
     PVRTC1_4_RGB = 8
     PVRTC1_4_RGBA = 9
-    ASTC_4x4_RGBA = 10
+    ASTC_LDR_4x4_RGBA = 10
+    ASTC_4x4_RGBA = ASTC_LDR_4x4_RGBA
     PVRTC2_4_RGB = 18
     PVRTC2_4_RGBA = 19
     ETC2_EAC_R11 = 20
@@ -27,4 +28,10 @@ class KtxTranscodeFmt(IntEnum):
     RGBA4444 = 16
     ETC = 22
     BC1_OR_3 = 23
+    RGB_HALF = 24
+    RGBA_HALF = 25
+    RGB_9E5 = 26
+    ASTC_HDR_4x4_RGBA = 29
+    ASTC_HDR_6x6_RGBA = 30
+    BC6HU_RGB = 31
     NO_SELECTION = 0x7fffffff

--- a/lib/include/ktx.h
+++ b/lib/include/ktx.h
@@ -1693,11 +1693,14 @@ typedef enum ktx_transcode_fmt_e {
                  texture format. */
 
         // ASTC (mobile, Intel devices, hopefully all desktop GPU's one day)
-        KTX_TTF_ASTC_4x4_RGBA = 10,
+        KTX_TTF_ASTC_LDR_4x4_RGBA = 10,
             /*!< Opaque+alpha, ASTC 4x4. The alpha channel will be opaque for
                  textures without an alpha channel.  The transcoder uses
                  RGB/RGBA/L/LA modes, void extent, and up to two ([0,47] and
                  [0,255]) endpoint precisions. */
+
+        KTX_TTF_ASTC_4x4_RGBA = KTX_TTF_ASTC_LDR_4x4_RGBA,
+            /*!< @deprecated Use #KTX_TTF_ASTC_LDR_4x4_RGBA. */
 
         // ATC and FXT1 formats are not supported by KTX2 as there
         // are no equivalent VkFormats.
@@ -1744,12 +1747,24 @@ typedef enum ktx_transcode_fmt_e {
             /*!< Automatically selects @c KTX_TTF_BC1_RGB or
                  @c KTX_TTF_BC3_RGBA according to presence of alpha. */
 
-        /* 48bpp RGB half (16-bits/component, 3 components) */
-        KTX_TTF_RGBA_HALF = 25, 
+        KTX_TTF_RGB_HALF = 24,
+            /*!< 48bpp RGB half (16-bits/component, 3 components) */
+        KTX_TTF_RGBA_HALF = 25,
+            /*!< 64bpp RGBA half (16-bits/component, 4 components). A will
+                always be  1.0 as UASTC_HDR does not support alpha. */
+        KTX_TTF_RGB_9E5 = 26,
+            /*!< 32bpp RGB 9E5 (shared exponent, positive only). */
 
-        KTX_TTF_ASTC_HDR_4x4_RGBA = 29,					// HDR, RGBA (currently UASTC HDR 4x4 encoders are only RGB), unsigned
-        KTX_TTF_ASTC_HDR_6x6_RGBA = 30,					// HDR, RGBA (currently UASTC HDR 4x4 encoders are only RGB), unsigned
-        KTX_TTF_BC6HU = 31,						// HDR, RGB only, unsigned
+        KTX_TTF_ASTC_HDR_4x4_RGBA = 29,
+            /*!< HDR, RGBA unsigned. A will always be 1.0 as UASTC_HDR does
+                 not support alpha. */
+        KTX_TTF_ASTC_HDR_6x6_RGBA = 30,
+            /*!< HDR, RGBA unsigned. A will always be 1.0 as UASTC_HDR does
+                 not support alpha. */
+        KTX_TTF_BC6HU_RGB = 31,
+            /*!< HDR, RGB only, unsigned. */
+        KTX_TTF_BC6HU = KTX_TTF_BC6HU_RGB,
+            /*!< @deprecated Use #KTX_TTF_BC6HU_RGB. */
 
         KTX_TTF_NOSELECTION = 0x7fffffff,
 
@@ -1784,17 +1799,23 @@ typedef enum ktx_transcode_fmt_e {
 typedef enum ktx_transcode_flag_bits_e {
     KTX_TF_PVRTC_DECODE_TO_NEXT_POW2 = 2U,
         /*!< PVRTC1: decode non-pow2 ETC1S texture level to the next larger
-             power of 2 (not implemented yet, but we're going to support it).
-             Ignored if the slice's dimensions are already a power of 2.
+             power of 2 (not implemented yet). Ignored if the slice's
+             dimensions are already a power of 2.
          */
     KTX_TF_TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS = 4U,
         /*!< When decoding to an opaque texture format, if the Basis data has
              alpha, decode the alpha slice instead of the color slice to the
              output texture format. Has no effect if there is no alpha data.
          */
+
+    KTX_TF_NO_ETC1S_CHROMA_FILTERING = 64U,
+        /*!< Disable ETC1S to BC7 adaptive chroma filtering, for much faster
+             transcoding to BC7.  This flag is unused by other ETC1S
+             transcoders. */
+
     KTX_TF_HIGH_QUALITY = 32U,
-        /*!< Request higher quality transcode of UASTC to BC1, BC3, ETC2_EAC_R11 and
-             ETC2_EAC_RG11. The flag is unused by other UASTC transcoders.
+        /*!< Request higher quality transcode of UASTC to BC1, BC3, ETC2\_EAC\_R11 or
+             ETC2\_EAC\_RG11. The flag is unused by other UASTC transcoders.
          */
 } ktx_transcode_flag_bits_e;
 typedef ktx_uint32_t ktx_transcode_flags;

--- a/lib/src/basis_transcode.cpp
+++ b/lib/src/basis_transcode.cpp
@@ -350,6 +350,7 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
         break;
       case KTX_TTF_RGB_9E5:
         vkFormat = VK_FORMAT_E5B9G9R9_UFLOAT_PACK32;
+        break;
       default:
         return KTX_INVALID_VALUE;
     }

--- a/lib/src/basis_transcode.cpp
+++ b/lib/src/basis_transcode.cpp
@@ -66,6 +66,18 @@ ktxTexture2_transcodeUastc(ktxTexture2* This,
                            ktx_transcode_fmt_e outputFormat,
                            ktx_transcode_flags transcodeFlags);
 
+/**
+ * @private
+ * @ingroup reader
+ * @~English
+ * @brief Map @c KTX_TTF* format to BasisU @c transcoder_texture_format.
+ *
+ * Needed because the values chosen long ago for the automatic selection
+ * formats have collided with the values Binomial chose for some HDR formats.
+ *
+ * @param(in)   ktx_fmt   the KTX_TTF format value to map.
+ * @return the equivalent @c transcoder_texture_format.
+ */
 static transcoder_texture_format
 ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
   switch (ktx_fmt) {
@@ -75,7 +87,7 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
   case KTX_TTF_ASTC_HDR_6x6_RGBA:
       return transcoder_texture_format::cTFASTC_HDR_6x6_RGBA;
       break;
-  case KTX_TTF_BC6HU:
+  case KTX_TTF_BC6HU_RGB:
       return transcoder_texture_format::cTFBC6H;
       break;
   default:
@@ -90,7 +102,7 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
  * @~English
  * @brief Transcode a KTX2 texture with BasisLZ/ETC1S or UASTC images.
  *
- * If the texture contains BasisLZ supercompressed images, Inflates them from
+ * If the texture contains BasisLZ supercompressed images, Inflates them
  * back to ETC1S then transcodes them to the specified block-compressed
  * format. If the texture contains UASTC images, inflates them, if they have been
  * supercompressed with zstd, then transcodes then to the specified format, The
@@ -98,17 +110,18 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
  * the DFD are modified to reflect the new format.
  *
  * These types of textures must be transcoded to a desired target
- * block-compressed format before they can be uploaded to a GPU via a
+ * GPU-compatible format before they can be uploaded to a GPU via a
  * graphics API.
  *
  * The following block compressed transcode targets are available: @c KTX_TTF_ETC1_RGB,
  * @c KTX_TTF_ETC2_RGBA, @c KTX_TTF_BC1_RGB, @c KTX_TTF_BC3_RGBA,
- * @c KTX_TTF_BC4_R, @c KTX_TTF_BC5_RG, @c KTX_TTF_BC7_RGBA,
- * @c @c KTX_TTF_PVRTC1_4_RGB, @c KTX_TTF_PVRTC1_4_RGBA,
- * @c KTX_TTF_PVRTC2_4_RGB, @c KTX_TTF_PVRTC2_4_RGBA, @c KTX_TTF_ASTC_4x4_RGBA,
- * @c KTX_TTF_ASTC_HDR_4x4_RGBA, KTX_TTF_ASTC_HDR_6x6_RGBA
+ * @c KTX_TTF_BC4_R, @c KTX_TTF_BC5_RG, @c KTX_TTF_BC6HU, @c KTX_TTF_BC7_RGBA,
+ * @c KTX_TTF_PVRTC1_4_RGB, @c KTX_TTF_PVRTC1_4_RGBA, @c KTX_TTF_PVRTC2_4_RGB,
+ * @c KTX_TTF_PVRTC2_4_RGBA, @c KTX_TTF_ASTC_4x4_RGBA,
+ * @c KTX_TTF_ASTC_HDR_4x4_RGBA, @c KTX_TTF_ASTC_HDR_6x6_RGBA
  * @c KTX_TTF_ETC2_EAC_R11, @c KTX_TTF_ETC2_EAC_RG11, @c KTX_TTF_ETC and
- * @c KTX_TTF_BC1_OR_3.
+ * @c KTX_TTF_BC1_OR_3. Only UASTC HDR formats can be transcoded to the
+ * ASTC HDR and BC6HU formats and only UASTC LDR 4x4 can be transcoded to the others.
  *
  * @c KTX_TTF_ETC automatically selects between @c KTX_TTF_ETC1_RGB and
  * @c KTX_TTF_ETC2_RGBA according to whether an alpha channel is available. @c KTX_TTF_BC1_OR_3
@@ -120,17 +133,25 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
  * are no equivalent Vulkan formats.
  *
  * The following uncompressed transcode targets are also available: @c KTX_TTF_RGBA32,
- * @c KTX_TTF_RGBA_HALF, @c KTX_TTF_RGB565, KTX_TTF_BGR565 and KTX_TTF_RGBA4444.
+ * @c KTX_TTF_RGB565, @c KTX_TTF_BGR565, @c KTX_TTF_RGBA4444,
+ * @c KTX_TTF_RGB_HALF,   @c KTX_TTF_RGB_9E5 and @c KTX_TTF_RGBA_HALF.
+ * Only UASTC HDR formats can be transcoded to the last three and only
+ * UASTC LDR 4x4 can be transcoded to the others.
  *
- * The following @p transcodeFlags are available.
+ * The following @p transcodeFlags are available:
+ * @c KTX_TF_PVRTC_DECODE_TO_NEXT_POW2,
+ * @c KTX_TF_TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS,
+ * @c KTX_TF_NO_ETC1S_CHROMA_FILTERING and @c KTX_TF_HIGH_QUALITY.
+ * The last only applies when transcoding from UASTC to BC1, BC3,
+ * ETC2\_EAC\_R11 or ETC2\_EAC\_RG11.
  *
- * @sa ktxtexture2_CompressBasis().
+ * @sa ktxTexture2_CompressBasis().
  *
  * @param[in]   This         pointer to the ktxTexture2 object of interest.
  * @param[in]   outputFormat a value from the ktx_texture_transcode_fmt_e enum
- *                                             specifying the target format.
+ *                           specifying the target format.
  * @param[in]   transcodeFlags  bitfield of flags modifying the transcode
- *                                                operation. @sa ktx_texture_decode_flags_e.
+ *                              operation. @sa ktx_texture_transcode_flags_e.
  *
  * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
  *
@@ -305,7 +326,7 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
       case KTX_TTF_ASTC_HDR_6x6_RGBA:
         vkFormat = VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK;
         break;
-      case KTX_TTF_BC6HU:
+      case KTX_TTF_BC6HU_RGB:
         vkFormat = VK_FORMAT_BC6H_UFLOAT_BLOCK;
         break;
       case KTX_TTF_RGB565:
@@ -321,9 +342,14 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
         vkFormat = srgb ? VK_FORMAT_R8G8B8A8_SRGB
                         : VK_FORMAT_R8G8B8A8_UNORM;
         break;
+      case KTX_TTF_RGB_HALF:
+        vkFormat = VK_FORMAT_R16G16B16_SFLOAT;
+        break;
       case KTX_TTF_RGBA_HALF:
         vkFormat = VK_FORMAT_R16G16B16A16_SFLOAT;
         break;
+      case KTX_TTF_RGB_9E5:
+        vkFormat = VK_FORMAT_E5B9G9R9_UFLOAT_PACK32;
       default:
         return KTX_INVALID_VALUE;
     }
@@ -334,10 +360,9 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
     else if (colorModel == KHR_DF_MODEL_UASTC_HDR_4x4)
         textureFormat = basis_tex_format::cUASTC_HDR_4x4;        
     else if (colorModel == KHR_DF_MODEL_UASTC_HDR_6x6)
-      textureFormat = basis_tex_format::cUASTC_HDR_6x6_INTERMEDIATE;    
+        textureFormat = basis_tex_format::cUASTC_HDR_6x6_INTERMEDIATE;
     else
         textureFormat = basis_tex_format::cETC1S;
-
     
     if (!basis_is_format_supported(ktx2transcoderFormat(outputFormat),
                                    textureFormat)) {
@@ -451,7 +476,8 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
  }
 
 /**
- * @memberof ktxTexture2 @private
+ * @memberof ktxTexture2
+ * @private
  * @ingroup reader
  * @~English
  * @brief Transcode a KTX2 texture with BasisLZ supercompressed ETC1S images.
@@ -462,13 +488,13 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
  * including the DFD are modified to reflect the new format.
  *
  * BasisLZ supercompressed textures must be transcoded to a desired target
- * block-compressed format before they can be uploaded to a GPU via a graphics
+ * GPU-compatible format before they can be uploaded to a GPU via a graphics
  * API.
  *
  * The following block compressed transcode targets are available: @c KTX_TTF_ETC1_RGB,
  * @c KTX_TTF_ETC2_RGBA, @c KTX_TTF_BC1_RGB, @c KTX_TTF_BC3_RGBA,
  * @c KTX_TTF_BC4_R, @c KTX_TTF_BC5_RG, @c KTX_TTF_BC7_RGBA,
- * @c @c KTX_TTF_PVRTC1_4_RGB, @c KTX_TTF_PVRTC1_4_RGBA,
+ * @c KTX_TTF_PVRTC1_4_RGB, @c KTX_TTF_PVRTC1_4_RGBA,
  * @c KTX_TTF_PVRTC2_4_RGB, @c KTX_TTF_PVRTC2_4_RGBA, @c KTX_TTF_ASTC_4x4_RGBA,
  * @c KTX_TTF_ETC2_EAC_R11, @c KTX_TTF_ETC2_EAC_RG11, @c KTX_TTF_ETC and
  * @c KTX_TTF_BC1_OR_3.
@@ -482,42 +508,34 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
  * ATC & FXT1 formats are not supported by KTX2 & libktx as there are no equivalent Vulkan formats.
  *
  * The following uncompressed transcode targets are also available: @c KTX_TTF_RGBA32,
- * @c KTX_TTF_RGB565, KTX_TTF_BGR565 and KTX_TTF_RGBA4444.
+ * @c KTX_TTF_RGB565, @c KTX_TTF_BGR565 and @c KTX_TTF_RGBA4444.
  *
- * The following @p transcodeFlags are available.
+ * The following @p transcodeFlags are available:
+ * @c KTX_TF_PVRTC_DECODE_TO_NEXT_POW2,
+ * @c KTX_TF_TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS and
+ * @c KTX_TF_NO_ETC1S_CHROMA_FILTERING.
  *
- * @sa ktxtexture2_CompressBasis().
+ * @sa ktxTexture2_TranscodeBasis().
+ * @sa ktxTexture2_CompressBasis().
  *
- * @param[in]   This         pointer to the ktxTexture2 object of interest.
+ * @param[in]   This            pointer to the ktxTexture2 object of interest.
+ * @param[in]   alphaContent @c alpha_content_e enum describing the alpha
+ *                           content of the texture.
+ * @param[in]   prototype  pointer to an empty ktxTexture2 object initialized
+ *                         with the target VkFormat. Used to construct the
+ *                         replacement transcoded texture.
  * @param[in]   outputFormat a value from the ktx_texture_transcode_fmt_e enum
  *                           specifying the target format.
  * @param[in]   transcodeFlags  bitfield of flags modifying the transcode
- *                           operation. @sa ktx_texture_decode_flags_e.
+ *                              operation. @sa ktx_texture_transcode_flags_e.
  *
  * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
  *
  * @exception KTX_FILE_DATA_ERROR
  *                              Supercompression global data is corrupted.
- * @exception KTX_INVALID_OPERATION
- *                              The texture's format is not transcodable (not
- *                              ETC1S/BasisLZ or UASTC).
- * @exception KTX_INVALID_OPERATION
- *                              Supercompression global data is missing, i.e.,
- *                              the texture object is invalid.
- * @exception KTX_INVALID_OPERATION
- *                              Image data is missing, i.e., the texture object
- *                              is invalid.
- * @exception KTX_INVALID_OPERATION
- *                              @p outputFormat is PVRTC1 but the texture does
- *                              does not have power-of-two dimensions.
- * @exception KTX_INVALID_VALUE @p outputFormat is invalid.
  * @exception KTX_TRANSCODE_FAILED
  *                              Something went wrong during transcoding. The
  *                              texture object will be corrupted.
- * @exception KTX_UNSUPPORTED_FEATURE
- *                              KTX_TF_PVRTC_DECODE_TO_NEXT_POW2 was requested
- *                              or the specified transcode target has not been
- *                              included in the library being used.
  * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out transcoding.
  */
 KTX_error_code
@@ -563,7 +581,7 @@ ktxTexture2_transcodeLzEtc1s(ktxTexture2* This,
     if (BGD_TABLES_ADDR(0, bgdh, imageCount) + bgdh.tablesByteLength > priv._sgdByteLength) {
         // Compiler will not allow `goto cleanup;` because "jump bypasses variable initialization."
         // The static initializations below this and before the loop are presumably the issue
-        // as the compiler is,presumably, inserting code to destruct those at the end of the
+        // as the compiler is, presumably, inserting code to destruct those at the end of the
         // function.
         delete[] firstImages;
         return KTX_FILE_DATA_ERROR;
@@ -935,14 +953,15 @@ transcodeUastcHDR6x6_intermediate(ktxTexture2* This, alpha_content_e alphaConten
 
         // Sanity check the level data length (transcode_image() wants uint32_t).
         if (levelDataLength > UINT32_MAX) {
-            // Either we've got a bug or the KTX2 file is too small/invalid. Either way we can't
-            // continue.
+            // Either we've got a bug or the KTX2 file's level data is too
+            // large for transcoding. Either way we can't continue.
             return KTX_FILE_DATA_ERROR;
         }
 
         // Ensure the mipmap level's data is fully contained within the KTX2 file's data.
         if ((levelDataOffset + levelDataLength) > This->dataSize) {
-            // Either we've got a bug or the KTX2 file is too small/invalid. Either way we can't safely continue.
+            // Either we've got a bug or the KTX2 file is too small/invalid.
+            // Either way we can't safely continue.
             return KTX_FILE_DATA_ERROR;
         }
 
@@ -1001,6 +1020,79 @@ transcodeUastcHDR6x6_intermediate(ktxTexture2* This, alpha_content_e alphaConten
     return KTX_SUCCESS;
 }
 
+/**
+ * @memberof ktxTexture2
+ * @private
+ * @ingroup reader
+ * @~English
+ * @brief Transcode a KTX2 texture with UASTC LDR or HDR images.
+ *
+ * If the texture contains UASTC images, inflates them, if they have been
+ * supercompressed with zlib or zstd, then transcodes then to the specified
+ * format, The transcoded images replace the original images and the texture's
+ * fields including the DFD are modified to reflect the new format.
+ *
+ * These types of textures must be transcoded to a desired target
+ * GPU-compatible format before they can be uploaded to a GPU via a
+ * graphics API.
+ *
+ * The following block compressed transcode targets are available: @c KTX_TTF_ETC1_RGB,
+ * @c KTX_TTF_ETC2_RGBA, @c KTX_TTF_BC1_RGB, @c KTX_TTF_BC3_RGBA,
+ * @c KTX_TTF_BC4_R, @c KTX_TTF_BC5_RG, @c KTX_TTF_BC6HU, @c KTX_TTF_BC7_RGBA,
+ * @c KTX_TTF_PVRTC1_4_RGB, @c KTX_TTF_PVRTC1_4_RGBA, @c KTX_TTF_PVRTC2_4_RGB,
+ * @c KTX_TTF_PVRTC2_4_RGBA, @c KTX_TTF_ASTC_4x4_RGBA,
+ * @c KTX_TTF_ASTC_HDR_4x4_RGBA, @c KTX_TTF_ASTC_HDR_6x6_RGBA
+ * @c KTX_TTF_ETC2_EAC_R11, @c KTX_TTF_ETC2_EAC_RG11, @c KTX_TTF_ETC and
+ * @c KTX_TTF_BC1_OR_3. Only UASTC HDR formats can be transcoded to the
+ * ASTC HDR and BC6HU formats and only UASTC LDR 4x4 can be transcoded to the others.
+ *
+ * @c KTX_TTF_BC1_OR_3 automatically selects between @c KTX_TTF_BC1_RGB and
+ * @c KTX_TTF_BC3_RGBA according to whether an alpha channel is available. Note that if
+ * @c KTX_TTF_PVRTC1_4_RGBA or @c KTX_TTF_PVRTC2_4_RGBA is specified and there is no alpha
+ * channel @c KTX_TTF_PVRTC1_4_RGB or @c KTX_TTF_PVRTC2_4_RGB respectively will be selected.
+ *
+ * Transcoding to ATC & FXT1 formats is not supported by libktx as there
+ * are no equivalent Vulkan formats.
+ *
+ * The following uncompressed transcode targets are also available: @c KTX_TTF_RGBA32,
+ * @c KTX_TTF_RGB565, @c KTX_TTF_BGR565, @c KTX_TTF_RGBA4444,
+ * @c KTX_TTF_RGB_HALF,  @c KTX_TTF_RGB_9E5 and @c KTX_TTF_RGBA_HALF.
+ * Only UASTC HDR formats can be transcoded to the last three and only
+ * UASTC LDR 4x4 can be transcoded to the others.
+ *
+ * The following @p transcodeFlags are available:
+ * @c KTX_TF_PVRTC_DECODE_TO_NEXT_POW2,
+ * @c KTX_TF_TRANSCODE_ALPHA_DATA_TO_OPAQUE_FORMATS and
+ * @c KTX_TF_HIGH_QUALITY.
+ * The last only applies when transcoding to BC1, BC3, ETC2\_EAC\_R11
+ * or ETC2\_EAC\_RG11.
+ *
+ * @sa ktxTexture2_TranscodeBasis().
+ * @sa ktxTexture2_CompressBasis().
+ *
+ * @param[in]   This            pointer to the ktxTexture2 object of interest.
+ * @param[in]   alphaContent @c alpha_content_e enum describing the alpha
+ *                           content of the texture.
+ * @param[in]   prototype  pointer to an empty ktxTexture2 object initialized
+ *                         with the target VkFormat. Used to construct the
+ *                         replacement transcoded texture.
+ * @param[in]   outputFormat a value from the ktx_texture_transcode_fmt_e enum
+ *                           specifying the target format.
+ * @param[in]   transcodeFlags  bitfield of flags modifying the transcode
+ *                              operation. @sa ktx_texture_transcode_flags_e.
+ *
+ * @return      KTX_SUCCESS on success, other KTX_* enum values on error.
+ *
+ * @exception KTX_FILE_DATA_ERROR
+ *                              Either the length of a level exceeds UINT32_MAX
+ *                              or the file does not have enough data.
+ * @exception KTX_TRANSCODE_FAILED
+ *                              Something went wrong during transcoding.
+ * @exception KTX_UNSUPPORTED_FEATURE
+ *                              The file has an unsupported Basis colorModel.
+ * @exception KTX_OUT_OF_MEMORY Not enough memory to carry out transcoding.
+ */
+
 KTX_error_code
 ktxTexture2_transcodeUastc(ktxTexture2* This,
                            alpha_content_e alphaContent,
@@ -1022,6 +1114,7 @@ ktxTexture2_transcodeUastc(ktxTexture2* This,
     } else if (colorModel == KHR_DF_MODEL_UASTC_HDR_6x6) {
         return transcodeUastcHDR6x6_intermediate(This, alphaContent, prototype, outputFormat, transcodeFlags);
     } else {
+        // Maybe an XUASTC file.
         debug_printf(
             "ktxTexture2_transcodeUastc: colorModel currently unsupported\n");
         return KTX_UNSUPPORTED_FEATURE;

--- a/tests/loadtests/glloadtests/utils/GLTextureTranscoder.hpp
+++ b/tests/loadtests/glloadtests/utils/GLTextureTranscoder.hpp
@@ -45,7 +45,7 @@ class TextureTranscoder {
         if (deviceFeatures.astc_hdr)
             defaultHDRTf = KTX_TTF_ASTC_HDR_4x4_RGBA;
         else if (deviceFeatures.bc6h)
-            defaultHDRTf = KTX_TTF_BC6HU;
+            defaultHDRTf = KTX_TTF_BC6HU_RGB;
         else
             defaultHDRTf = KTX_TTF_NOSELECTION;
     }

--- a/tests/loadtests/vkloadtests/utils/VulkanTextureTranscoder.hpp
+++ b/tests/loadtests/vkloadtests/utils/VulkanTextureTranscoder.hpp
@@ -33,7 +33,7 @@ class TextureTranscoder {
         if (vkctx.gpuFeatureAstcHdr)
             defaultHDRTf = KTX_TTF_ASTC_HDR_4x4_RGBA;
         else if (vkctx.gpuFeatures.textureCompressionBC)
-            defaultHDRTf = KTX_TTF_BC6HU;
+            defaultHDRTf = KTX_TTF_BC6HU_RGB;
     }
 
     void transcode(ktxTexture2* kTexture,

--- a/tools/ktx/command_transcode.cpp
+++ b/tools/ktx/command_transcode.cpp
@@ -42,8 +42,8 @@ Transcode a KTX2 file.
     optionally supercompress the result, and save it as the @e output-file.
     If the @e input-file is '-' the file will be read from the stdin.
     If the @e output-path is '-' the output file will be written to the stdout.
-    The input file must be transcodable (it must be either BasisLZ supercompressed or has UASTC
-    color model in the DFD).
+    The input file must be transcodable (it must be either BasisLZ supercompressed or has one of
+    the UASTC color models in the DFD).
     If the input file is invalid the first encountered validation error is displayed
     to the stderr and the command exits with the relevant non-zero status code.
 
@@ -53,11 +53,12 @@ Transcode a KTX2 file.
         <dt>\--target &lt;target&gt;</dt>
         <dd>Target transcode format.
             If the target option is not set the r8, rg8, rgb8 or rgba8 target will be
-            selected based on the number of channels in the input texture.
-            Block compressed transcode targets can only be saved in raw format.
-            Case-insensitive. Possible options are:
-            etc-rgb | etc-rgba | eac-r11 | eac-rg11 | bc1 | bc3 | bc4 | bc5 | bc6hu | bc7 | astc | astc-hdr-4x4 | astc-hdr-6x6 |
-            r8 | rg8 | rgb8 | rgba8 | rgba16f.
+            selected for LDR payloads based on the number of channels in the input texture.
+            rgba16f will be selected for HDR payloads. Case-insensitive. Possible options are:
+            etc-rgb | etc-rgba | eac-r11 | eac-rg11 | bc1 | bc3 | bc4 | bc5 | bc6hu | bc7 | astc |
+            astc-hdr-4x4 | astc-hdr-6x6 | r8 | rg8 | rgb8 | rgba8 | rgb16f | rgba16f | rgb9e5.
+            KTX files with UASTC HDR payloads can only be transcoded to HDR formats: astc-hdr-\*,
+            rgb16f, rgba16f or rgb9e5. LDR payloads can only be transcoded to LDR formats.
             etc-rgb is ETC1; etc-rgba, eac-r11 and eac-rg11 are ETC2.
         </dd>
     </dl>
@@ -119,12 +120,18 @@ int CommandTranscode::main(int argc, char* argv[]) {
 void CommandTranscode::OptionsTranscode::init(cxxopts::Options& opts) {
     opts.add_options()
         ("target", "Target transcode format."
-                   " Block compressed transcode targets can only be saved in raw format."
+                   " If the target option is not set the r8, rg8, rgb8 or rgba8 target will be"
+                   " selected for LDR payloads based on the number of channels in the input"
+                   " texture. rgba16f will be selected for HDR payloads."
                    " Case-insensitive."
                    "\nPossible options are:"
-                   " etc-rgb | etc-rgba | eac-r11 | eac-rg11 | bc1 | bc3 | bc4 | bc5 | bc6hu | bc7 |"
-                   " astc | astc-hdr-4x4 | astc-hdr-6x6 | r8 | rg8 | rgb8 | rgba8 | rgba16f."
-                   "\netc-rgb is ETC1; etc-rgba, eac-r11 and eac-rg11 are ETC2.",
+                   " etc-rgb | etc-rgba | eac-r11 | eac-rg11 | bc1 | bc3 | bc4 | bc5 | bc6hu |"
+                   " bc7 | astc | astc-hdr-4x4 | astc-hdr-6x6 | r8 | rg8 | rgb8 | rgba8 | rgb16f |"
+                   " rgba16f | rgb9e5."
+                   "\nKTX files with UASTC HDR payloads can only be transcoded to HDR"
+                   " formats: astc-hdr-*, rgb16f, rgba16f or rgb9e5. LDR payloads can only"
+                   " be transcoded to LDR formats. etc-rgb is ETC1; etc-rgba, eac-r11 and"
+                   " eac-rg11 are ETC2.",
                    cxxopts::value<std::string>(), "<target>");
 }
 

--- a/tools/ktx/transcode_utils.h
+++ b/tools/ktx/transcode_utils.h
@@ -42,7 +42,7 @@ struct OptionsTranscodeTarget {
         // "extract" command - optional "transcode" argument
         const auto argName = TRANSCODE_CMD ? "target" : "transcode";
 
-        static const std::unordered_map<std::string, std::pair<ktx_transcode_fmt_e, uint32_t>> targets{
+        static const std::unordered_map<std::string, std::pair<ktx_transcode_fmt_e, uint32_t>> targets {
             {"etc-rgb", {KTX_TTF_ETC1_RGB, 0}},
             {"etc-rgba", {KTX_TTF_ETC2_RGBA, 0}},
             {"eac-r11", {KTX_TTF_ETC2_EAC_R11, 0}},
@@ -57,10 +57,12 @@ struct OptionsTranscodeTarget {
             {"rg8", {KTX_TTF_RGBA32, 2}},
             {"rgb8", {KTX_TTF_RGBA32, 3}},
             {"rgba8", {KTX_TTF_RGBA32, 4}},
-            {"rgba16f", {KTX_TTF_RGBA_HALF, 4}},
+            {"rgb16f", {KTX_TTF_RGB_HALF, 0}},
+            {"rgba16f", {KTX_TTF_RGBA_HALF, 0}},
+            {"rgb9e5", {KTX_TTF_RGB_9E5, 0}},
             {"astc-hdr-4x4", {KTX_TTF_ASTC_HDR_4x4_RGBA, 0}},
             {"astc-hdr-6x6", {KTX_TTF_ASTC_HDR_6x6_RGBA, 0}},
-            {"bc6hu", {KTX_TTF_BC6HU, 0}},        
+            {"bc6hu", {KTX_TTF_BC6HU_RGB, 0}},
         };
         if (args[argName].count()) {
             const auto argStr = to_lower_copy(args[argName].as<std::string>());
@@ -74,13 +76,27 @@ struct OptionsTranscodeTarget {
         }
     }
 
+    static bool isTargetHDR(ktx_transcode_fmt_e target) {
+        switch (target) {
+        case KTX_TTF_RGB_HALF: [[fallthrough]];
+        case KTX_TTF_RGBA_HALF: [[fallthrough]];
+        case KTX_TTF_RGB_9E5: [[fallthrough]];
+        case KTX_TTF_ASTC_HDR_4x4_RGBA: [[fallthrough]];
+        case KTX_TTF_ASTC_HDR_6x6_RGBA: [[fallthrough]];
+        case KTX_TTF_BC6HU_RGB:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     void validateTextureTranscode(const KTXTexture2& texture, Reporter& report) {
         const auto tswizzle = determineTranscodeSwizzle(texture, report);
-
+        const uint32_t model = khr_df_model_e(KHR_DFDVAL(texture->pDfd + 1, MODEL));
+        const bool isSrcHDR =
+                (model == KHR_DF_MODEL_UASTC_HDR_6x6 || model == KHR_DF_MODEL_UASTC_HDR_4x4);
         if (!transcodeTarget.has_value()) {
-            const auto* bdfd = texture->pDfd + 1;
-            if (khr_df_model_e(KHR_DFDVAL(bdfd, MODEL)) == KHR_DF_MODEL_UASTC_HDR_6x6
-             || khr_df_model_e(KHR_DFDVAL(bdfd, MODEL)) == KHR_DF_MODEL_UASTC_HDR_4x4) {
+            if (isSrcHDR) {
                 transcodeTarget = KTX_TTF_RGBA_HALF;
                 transcodeTargetName = "rgba16f";
                 transcodeSwizzleComponents = tswizzle.defaultNumComponents;
@@ -89,6 +105,10 @@ struct OptionsTranscodeTarget {
                 transcodeTargetName = "rgba8";
                 transcodeSwizzleComponents = tswizzle.defaultNumComponents;
             }
+        } else if (isSrcHDR && !isTargetHDR(transcodeTarget.value())) {
+            report.fatal_usage("UASTC HDR textures can only be transcoded to HDR formats.");
+        } else if (!isSrcHDR && isTargetHDR(transcodeTarget.value())) {
+            report.fatal_usage("BasisLZ and UASTC LDR textures can only be transcoded to LDR formats.");
         }
 
         transcodeSwizzle = tswizzle.swizzle;


### PR DESCRIPTION
Expose the following that are in basis_universal but not previously in libktx.

HDR Formats: KTX_TTF_RGB_HALF, KTX_TTF_RGB9E5.
Flags: KTX_TF_NO_ETC1S_CHROMA_FILTERING.

Rename KTX_TTF_BC6HU to KTX_TTF_BC6HU_RGB. Retain but deprecate the
old name.

Deprecate KTX_TTF_ASTC_4x4_RGBA in favour of KTX_TTF_ASTC_LDR_4x4_RGBA

Fix description of KTX_TTF_RGBA_HALF and a multitude of errors in the
documentation for the ktxTexture2 transcode functions.

Fixes https://github.com/KhronosGroup/KTX-Software/issues/1221.

Needs https://github.com/KhronosGroup/KTX-Software-CTS/pull/81.