### PR TITLE
Fix vkloadtests build issues

### DIFF
--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -469,7 +469,7 @@ VulkanAppSDL::createInstance()
 {
     MAYBE_UNUSED VkResult err;
     uint32_t instanceLayerCount = 0;
-    std::vector<const char *>* instanceValidationLayers = nullptr;
+    std::vector<const char *> instanceValidationLayers;
 
     std::vector<const char *> instanceValidationLayers_alt1 = {
         "VK_LAYER_KHRONOS_validation"
@@ -498,7 +498,7 @@ VulkanAppSDL::createInstance()
                                 instanceLayerCount,
                                 instanceLayers);
             if (validationFound) {
-                instanceValidationLayers = &instanceValidationLayers_alt1;
+                instanceValidationLayers = instanceValidationLayers_alt1;
             } else {
                 // Use alternative set of validation layers.
                 validationFound = checkLayers(
@@ -506,8 +506,11 @@ VulkanAppSDL::createInstance()
                                 instanceValidationLayers_alt2.data(),
                                 instanceLayerCount,
                                 instanceLayers);
-                instanceValidationLayers = &instanceValidationLayers_alt2;
+                if (validationFound) {
+                    instanceValidationLayers = instanceValidationLayers_alt2;
+                }
             }
+#if 0
             if (validationFound) {
                 for (uint32_t i = 0; i < instanceValidationLayers->size(); i++)
                 {
@@ -515,6 +518,7 @@ VulkanAppSDL::createInstance()
                                 instanceValidationLayers->data()[i]);
                 }
             }
+#endif
             delete [] instanceLayers;
         }
 
@@ -585,8 +589,8 @@ VulkanAppSDL::createInstance()
     vk::InstanceCreateInfo instanceInfo(
                             {},
                             &app,
-                            (uint32_t)deviceValidationLayers.size(),
-                            (const char *const *)deviceValidationLayers.data(),
+                            (uint32_t)instanceValidationLayers.size(),
+                            (const char *const *)instanceValidationLayers.data(),
                             (uint32_t)extensionNames.size(),
                             (const char *const *)extensionNames.data());
 #if VK_KHR_portability_subset
@@ -913,10 +917,8 @@ VulkanAppSDL::createDevice()
             {},
             1,
             &queueInfo,
-            (uint32_t)deviceValidationLayers.size(),
-            (const char *const *)((validate)
-                                  ? deviceValidationLayers.data()
-                                  : NULL),
+            0, // enabledLayerCount
+            nullptr,
             (uint32_t)extensionsToEnable.size(),
             (const char *const *)extensionsToEnable.data(),
             nullptr);

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -806,7 +806,7 @@ VulkanAppSDL::createDevice()
     if (hdr)
         wantedExtensions.push_back({VK_EXT_HDR_METADATA_EXTENSION_NAME, optional});
 #if VK_EXT_texture_compression_astc_3d
-    wantedExtensions.push_back({TEXTURE_COMPRESSION_ASTC_3D_EXTENSION_NAME, optional});
+    wantedExtensions.push_back({VK_EXT_TEXTURE_COMPRESSION_ASTC_3D_EXTENSION_NAME, optional});
 #endif
 
     vk::Result err;

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.cpp
@@ -510,15 +510,6 @@ VulkanAppSDL::createInstance()
                     instanceValidationLayers = instanceValidationLayers_alt2;
                 }
             }
