### PR TITLE
VK_IMAGE_LAYOUT_GENERAL support for image layout

### DIFF
--- a/lib/src/vkloader.c
+++ b/lib/src/vkloader.c
@@ -1748,6 +1748,12 @@ setImageLayout(
         imageMemoryBarrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
         break;
 
+    case VK_IMAGE_LAYOUT_GENERAL:
+        // Image may be used for arbitrary read/write access.
+        // Make sure any reads and writes to the image have finished.
+        imageMemoryBarrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+        break;
+
     default:
         /* Value not used by callers, so not supported. */
         assert(KTX_FALSE);
@@ -1797,6 +1803,12 @@ setImageLayout(
         }
         imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
         destStageFlags = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+        break;
+
+    case VK_IMAGE_LAYOUT_GENERAL:
+        // Image may be used for arbitrary read/write access.
+        imageMemoryBarrier.dstAccessMask
+                                = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
         break;
 
     default:

--- a/tests/loadtests/appfwSDL/VulkanAppSDL/vulkantools.cpp
+++ b/tests/loadtests/appfwSDL/VulkanAppSDL/vulkantools.cpp
@@ -180,6 +180,12 @@ namespace vkTools
                 imageMemoryBarrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
                 break;
 
+        case VK_IMAGE_LAYOUT_GENERAL:
+            // Image may be used for arbitrary read/write access.
+            // Make sure any reads and writes to the image have finished.
+            imageMemoryBarrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+            break;
+
         default:
             assert(0); // Attempt to use unhandled case.
         }
@@ -222,6 +228,12 @@ namespace vkTools
                 imageMemoryBarrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
             }
             imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            break;
+
+        case VK_IMAGE_LAYOUT_GENERAL:
+            // Image may be used for arbitrary read/write access.
+            imageMemoryBarrier.dstAccessMask
+                                    = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
             break;
 
         default:

--- a/tests/loadtests/vkloadtests/Texture.cpp
+++ b/tests/loadtests/vkloadtests/Texture.cpp
@@ -64,6 +64,7 @@ Texture::Texture(VulkanContext& vkctx,
     zoom = -2.5f;
     rotation = { 0.0f, 15.0f, 0.0f };
     tiling = vk::ImageTiling::eOptimal;
+    finalLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
     useSubAlloc = UseSuballocator::No;
     rgbcolor upperLeftColor{ 0.7f, 0.1f, 0.2f };
     rgbcolor lowerLeftColor{ 0.8f, 0.9f, 0.3f };
@@ -126,13 +127,14 @@ Texture::Texture(VulkanContext& vkctx,
         ktxresult = ktxTexture_VkUploadEx_WithSuballocator(kTexture, &vdi, &texture,
                                                            static_cast<VkImageTiling>(tiling),
                                                            VK_IMAGE_USAGE_SAMPLED_BIT,
-                                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, &subAllocatorCallbacks);
+                                                           static_cast<VkImageLayout>(finalLayout),
+                                                           &subAllocatorCallbacks);
     }
     else // Keep separate call so ktxTexture_VkUploadEx is also tested.
         ktxresult = ktxTexture_VkUploadEx(kTexture, &vdi, &texture,
                                           static_cast<VkImageTiling>(tiling),
                                           VK_IMAGE_USAGE_SAMPLED_BIT,
-                                          VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                                          static_cast<VkImageLayout>(finalLayout));
     
     if (KTX_SUCCESS != ktxresult) {
         std::stringstream message;
@@ -235,6 +237,7 @@ Texture::processArgs(std::string sArgs)
     struct argparser::option longopts[] = {
       {"external",      argparser::option::no_argument,       &externalFile,        1},
       {"linear-tiling", argparser::option::no_argument,       (int*)&tiling,        (int)vk::ImageTiling::eLinear},
+      {"general-layout",argparser::option::no_argument,       (int*)&finalLayout,   (int)vk::ImageLayout::eGeneral},
       {"use-vma",       argparser::option::no_argument,       (int*)&useSubAlloc,   (int)UseSuballocator::Yes},
       {"qcolor",        argparser::option::required_argument, NULL,                 1},
       {NULL,            argparser::option::no_argument,       NULL,                 0}
@@ -557,7 +560,7 @@ Texture::setupDescriptorSet()
     vk::DescriptorImageInfo texDescriptor(
             sampler,
             imageView,
-            vk::ImageLayout::eShaderReadOnlyOptimal);
+            finalLayout);
 
     std::vector<vk::WriteDescriptorSet> writeDescriptorSets;
     // Binding 0 : Vertex shader uniform buffer

--- a/tests/loadtests/vkloadtests/Texture.h
+++ b/tests/loadtests/vkloadtests/Texture.h
@@ -44,6 +44,7 @@ class Texture : public VulkanLoadTestSample
     vk::Sampler sampler;
     vk::ImageView imageView;
     vk::ImageTiling tiling;
+    vk::ImageLayout finalLayout;
     UseSuballocator useSubAlloc;
     vk::ComponentMapping swizzle;
 

--- a/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
+++ b/tests/loadtests/vkloadtests/VulkanLoadTests.cpp
@@ -489,6 +489,10 @@ const VulkanLoadTests::sampleInvocation siSamples[] = {
       "KTX2: RGBA8 2D No KTXOrientation"
     },
     { Texture::create,
+      "--general-layout r8g8b8a8_srgb.ktx2",
+      "KTX2: RGBA8 2D No KTXOrientation, Using GENERAL Layout"
+    },
+    { Texture::create,
         "--linear-tiling r8g8b8a8_srgb.ktx2",
         "KTX2: RGBA8 2D No KTXOrientation, Using Linear Tiling"
     },


### PR DESCRIPTION
Resolves #1244

Since VK_IMAGE_LAYOUT_GENERAL could be used anywhere, we shouldn't assume how it's accessed either before/after the transition. So, we're using the most conservative VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT for both.

- Added VK_IMAGE_LAYOUT_GENERAL as an image layout option for oldLayout and newLayout for setImageLayout,