### PR TITLE
Allocate the replacement DFD before mutating the texture in the UASTC HDR 4x4 relabel path

### DIFF
--- a/lib/src/basis_transcode.cpp
+++ b/lib/src/basis_transcode.cpp
@@ -203,12 +203,16 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
     // Early exit for redundant transcode from UASTC4x4 to ASTC4x4
     if (colorModel   == KHR_DF_MODEL_UASTC_HDR_4x4 &&
         outputFormat == KTX_TTF_ASTC_HDR_4x4_RGBA) {
+        // Create the new DFD before modifying the texture so a failure
+        // leaves the texture unchanged instead of freeing its DFD and
+        // relabelling its vkFormat first.
+        uint32_t* newDfd = vk2dfd(VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK);
+        if (!newDfd)
+            return KTX_OUT_OF_MEMORY;
         // Fix up the current texture
         free(This->pDfd);
+        This->pDfd = newDfd;
         This->vkFormat = VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK;
-        This->pDfd = vk2dfd(VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK);
-        if (!This->pDfd)
-            return KTX_INVALID_VALUE;  // Format is unknown or unsupported.
         return KTX_SUCCESS;
     }
 

--- a/lib/src/basis_transcode.cpp
+++ b/lib/src/basis_transcode.cpp
@@ -203,12 +203,16 @@ ktx2transcoderFormat(ktx_transcode_fmt_e ktx_fmt) {
     // Early exit for redundant transcode from UASTC4x4 to ASTC4x4
     if (colorModel   == KHR_DF_MODEL_UASTC_HDR_4x4 &&
         outputFormat == KTX_TTF_ASTC_HDR_4x4_RGBA) {
+        // Create the new DFD before modifying the texture so a failure
+        // leaves the texture unchanged instead of freeing its DFD and
+        // relabelling its vkFormat first.
+        uint32_t* newDfd = vk2dfd(VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK);
+        if (!newDfd)
+            return KTX_INVALID_VALUE;  // Format is unknown or unsupported.
         // Fix up the current texture
         free(This->pDfd);
+        This->pDfd = newDfd;
         This->vkFormat = VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK;
-        This->pDfd = vk2dfd(VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK);
-        if (!This->pDfd)
-            return KTX_INVALID_VALUE;  // Format is unknown or unsupported.
         return KTX_SUCCESS;
     }
 


### PR DESCRIPTION
Small defensive robustness fix in the UASTC_HDR_4x4 → ASTC_HDR_4x4 early exit of
`ktxTexture2_TranscodeBasis`, related to the passthrough discussion in #1224.

#### Problem

The early exit frees `This->pDfd` and updates `This->vkFormat` before constructing
the replacement DFD with `vk2dfd()`.

If DFD creation ever reports a failure, the function returns with a partially
mutated texture: the original DFD has already been freed and `vkFormat` already
describes ASTC HDR.

#### Fix

Construct the replacement DFD first. Only after successful construction, free
the old DFD and commit the new `pDfd` and `vkFormat`.

There is no behavior change on the success path. The path was smoke-tested with
an encode → relabel-transcode round trip.

No regression test is included because the current generated mapping contains
`VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK`, and there is no existing failure-injection
mechanism for `vk2dfd()`. This is therefore a defensive transactional-ordering
fix rather than a currently reproducible input-driven failure.