-#if 0
-            if (validationFound) {
-                for (uint32_t i = 0; i < instanceValidationLayers->size(); i++)
-                {
-                    deviceValidationLayers.push_back(
-                                instanceValidationLayers->data()[i]);
-                }
-            }
-#endif
             delete [] instanceLayers;
         }
 

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanAppSDL.h
@@ -137,7 +137,6 @@ class VulkanAppSDL : public AppBaseSDL {
     VkColorSpaceKHR colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 
     std::vector<const char*> extensionNames;
-    std::vector<const char*> deviceValidationLayers;
 
     VkCommandBuffer setupCmdBuffer;
     VkSurfaceKHR vsSurface;

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanContext.h
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/VulkanContext.h
@@ -44,7 +44,7 @@ struct VulkanContext {
 #endif
 #if VK_EXT_texture_compression_astc_3d
      vk::PhysicalDeviceTextureCompressionASTC3DFeaturesEXT& gpuAstc3dFeatures =
-         gpuFeaturesChain.get<vk::PhysicalDeviceTextureCompressionASTC3DFeaturesEXT();
+     gpuFeaturesChain.get<vk::PhysicalDeviceTextureCompressionASTC3DFeaturesEXT>();
 #endif
 #if VK_KHR_portability_subset
     vk::PhysicalDevicePortabilitySubsetFeaturesKHR& gpuPortabilityFeatures =

--- a/tests/loadtests/compile_shader.cmake
+++ b/tests/loadtests/compile_shader.cmake
@@ -10,7 +10,7 @@ function(compile_shader shader_target shader_name shader_src_path shader_path)
     add_custom_command(OUTPUT
         ${vert2spirv_out}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
-        COMMAND glslc "-fshader-stage=vertex" -o "${vert2spirv_out}" "${vert2spirv_in}"
+        COMMAND ${Vulkan_GLSLC_EXECUTABLE} "-fshader-stage=vertex" -o "${vert2spirv_out}" "${vert2spirv_in}"
         DEPENDS ${vert2spirv_in}
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         COMMENT "Compiling ${vert_name}."
@@ -24,7 +24,7 @@ function(compile_shader shader_target shader_name shader_src_path shader_path)
     add_custom_command(OUTPUT
         ${frag2spirv_out}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
-        COMMAND glslc "-fshader-stage=fragment" -o "${frag2spirv_out}" "${frag2spirv_in}"
+        COMMAND ${Vulkan_GLSLC_EXECUTABLE} "-fshader-stage=fragment" -o "${frag2spirv_out}" "${frag2spirv_in}"
         DEPENDS ${frag2spirv_in}
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         COMMENT "Compiling ${frag_name}."
@@ -57,7 +57,7 @@ function(compile_shader_list shader_target shader_src_path shader_path)
         add_custom_command(OUTPUT
             ${spirv_out}
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${shader_path}
-            COMMAND glslc -o "${spirv_out}" "${spirv_in}"
+            COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o "${spirv_out}" "${spirv_in}"
             DEPENDS ${spirv_in}
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
             COMMENT "Compiling ${shader}."

--- a/tests/loadtests/glloadtests.cmake
+++ b/tests/loadtests/glloadtests.cmake
@@ -23,6 +23,14 @@ function( create_gl_target target version sources common_resources ktx_file_sour
         ${EXE_FLAG}
         glloadtests.cmake
         ${sources}
+    )
+    # Resource files will not be copied to their destination (app bundle or
+    # directory specified by the RESOURCE option of the install(TARGETS)
+    # command) unless they appear in both the target's RESOURCE and SOURCES
+    # properties. Add them to SOURCES this way so we can mark them private
+    # though I'm not sure there is any benefit to doing so.
+    target_sources( ${target}
+    PRIVATE
         ${resources}
     )
 

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -180,21 +180,23 @@ add_executable( vkloadtests
     vkloadtests/VulkanLoadTestSample.cpp
     vkloadtests/VulkanLoadTestSample.h
     vkloadtests.cmake
+)
+# Resource files will not be copied to their destination (app bundle or
+# directory specified by the RESOURCE option of the install(TARGETS) command)
+# unless they appear in both the target's RESOURCE and SOURCES properties.
+# Add them to SOURCES this way so we can mark them private though I'm not
+# sure there is any benefit to doing so.
+target_sources( vkloadtests
+PRIVATE
     ${ktx2_file_sources}
     ${ktx1_file_sources}
     ${KTX_ICON_SOURCES}
     ${LOAD_TEST_COMMON_MODEL_SOURCES}
     ${SHADER_SOURCES}
     ${Vulkan_SHARE_VULKAN}
+    # These are shader binaries not sources. Annoying they have to be in SOURCES.
+    ${SHADER_SPVS}
 )
-if(APPLE)
-    target_sources( vkloadtests
-    PRIVATE
-        # Annoyingly, files will not be copied to a bundle's resources unless they appear
-        # both in RESOURCES and in the targets source list. At least mark them private.
-        ${SHADER_SPVS}
-    )
-endif()
 
 source_group( "Shader Source Files" FILES ${SHADER_SOURCES})
 source_group( "Resources/Shader Binaries" FILES ${SHADER_SPVS})

--- a/tests/loadtests/vkloadtests.cmake
+++ b/tests/loadtests/vkloadtests.cmake
@@ -187,8 +187,17 @@ add_executable( vkloadtests
     ${SHADER_SOURCES}
     ${Vulkan_SHARE_VULKAN}
 )
+if(APPLE)
+    target_sources( vkloadtests
+    PRIVATE
+        # Annoyingly, files will not be copied to a bundle's resources unless they appear
+        # both in RESOURCES and in the targets source list. At least mark them private.
+        ${SHADER_SPVS}
+    )
+endif()
 
-source_group( "Resources/Shaders" FILES ${SHADER_SOURCES})
+source_group( "Shader Source Files" FILES ${SHADER_SOURCES})
+source_group( "Resources/Shader Binaries" FILES ${SHADER_SPVS})
 source_group( "Resources/KTX Images" REGULAR_EXPRESSION "${TEST_RESOURCES_DIR}/ktx(2?)/.*" )
 
 # Keep this in case something changes in the Vulkan implementation and we need to


### PR DESCRIPTION
Fixed issues include:
- failure to build with SDK having ASTC 3D extension due to syntax error.
- failure to copy the .spv files to the bundle's resources due to them not appearing in vkloadtests' SOURCES property.
- failure to build when VulkanSDK was not globally installed due to calling `glslc` instead of `${Vulkan_GLSLC_EXECUTABLE}`.
- invalid enabling of validation layers at device creation. It must happen, and is/was, at instance creation.

Fixes #1235.